### PR TITLE
Switch to xmlschema for all validations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "3.7"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ suite.
 
 # Report
 
-90 failed, 26078 passed, 156 skipped
+85 failed, 26077 passed, 162 skipped
 
 # Methodology
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ suite.
 
 # Report
 
-96 failed, 26036 passed, 192 skipped
+90 failed, 26078 passed, 156 skipped
 
 # Methodology
 

--- a/tests/test_boeing_meta_12.py
+++ b/tests/test_boeing_meta_12.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo6_ipo_1(save_xml):
     """
@@ -14,11 +15,12 @@ def test_ipo6_ipo_1(save_xml):
         instance="boeingData/ipo6/ipo_1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo6_ipo_2(save_xml):
     """
@@ -30,11 +32,12 @@ def test_ipo6_ipo_2(save_xml):
         instance="boeingData/ipo6/ipo_2.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo5_ipo_1(save_xml):
     """
@@ -46,11 +49,12 @@ def test_ipo5_ipo_1(save_xml):
         instance="boeingData/ipo5/ipo_1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo5_ipo_2(save_xml):
     """
@@ -62,11 +66,12 @@ def test_ipo5_ipo_2(save_xml):
         instance="boeingData/ipo5/ipo_2.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo4_ipo_1(save_xml):
     """
@@ -78,11 +83,12 @@ def test_ipo4_ipo_1(save_xml):
         instance="boeingData/ipo4/ipo_1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo4_ipo_2(save_xml):
     """
@@ -94,11 +100,12 @@ def test_ipo4_ipo_2(save_xml):
         instance="boeingData/ipo4/ipo_2.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo3_ipo_1(save_xml):
     """
@@ -110,11 +117,12 @@ def test_ipo3_ipo_1(save_xml):
         instance="boeingData/ipo3/ipo_1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo3_ipo_2(save_xml):
     """
@@ -126,11 +134,12 @@ def test_ipo3_ipo_2(save_xml):
         instance="boeingData/ipo3/ipo_2.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo2_ipo_1(save_xml):
     """
@@ -142,11 +151,12 @@ def test_ipo2_ipo_1(save_xml):
         instance="boeingData/ipo2/ipo_1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo2_ipo_2(save_xml):
     """
@@ -158,11 +168,12 @@ def test_ipo2_ipo_2(save_xml):
         instance="boeingData/ipo2/ipo_2.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo1_ipo_1(save_xml):
     """
@@ -174,11 +185,12 @@ def test_ipo1_ipo_1(save_xml):
         instance="boeingData/ipo1/ipo_1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ipo1_ipo_2(save_xml):
     """
@@ -190,6 +202,6 @@ def test_ipo1_ipo_2(save_xml):
         instance="boeingData/ipo1/ipo_2.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_common_91.py
+++ b/tests/test_common_91.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_introspection_1(save_xml):
 
     assert_bindings(
@@ -9,11 +12,12 @@ def test_introspection_introspect_test_set_introspection_1(save_xml):
         instance="common/introspection.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_nist2004_01_14_2(save_xml):
 
     assert_bindings(
@@ -22,11 +26,12 @@ def test_introspection_introspect_test_set_nist2004_01_14_2(save_xml):
         instance="nistMeta/NISTXMLSchemaDatatypes.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_suntest_3(save_xml):
 
     assert_bindings(
@@ -35,11 +40,12 @@ def test_introspection_introspect_test_set_suntest_3(save_xml):
         instance="sunMeta/suntest.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_agroup_def_4(save_xml):
 
     assert_bindings(
@@ -48,11 +54,12 @@ def test_introspection_introspect_test_set_agroup_def_4(save_xml):
         instance="sunMeta/AGroupDef.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_attr_decl_5(save_xml):
 
     assert_bindings(
@@ -61,11 +68,12 @@ def test_introspection_introspect_test_set_attr_decl_5(save_xml):
         instance="sunMeta/AttrDecl.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_attr_use_6(save_xml):
 
     assert_bindings(
@@ -74,11 +82,12 @@ def test_introspection_introspect_test_set_attr_use_6(save_xml):
         instance="sunMeta/AttrUse.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ctype_7(save_xml):
 
     assert_bindings(
@@ -87,11 +96,12 @@ def test_introspection_introspect_test_set_ctype_7(save_xml):
         instance="sunMeta/CType.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_elem_decl_8(save_xml):
 
     assert_bindings(
@@ -100,11 +110,12 @@ def test_introspection_introspect_test_set_elem_decl_8(save_xml):
         instance="sunMeta/ElemDecl.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_id_constr_defs_9(save_xml):
 
     assert_bindings(
@@ -113,11 +124,12 @@ def test_introspection_introspect_test_set_id_constr_defs_9(save_xml):
         instance="sunMeta/IdConstrDefs.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_mgroup_10(save_xml):
 
     assert_bindings(
@@ -126,11 +138,12 @@ def test_introspection_introspect_test_set_mgroup_10(save_xml):
         instance="sunMeta/MGroup.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_mgroup_def_11(save_xml):
 
     assert_bindings(
@@ -139,11 +152,12 @@ def test_introspection_introspect_test_set_mgroup_def_11(save_xml):
         instance="sunMeta/MGroupDef.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_notation_12(save_xml):
 
     assert_bindings(
@@ -152,11 +166,12 @@ def test_introspection_introspect_test_set_notation_12(save_xml):
         instance="sunMeta/Notation.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_stype_13(save_xml):
 
     assert_bindings(
@@ -165,11 +180,12 @@ def test_introspection_introspect_test_set_stype_13(save_xml):
         instance="sunMeta/SType.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_schema_14(save_xml):
 
     assert_bindings(
@@ -178,11 +194,12 @@ def test_introspection_introspect_test_set_schema_14(save_xml):
         instance="sunMeta/Schema.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_wildcard_15(save_xml):
 
     assert_bindings(
@@ -191,11 +208,12 @@ def test_introspection_introspect_test_set_wildcard_15(save_xml):
         instance="sunMeta/Wildcard.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_additional2006_07_15_16(save_xml):
 
     assert_bindings(
@@ -204,11 +222,12 @@ def test_introspection_introspect_test_set_ms_additional2006_07_15_16(save_xml):
         instance="msMeta/Additional_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_annotations2006_07_15_17(save_xml):
 
     assert_bindings(
@@ -217,11 +236,12 @@ def test_introspection_introspect_test_set_ms_annotations2006_07_15_17(save_xml)
         instance="msMeta/Annotations_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_attribute_group2006_07_15_18(save_xml):
 
     assert_bindings(
@@ -230,11 +250,12 @@ def test_introspection_introspect_test_set_ms_attribute_group2006_07_15_18(save_
         instance="msMeta/AttributeGroup_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_attribute2006_07_15_19(save_xml):
 
     assert_bindings(
@@ -243,11 +264,12 @@ def test_introspection_introspect_test_set_ms_attribute2006_07_15_19(save_xml):
         instance="msMeta/Attribute_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_complex_type2006_07_15_20(save_xml):
 
     assert_bindings(
@@ -256,11 +278,12 @@ def test_introspection_introspect_test_set_ms_complex_type2006_07_15_20(save_xml
         instance="msMeta/ComplexType_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_data_types2006_07_15_21(save_xml):
 
     assert_bindings(
@@ -269,11 +292,12 @@ def test_introspection_introspect_test_set_ms_data_types2006_07_15_21(save_xml):
         instance="msMeta/DataTypes_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_element2006_07_15_22(save_xml):
 
     assert_bindings(
@@ -282,11 +306,12 @@ def test_introspection_introspect_test_set_ms_element2006_07_15_22(save_xml):
         instance="msMeta/Element_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_errata102006_07_15_23(save_xml):
 
     assert_bindings(
@@ -295,11 +320,12 @@ def test_introspection_introspect_test_set_ms_errata102006_07_15_23(save_xml):
         instance="msMeta/Errata10_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_group2006_07_15_24(save_xml):
 
     assert_bindings(
@@ -308,11 +334,12 @@ def test_introspection_introspect_test_set_ms_group2006_07_15_24(save_xml):
         instance="msMeta/Group_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_identity_constraint2006_07_15_25(save_xml):
 
     assert_bindings(
@@ -321,11 +348,12 @@ def test_introspection_introspect_test_set_ms_identity_constraint2006_07_15_25(s
         instance="msMeta/IdentityConstraint_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_model_groups2006_07_15_26(save_xml):
 
     assert_bindings(
@@ -334,11 +362,12 @@ def test_introspection_introspect_test_set_ms_model_groups2006_07_15_26(save_xml
         instance="msMeta/ModelGroups_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_notations2006_07_15_27(save_xml):
 
     assert_bindings(
@@ -347,11 +376,12 @@ def test_introspection_introspect_test_set_ms_notations2006_07_15_27(save_xml):
         instance="msMeta/Notations_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_particles2006_07_15_28(save_xml):
 
     assert_bindings(
@@ -360,11 +390,12 @@ def test_introspection_introspect_test_set_ms_particles2006_07_15_28(save_xml):
         instance="msMeta/Particles_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_regex2006_07_15_29(save_xml):
 
     assert_bindings(
@@ -373,11 +404,12 @@ def test_introspection_introspect_test_set_ms_regex2006_07_15_29(save_xml):
         instance="msMeta/Regex_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_schema2006_07_15_30(save_xml):
 
     assert_bindings(
@@ -386,11 +418,12 @@ def test_introspection_introspect_test_set_ms_schema2006_07_15_30(save_xml):
         instance="msMeta/Schema_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_simple_type2006_07_15_31(save_xml):
 
     assert_bindings(
@@ -399,11 +432,12 @@ def test_introspection_introspect_test_set_ms_simple_type2006_07_15_31(save_xml)
         instance="msMeta/SimpleType_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_ms_wildcards2006_07_15_32(save_xml):
 
     assert_bindings(
@@ -412,11 +446,12 @@ def test_introspection_introspect_test_set_ms_wildcards2006_07_15_32(save_xml):
         instance="msMeta/Wildcards_w3c.xml",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_boeing_xsdtest_cases_33(save_xml):
 
     assert_bindings(
@@ -425,11 +460,12 @@ def test_introspection_introspect_test_set_boeing_xsdtest_cases_33(save_xml):
         instance="boeingMeta/BoeingXSDTestSet.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_all_34(save_xml):
 
     assert_bindings(
@@ -438,11 +474,12 @@ def test_introspection_introspect_test_set_all_34(save_xml):
         instance="saxonMeta/All.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_assert_35(save_xml):
 
     assert_bindings(
@@ -451,11 +488,12 @@ def test_introspection_introspect_test_set_assert_35(save_xml):
         instance="saxonMeta/Assert.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_complex_36(save_xml):
 
     assert_bindings(
@@ -464,11 +502,12 @@ def test_introspection_introspect_test_set_complex_36(save_xml):
         instance="saxonMeta/Complex.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_cta_37(save_xml):
 
     assert_bindings(
@@ -477,11 +516,12 @@ def test_introspection_introspect_test_set_cta_37(save_xml):
         instance="saxonMeta/CTA.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_id_38(save_xml):
 
     assert_bindings(
@@ -490,11 +530,12 @@ def test_introspection_introspect_test_set_id_38(save_xml):
         instance="saxonMeta/Id.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_open_39(save_xml):
 
     assert_bindings(
@@ -503,11 +544,12 @@ def test_introspection_introspect_test_set_open_39(save_xml):
         instance="saxonMeta/Open.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_override_40(save_xml):
 
     assert_bindings(
@@ -516,11 +558,12 @@ def test_introspection_introspect_test_set_override_40(save_xml):
         instance="saxonMeta/Override.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_simple_41(save_xml):
 
     assert_bindings(
@@ -529,11 +572,12 @@ def test_introspection_introspect_test_set_simple_41(save_xml):
         instance="saxonMeta/Simple.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_subsgroup_42(save_xml):
 
     assert_bindings(
@@ -542,11 +586,12 @@ def test_introspection_introspect_test_set_subsgroup_42(save_xml):
         instance="saxonMeta/Subsgroup.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_target_ns_43(save_xml):
 
     assert_bindings(
@@ -555,11 +600,12 @@ def test_introspection_introspect_test_set_target_ns_43(save_xml):
         instance="saxonMeta/TargetNS.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_vc_44(save_xml):
 
     assert_bindings(
@@ -568,11 +614,12 @@ def test_introspection_introspect_test_set_vc_44(save_xml):
         instance="saxonMeta/VC.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_wild_45(save_xml):
 
     assert_bindings(
@@ -581,11 +628,12 @@ def test_introspection_introspect_test_set_wild_45(save_xml):
         instance="saxonMeta/Wild.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_xml_versions_46(save_xml):
 
     assert_bindings(
@@ -594,11 +642,12 @@ def test_introspection_introspect_test_set_xml_versions_46(save_xml):
         instance="saxonMeta/XmlVersions.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_zone_47(save_xml):
 
     assert_bindings(
@@ -607,11 +656,12 @@ def test_introspection_introspect_test_set_zone_47(save_xml):
         instance="saxonMeta/Zone.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_zone_48(save_xml):
 
     assert_bindings(
@@ -620,11 +670,12 @@ def test_introspection_introspect_test_set_zone_48(save_xml):
         instance="oracleMeta/Zone.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_substitution_groups_49(save_xml):
 
     assert_bindings(
@@ -633,11 +684,12 @@ def test_introspection_introspect_test_set_substitution_groups_49(save_xml):
         instance="wgMeta/substitution-groups.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_all_group_50(save_xml):
 
     assert_bindings(
@@ -646,11 +698,12 @@ def test_introspection_introspect_test_set_all_group_50(save_xml):
         instance="ibmMeta/allGroup.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_any_attribute_51(save_xml):
 
     assert_bindings(
@@ -659,11 +712,12 @@ def test_introspection_introspect_test_set_any_attribute_51(save_xml):
         instance="ibmMeta/anyAttribute.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_assert_52(save_xml):
 
     assert_bindings(
@@ -672,11 +726,12 @@ def test_introspection_introspect_test_set_assert_52(save_xml):
         instance="ibmMeta/assert.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_assertion_53(save_xml):
 
     assert_bindings(
@@ -685,11 +740,12 @@ def test_introspection_introspect_test_set_assertion_53(save_xml):
         instance="ibmMeta/assertion.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_conditional_inclusion_54(save_xml):
 
     assert_bindings(
@@ -698,11 +754,12 @@ def test_introspection_introspect_test_set_conditional_inclusion_54(save_xml):
         instance="ibmMeta/conditionalInclusion.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_constraints_on_attribute_55(save_xml):
 
     assert_bindings(
@@ -711,11 +768,12 @@ def test_introspection_introspect_test_set_constraints_on_attribute_55(save_xml)
         instance="ibmMeta/constraintsOnAttribute.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_cyclic_dependencies_redefine_include_import_override_56(save_xml):
 
     assert_bindings(
@@ -724,11 +782,12 @@ def test_introspection_introspect_test_set_cyclic_dependencies_redefine_include_
         instance="ibmMeta/cyclicRedefineIncludeImportOverride.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_date_57(save_xml):
 
     assert_bindings(
@@ -737,11 +796,12 @@ def test_introspection_introspect_test_set_date_57(save_xml):
         instance="ibmMeta/date.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_date_time_stamp_58(save_xml):
 
     assert_bindings(
@@ -750,11 +810,12 @@ def test_introspection_introspect_test_set_date_time_stamp_58(save_xml):
         instance="ibmMeta/dateTimeStamp.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_day_time_duration_59(save_xml):
 
     assert_bindings(
@@ -763,11 +824,12 @@ def test_introspection_introspect_test_set_day_time_duration_59(save_xml):
         instance="ibmMeta/dayTimeDuration.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_default_attributes_apply_60(save_xml):
 
     assert_bindings(
@@ -776,11 +838,12 @@ def test_introspection_introspect_test_set_default_attributes_apply_60(save_xml)
         instance="ibmMeta/defaultAttributesApply.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_default_fixed_61(save_xml):
 
     assert_bindings(
@@ -789,11 +852,12 @@ def test_introspection_introspect_test_set_default_fixed_61(save_xml):
         instance="ibmMeta/defaultFixed.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_double_62(save_xml):
 
     assert_bindings(
@@ -802,11 +866,12 @@ def test_introspection_introspect_test_set_double_62(save_xml):
         instance="ibmMeta/double.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_edcwildcard_63(save_xml):
 
     assert_bindings(
@@ -815,11 +880,12 @@ def test_introspection_introspect_test_set_edcwildcard_63(save_xml):
         instance="ibmMeta/edcWildcard.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_explicit_timezone_64(save_xml):
 
     assert_bindings(
@@ -828,11 +894,12 @@ def test_introspection_introspect_test_set_explicit_timezone_64(save_xml):
         instance="ibmMeta/explicitTimezone.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_float_65(save_xml):
 
     assert_bindings(
@@ -841,11 +908,12 @@ def test_introspection_introspect_test_set_float_65(save_xml):
         instance="ibmMeta/float.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_g_year_month_66(save_xml):
 
     assert_bindings(
@@ -854,11 +922,12 @@ def test_introspection_introspect_test_set_g_year_month_66(save_xml):
         instance="ibmMeta/gYearMonth.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_g_year_67(save_xml):
 
     assert_bindings(
@@ -867,11 +936,12 @@ def test_introspection_introspect_test_set_g_year_67(save_xml):
         instance="ibmMeta/gYear.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_g_month_day_68(save_xml):
 
     assert_bindings(
@@ -880,11 +950,12 @@ def test_introspection_introspect_test_set_g_month_day_68(save_xml):
         instance="ibmMeta/gMonthDay.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_g_day_69(save_xml):
 
     assert_bindings(
@@ -893,11 +964,12 @@ def test_introspection_introspect_test_set_g_day_69(save_xml):
         instance="ibmMeta/gDay.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_g_month_70(save_xml):
 
     assert_bindings(
@@ -906,11 +978,12 @@ def test_introspection_introspect_test_set_g_month_70(save_xml):
         instance="ibmMeta/gMonth.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_id_idref_71(save_xml):
 
     assert_bindings(
@@ -919,11 +992,12 @@ def test_introspection_introspect_test_set_id_idref_71(save_xml):
         instance="ibmMeta/idIDREF.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_identity_constraint_72(save_xml):
 
     assert_bindings(
@@ -932,11 +1006,12 @@ def test_introspection_introspect_test_set_identity_constraint_72(save_xml):
         instance="ibmMeta/identityConstraint.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_list_73(save_xml):
 
     assert_bindings(
@@ -945,11 +1020,12 @@ def test_introspection_introspect_test_set_list_73(save_xml):
         instance="ibmMeta/list.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_popen_content_74(save_xml):
 
     assert_bindings(
@@ -958,11 +1034,12 @@ def test_introspection_introspect_test_set_popen_content_74(save_xml):
         instance="ibmMeta/openContent.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_regular_expression_75(save_xml):
 
     assert_bindings(
@@ -971,11 +1048,12 @@ def test_introspection_introspect_test_set_regular_expression_75(save_xml):
         instance="ibmMeta/regularExpression.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_restriction_of_complex_types_76(save_xml):
 
     assert_bindings(
@@ -984,11 +1062,12 @@ def test_introspection_introspect_test_set_restriction_of_complex_types_76(save_
         instance="ibmMeta/restrictionOfComplexTypes.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_rf_white_space_77(save_xml):
 
     assert_bindings(
@@ -997,11 +1076,12 @@ def test_introspection_introspect_test_set_rf_white_space_77(save_xml):
         instance="ibmMeta/rf_whiteSpace.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_substitution_group_78(save_xml):
 
     assert_bindings(
@@ -1010,11 +1090,12 @@ def test_introspection_introspect_test_set_substitution_group_78(save_xml):
         instance="ibmMeta/substitutionGroup.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_target_ns_79(save_xml):
 
     assert_bindings(
@@ -1023,11 +1104,12 @@ def test_introspection_introspect_test_set_target_ns_79(save_xml):
         instance="ibmMeta/targetNamespace.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_time_80(save_xml):
 
     assert_bindings(
@@ -1036,11 +1118,12 @@ def test_introspection_introspect_test_set_time_80(save_xml):
         instance="ibmMeta/time.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_type_alternative_tests_81(save_xml):
 
     assert_bindings(
@@ -1049,11 +1132,12 @@ def test_introspection_introspect_test_set_type_alternative_tests_81(save_xml):
         instance="ibmMeta/typeAlternatives.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_cta_82(save_xml):
 
     assert_bindings(
@@ -1062,11 +1146,12 @@ def test_introspection_introspect_test_set_cta_82(save_xml):
         instance="ibmMeta/typeAlternativesMixed.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_union_83(save_xml):
 
     assert_bindings(
@@ -1075,11 +1160,12 @@ def test_introspection_introspect_test_set_union_83(save_xml):
         instance="ibmMeta/union.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_units_length_84(save_xml):
 
     assert_bindings(
@@ -1088,11 +1174,12 @@ def test_introspection_introspect_test_set_units_length_84(save_xml):
         instance="ibmMeta/unitsLength.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_unsigned_integers_85(save_xml):
 
     assert_bindings(
@@ -1101,11 +1188,12 @@ def test_introspection_introspect_test_set_unsigned_integers_85(save_xml):
         instance="ibmMeta/unsignedInteger.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_vc_86(save_xml):
 
     assert_bindings(
@@ -1114,11 +1202,12 @@ def test_introspection_introspect_test_set_vc_86(save_xml):
         instance="ibmMeta/vc.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_wildcard_87(save_xml):
 
     assert_bindings(
@@ -1127,11 +1216,12 @@ def test_introspection_introspect_test_set_wildcard_87(save_xml):
         instance="ibmMeta/wildcard.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_xml11_support_88(save_xml):
 
     assert_bindings(
@@ -1140,11 +1230,12 @@ def test_introspection_introspect_test_set_xml11_support_88(save_xml):
         instance="ibmMeta/xml11Support.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_xpath_default_nson_key_key_ref_unique_89(save_xml):
 
     assert_bindings(
@@ -1153,11 +1244,12 @@ def test_introspection_introspect_test_set_xpath_default_nson_key_key_ref_unique
         instance="ibmMeta/xpathDefaultNSonKeyKeyRefUnique.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_xsimport_reference_90(save_xml):
 
     assert_bindings(
@@ -1166,11 +1258,12 @@ def test_introspection_introspect_test_set_xsimport_reference_90(save_xml):
         instance="ibmMeta/xsImportReference.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_introspection_introspect_test_set_year_month_duration_91(save_xml):
 
     assert_bindings(
@@ -1179,6 +1272,6 @@ def test_introspection_introspect_test_set_year_month_duration_91(save_xml):
         instance="ibmMeta/yearMonthDuration.testSet",
         instance_is_valid=True,
         class_name="TestSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_ibm_meta_404.py
+++ b/tests/test_ibm_meta_404.py
@@ -99,6 +99,7 @@ def test_s3_3_6v01_s3_3_6v01i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_6ii04_s3_10_6v04i(save_xml):
     """
     Tests namespace attribute on xs:anyAttribute
@@ -109,11 +110,12 @@ def test_s3_10_6ii04_s3_10_6v04i(save_xml):
         instance="ibmData/instance_invalid/S3_10_6/s3_10_6ii04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_6ii03_s3_10_6v03i(save_xml):
     """
     Tests namespace attribute on xs:anyAttribute
@@ -124,11 +126,12 @@ def test_s3_10_6ii03_s3_10_6v03i(save_xml):
         instance="ibmData/instance_invalid/S3_10_6/s3_10_6ii03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_6ii02_s3_10_6v02i(save_xml):
     """
     Tests notQName and notNamespace list in xs:anyAttribute
@@ -139,11 +142,12 @@ def test_s3_10_6ii02_s3_10_6v02i(save_xml):
         instance="ibmData/instance_invalid/S3_10_6/s3_10_6ii02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_6ii01_s3_10_6v01i(save_xml):
     """
     Tests notQName on xs:anyAttribute
@@ -154,7 +158,7 @@ def test_s3_10_6ii01_s3_10_6v01i(save_xml):
         instance="ibmData/instance_invalid/S3_10_6/s3_10_6ii01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -2662,6 +2666,7 @@ def test_s2_7_2ii01_s2_7_2ii01i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_s2_7_2v01_s2_7_2v01i(save_xml):
     """
     Structures introduces a mechanism for signaling that an element
@@ -2679,7 +2684,7 @@ def test_s2_7_2v01_s2_7_2v01i(save_xml):
         instance="ibmData/valid/S2_7_2/s2_7_2v01.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -5401,6 +5406,7 @@ def test_s3_16_2ii01_s3_16_2ii01i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_s3_16_2v07_s3_16_2v07i(save_xml):
     """
     xsi:type used to name a member of a restricted union type
@@ -5411,7 +5417,7 @@ def test_s3_16_2v07_s3_16_2v07i(save_xml):
         instance="ibmData/valid/S3_16_2/s3_16_2v07.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -5592,6 +5598,7 @@ def test_d3_3_16ii01_d3_3_16ii01i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_d3_3_16v01_d3_3_16v01i(save_xml):
     """
     test Units of length for hexBinary datatype.
@@ -5602,7 +5609,7 @@ def test_d3_3_16v01_d3_3_16v01i(save_xml):
         instance="ibmData/valid/D3_3_16/d3_3_16v01.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -5850,6 +5857,7 @@ def test_vc_001_vc_001_3(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_1ii09_s3_10_1ii09i(save_xml):
     """
     the keyword ##definedSibling can be used to exclude all elements
@@ -5862,11 +5870,12 @@ def test_s3_10_1ii09_s3_10_1ii09i(save_xml):
         instance="ibmData/instance_invalid/S3_10_1/s3_10_1ii09.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_1ii08_s3_10_1ii08i(save_xml):
     """
     the keyword ##definedSibling can be used to exclude all elements
@@ -5878,11 +5887,12 @@ def test_s3_10_1ii08_s3_10_1ii08i(save_xml):
         instance="ibmData/instance_invalid/S3_10_1/s3_10_1ii08.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_1ii07_s3_10_1ii07i(save_xml):
     """
     Tests namespace attribute in wildcard
@@ -5893,7 +5903,7 @@ def test_s3_10_1ii07_s3_10_1ii07i(save_xml):
         instance="ibmData/instance_invalid/S3_10_1/s3_10_1ii07.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -5915,6 +5925,7 @@ def test_s3_10_1ii06_s3_10_1ii06i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_1ii04_s3_10_1ii04i(save_xml):
     """
     invalid element in instance document as it does not match ns of
@@ -5926,11 +5937,12 @@ def test_s3_10_1ii04_s3_10_1ii04i(save_xml):
         instance="ibmData/instance_invalid/S3_10_1/s3_10_1ii04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_1ii03_s3_10_1ii03i(save_xml):
     """
     invalid element in instance document as it does not match ns of
@@ -5942,7 +5954,7 @@ def test_s3_10_1ii03_s3_10_1ii03i(save_xml):
         instance="ibmData/instance_invalid/S3_10_1/s3_10_1ii03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -5964,6 +5976,7 @@ def test_s3_10_1ii02_s3_10_1ii02i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_s3_10_1ii01_s3_10_1ii01i(save_xml):
     """
     invalid element in instance document as it does not match ns of
@@ -5975,7 +5988,7 @@ def test_s3_10_1ii01_s3_10_1ii01i(save_xml):
         instance="ibmData/instance_invalid/S3_10_1/s3_10_1ii01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -6096,6 +6109,7 @@ def test_s3_10_1v01_s3_10_1v01i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_d3_4_6ii04_d3_4_6ii04i(save_xml):
     r"""
     invalid instance for effect of \c in regular expressions
@@ -6106,11 +6120,12 @@ def test_d3_4_6ii04_d3_4_6ii04i(save_xml):
         instance="ibmData/instance_invalid/D3_4_6/d3_4_6ii04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_d3_4_6ii03_d3_4_6ii03i(save_xml):
     r"""
     invalid instance for effect of \i in regular expressions
@@ -6121,11 +6136,12 @@ def test_d3_4_6ii03_d3_4_6ii03i(save_xml):
         instance="ibmData/instance_invalid/D3_4_6/d3_4_6ii03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_d3_4_6ii02_d3_4_6ii02i(save_xml):
     """
     invalid instance for value space of xs:NCName
@@ -6136,11 +6152,12 @@ def test_d3_4_6ii02_d3_4_6ii02i(save_xml):
         instance="ibmData/instance_invalid/D3_4_6/d3_4_6ii02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_d3_4_6ii01_d3_4_6ii01i(save_xml):
     """
     invalid instance for value space of xs:Name
@@ -6151,7 +6168,7 @@ def test_d3_4_6ii01_d3_4_6ii01i(save_xml):
         instance="ibmData/instance_invalid/D3_4_6/d3_4_6ii01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 

--- a/tests/test_ms_meta_1000.py
+++ b/tests/test_ms_meta_1000.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_member_type024_member_type024_v(save_xml):
     """
     TEST :Adhoc XSD: : Attribute of union of user defined
@@ -14,11 +15,12 @@ def test_member_type024_member_type024_v(save_xml):
         instance="msData/additional/memberType024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type023_member_type023_v(save_xml):
     """
     TEST :Adhoc XSD: : Attribute of union of user defined
@@ -30,11 +32,12 @@ def test_member_type023_member_type023_v(save_xml):
         instance="msData/additional/memberType023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type022_member_type022_v(save_xml):
     """
     TEST :Adhoc XSD: : Element of union of user defined
@@ -46,11 +49,12 @@ def test_member_type022_member_type022_v(save_xml):
         instance="msData/additional/memberType022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type021_member_type021_v(save_xml):
     """
     TEST :Adhoc XSD: : Element of union of user defined
@@ -62,11 +66,12 @@ def test_member_type021_member_type021_v(save_xml):
         instance="msData/additional/memberType021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type008_member_type008_v(save_xml):
     """
     TEST :Adhoc XSD: : Element with default value and xsi:type: membertype
@@ -78,11 +83,12 @@ def test_member_type008_member_type008_v(save_xml):
         instance="msData/additional/memberType008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type007_member_type007_v(save_xml):
     """
     TEST :Adhoc XSD: : Element with xsi:type: membertype of
@@ -94,11 +100,12 @@ def test_member_type007_member_type007_v(save_xml):
         instance="msData/additional/memberType007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type006_member_type006_v(save_xml):
     """
     TEST :Adhoc XSD: : Element with xsi:type: membertype of
@@ -110,11 +117,12 @@ def test_member_type006_member_type006_v(save_xml):
         instance="msData/additional/memberType006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type005_member_type005_v(save_xml):
     """
     TEST :Adhoc XSD: : Attribute with default value: membertype of
@@ -126,11 +134,12 @@ def test_member_type005_member_type005_v(save_xml):
         instance="msData/additional/memberType005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type004_member_type004_v(save_xml):
     """
     TEST :Adhoc XSD: : Element with default value: membertype of
@@ -142,11 +151,12 @@ def test_member_type004_member_type004_v(save_xml):
         instance="msData/additional/memberType004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type003_member_type003_v(save_xml):
     """
     TEST :Adhoc XSD: : Attribute: membertype of union(bool,int,string)
@@ -157,11 +167,12 @@ def test_member_type003_member_type003_v(save_xml):
         instance="msData/additional/memberType003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type002_member_type002_v(save_xml):
     """
     TEST :Adhoc XSD: : Element: membertype of union(bool,int,string)
@@ -172,11 +183,12 @@ def test_member_type002_member_type002_v(save_xml):
         instance="msData/additional/memberType002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_member_type001_member_type001_v(save_xml):
     """
     TEST :Adhoc XSD: : Element : membertype of union(bool,int,string)
@@ -187,11 +199,12 @@ def test_member_type001_member_type001_v(save_xml):
         instance="msData/additional/memberType001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default079_is_default079_v(save_xml):
     """
     TEST :Adhoc XSD: : multiple 'fixed' constraints
@@ -202,11 +215,12 @@ def test_is_default079_is_default079_v(save_xml):
         instance="msData/additional/isdefault079.xml",
         instance_is_valid=True,
         class_name="Regvaluemodopset",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default078_is_default078_v(save_xml):
     """
     TEST :Adhoc XSD: : map xml namespace in the instance to be able to
@@ -218,11 +232,12 @@ def test_is_default078_is_default078_v(save_xml):
         instance="msData/additional/isdefault078.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default077_is_default077_i(save_xml):
     """
     TEST :Adhoc XSD: : fixed value on mixed content with invalid value in
@@ -234,11 +249,12 @@ def test_is_default077_is_default077_i(save_xml):
         instance="msData/additional/isdefault076.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default076_is_default076_v(save_xml):
     """
     TEST :Adhoc XSD: : fixed value on mixed content
@@ -249,11 +265,12 @@ def test_is_default076_is_default076_v(save_xml):
         instance="msData/additional/isdefault075.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default075_is_default075_v(save_xml):
     """
     TEST :Adhoc XSD: : default value on mixed content
@@ -264,11 +281,12 @@ def test_is_default075_is_default075_v(save_xml):
         instance="msData/additional/isdefault075.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default074_is_default074_v(save_xml):
     """
     TEST :Adhoc XSD: : attribute of type xs:anySimpleType with a default
@@ -280,11 +298,12 @@ def test_is_default074_is_default074_v(save_xml):
         instance="msData/additional/isdefault074.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default073_is_default073_v(save_xml):
     """
     TEST :Adhoc XSD: : element of type xs:anyType with a default and fixed
@@ -296,11 +315,12 @@ def test_is_default073_is_default073_v(save_xml):
         instance="msData/additional/isdefault073.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default072_is_default072_v(save_xml):
     """
     TEST :Adhoc XSD: : While adding default attributes with
@@ -312,11 +332,12 @@ def test_is_default072_is_default072_v(save_xml):
         instance="msData/additional/isdefault072.xml",
         instance_is_valid=True,
         class_name="Array",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default071_is_default071_v(save_xml):
     """
     TEST :Adhoc XSD: : element of type xs:anyType with value not matching
@@ -328,11 +349,12 @@ def test_is_default071_is_default071_v(save_xml):
         instance="msData/additional/isdefault071.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default070_is_default070_i(save_xml):
     """
     TEST :Adhoc XSD: : element of type xs:anyType with value not matching
@@ -344,11 +366,12 @@ def test_is_default070_is_default070_i(save_xml):
         instance="msData/additional/isdefault070.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default060_1_is_default060_1_v(save_xml):
     """
     TEST :Adhoc XSD: : test empty element typed as xsd:int with default
@@ -360,11 +383,12 @@ def test_is_default060_1_is_default060_1_v(save_xml):
         instance="msData/additional/test95960_1.xml",
         instance_is_valid=True,
         class_name="Employees",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default068_is_default068_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) Local Element with no
@@ -376,11 +400,12 @@ def test_is_default068_is_default068_v(save_xml):
         instance="msData/additional/isdefault068.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default067_is_default067_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) Local Element with all
@@ -392,11 +417,12 @@ def test_is_default067_is_default067_v(save_xml):
         instance="msData/additional/isdefault067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default066_is_default066_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) no attributes on root
@@ -408,11 +434,12 @@ def test_is_default066_is_default066_v(save_xml):
         instance="msData/additional/isdefault066.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default065_is_default065_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) No attributes on root
@@ -424,11 +451,12 @@ def test_is_default065_is_default065_v(save_xml):
         instance="msData/additional/isdefault065.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default064_is_default064_i(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -440,11 +468,12 @@ def test_is_default064_is_default064_i(save_xml):
         instance="msData/additional/isdefault064.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default063_is_default063_i(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -456,11 +485,12 @@ def test_is_default063_is_default063_i(save_xml):
         instance="msData/additional/isdefault063.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default062_is_default062_i(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -472,11 +502,12 @@ def test_is_default062_is_default062_i(save_xml):
         instance="msData/additional/isdefault062.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default061_is_default061_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -488,11 +519,12 @@ def test_is_default061_is_default061_v(save_xml):
         instance="msData/additional/isdefault061.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default058_is_default058_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) Local Element with no
@@ -504,11 +536,12 @@ def test_is_default058_is_default058_v(save_xml):
         instance="msData/additional/isdefault058.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default057_is_default057_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) Local Element with all
@@ -520,11 +553,12 @@ def test_is_default057_is_default057_v(save_xml):
         instance="msData/additional/isdefault057.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default056_is_default056_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) no attributes on root
@@ -536,11 +570,12 @@ def test_is_default056_is_default056_v(save_xml):
         instance="msData/additional/isdefault056.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default055_is_default055_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) No attributes on root
@@ -552,11 +587,12 @@ def test_is_default055_is_default055_v(save_xml):
         instance="msData/additional/isdefault055.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default054_is_default054_i(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -568,11 +604,12 @@ def test_is_default054_is_default054_i(save_xml):
         instance="msData/additional/isdefault054.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default053_is_default053_i(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -584,11 +621,12 @@ def test_is_default053_is_default053_i(save_xml):
         instance="msData/additional/isdefault053.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default052_is_default052_i(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -600,11 +638,12 @@ def test_is_default052_is_default052_i(save_xml):
         instance="msData/additional/isdefault052.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default051_is_default051_v(save_xml):
     """
     TEST :Adhoc XSD: : Attributes: IsDefault(fixed) attributes on root
@@ -616,11 +655,12 @@ def test_is_default051_is_default051_v(save_xml):
         instance="msData/additional/isdefault051.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default028_is_default028_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) a sequence with elements
@@ -632,11 +672,12 @@ def test_is_default028_is_default028_v(save_xml):
         instance="msData/additional/isdefault028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default027_is_default027_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) a sequence with elements
@@ -648,11 +689,12 @@ def test_is_default027_is_default027_v(save_xml):
         instance="msData/additional/isdefault027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default026_is_default026_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) a sequence with elements
@@ -664,11 +706,12 @@ def test_is_default026_is_default026_v(save_xml):
         instance="msData/additional/isdefault026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default025_is_default025_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) a sequence with elements
@@ -680,11 +723,12 @@ def test_is_default025_is_default025_v(save_xml):
         instance="msData/additional/isdefault025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default024_is_default024_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) for Element with invalid
@@ -696,11 +740,12 @@ def test_is_default024_is_default024_v(save_xml):
         instance="msData/additional/isdefault024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default023_is_default023_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) for Empty Element with
@@ -712,11 +757,12 @@ def test_is_default023_is_default023_v(save_xml):
         instance="msData/additional/isdefault023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default022_is_default022_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) for Empty Element with
@@ -728,11 +774,12 @@ def test_is_default022_is_default022_v(save_xml):
         instance="msData/additional/isdefault022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default021_is_default021_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(default) for Empty Element with no
@@ -744,11 +791,12 @@ def test_is_default021_is_default021_v(save_xml):
         instance="msData/additional/isdefault021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default011_is_default011_i(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -760,11 +808,12 @@ def test_is_default011_is_default011_i(save_xml):
         instance="msData/additional/isdefault011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default010_is_default010_i(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -776,11 +825,12 @@ def test_is_default010_is_default010_i(save_xml):
         instance="msData/additional/isdefault010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default009_is_default009_i(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -792,11 +842,12 @@ def test_is_default009_is_default009_i(save_xml):
         instance="msData/additional/isdefault009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default008_is_default008_i(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -808,11 +859,12 @@ def test_is_default008_is_default008_i(save_xml):
         instance="msData/additional/isdefault008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default007_is_default007_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -824,11 +876,12 @@ def test_is_default007_is_default007_v(save_xml):
         instance="msData/additional/isdefault007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default006_is_default006_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -840,11 +893,12 @@ def test_is_default006_is_default006_v(save_xml):
         instance="msData/additional/isdefault006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default005_is_default005_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) a sequence with elements
@@ -856,11 +910,12 @@ def test_is_default005_is_default005_v(save_xml):
         instance="msData/additional/isdefault005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default004_is_default004_i(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) for Element with invalid
@@ -872,11 +927,12 @@ def test_is_default004_is_default004_i(save_xml):
         instance="msData/additional/isdefault004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default003_is_default003_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) for Empty Element with fixed
@@ -888,11 +944,12 @@ def test_is_default003_is_default003_v(save_xml):
         instance="msData/additional/isdefault003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default002_is_default002_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) for Empty Element with start
@@ -904,11 +961,12 @@ def test_is_default002_is_default002_v(save_xml):
         instance="msData/additional/isdefault002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_is_default001_is_default001_v(save_xml):
     """
     TEST :Adhoc XSD: : Check IsDefault(fixed) for Empty Element with no
@@ -920,11 +978,12 @@ def test_is_default001_is_default001_v(save_xml):
         instance="msData/additional/isdefault001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_add_d004a_add_d004a_v(save_xml):
     """
@@ -937,11 +996,12 @@ def test_add_d004a_add_d004a_v(save_xml):
         instance="msData/additional/ipo.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_d004_add_d004_v(save_xml):
     """
     TEST :Adhoc XSD: : SAMPLE: xsd 1.0 Sturcture spec : the ipo.xsd with a
@@ -953,11 +1013,12 @@ def test_add_d004_add_d004_v(save_xml):
         instance="msData/additional/ipo_s1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_d002_add_d002_v(save_xml):
     """
     TEST :Adhoc XSD: : xsd 1.0 Prima: the po.xml and po.xsd declared as
@@ -969,11 +1030,12 @@ def test_add_d002_add_d002_v(save_xml):
         instance="msData/additional/po.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_d001_add_d001_v(save_xml):
     """
     TEST :Adhoc XSD: : xsd 1.0 Prima: the po.xml and po.xsd without
@@ -985,11 +1047,12 @@ def test_add_d001_add_d001_v(save_xml):
         instance="msData/additional/po1.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b202b_add_b202b_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test datatype parsing
@@ -1001,11 +1064,12 @@ def test_add_b202b_add_b202b_i(save_xml):
         instance="msData/additional/datetime.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b202a_add_b202a_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test datatype parsing
@@ -1017,11 +1081,12 @@ def test_add_b202a_add_b202a_i(save_xml):
         instance="msData/additional/hexbin.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b201_add_b201_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test namespace decl
@@ -1032,11 +1097,12 @@ def test_add_b201_add_b201_i(save_xml):
         instance="msData/additional/ns.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b200c_add_b200c_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test identity
@@ -1048,11 +1114,12 @@ def test_add_b200c_add_b200c_i(save_xml):
         instance="msData/additional/idc3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b200b_add_b200b_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test identity
@@ -1064,11 +1131,12 @@ def test_add_b200b_add_b200b_i(save_xml):
         instance="msData/additional/idc2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b200a_add_b200a_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test identity
@@ -1080,11 +1148,12 @@ def test_add_b200a_add_b200a_i(save_xml):
         instance="msData/additional/idc1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b199_add_b199_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with xsi type
@@ -1095,11 +1164,12 @@ def test_add_b199_add_b199_i(save_xml):
         instance="msData/additional/xsiType.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b198d_add_b198d_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with minLength
@@ -1111,11 +1181,12 @@ def test_add_b198d_add_b198d_v(save_xml):
         instance="msData/additional/minLength2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b198c_add_b198c_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with minLength
@@ -1127,11 +1198,12 @@ def test_add_b198c_add_b198c_v(save_xml):
         instance="msData/additional/minLength1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b198b_add_b198b_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with maxLength
@@ -1143,11 +1215,12 @@ def test_add_b198b_add_b198b_i(save_xml):
         instance="msData/additional/maxLength2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b198a_add_b198a_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with maxLength
@@ -1159,11 +1232,12 @@ def test_add_b198a_add_b198a_i(save_xml):
         instance="msData/additional/maxLength1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b197f_add_b197f_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with enumeration
@@ -1175,11 +1249,12 @@ def test_add_b197f_add_b197f_i(save_xml):
         instance="msData/additional/enum1c.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b197e_add_b197e_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with enumeration
@@ -1191,11 +1266,12 @@ def test_add_b197e_add_b197e_i(save_xml):
         instance="msData/additional/enum1a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b197d_add_b197d_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with enumeration
@@ -1207,11 +1283,12 @@ def test_add_b197d_add_b197d_i(save_xml):
         instance="msData/additional/enum1d.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b197c_add_b197c_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with enumeration
@@ -1223,11 +1300,12 @@ def test_add_b197c_add_b197c_v(save_xml):
         instance="msData/additional/enum1c.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b197b_add_b197b_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with enumeration
@@ -1239,11 +1317,12 @@ def test_add_b197b_add_b197b_i(save_xml):
         instance="msData/additional/enum1b.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b197a_add_b197a_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with enumeration
@@ -1255,11 +1334,12 @@ def test_add_b197a_add_b197a_v(save_xml):
         instance="msData/additional/enum1a.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196l_add_b196l_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1271,11 +1351,12 @@ def test_add_b196l_add_b196l_i(save_xml):
         instance="msData/additional/fixed3b.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196k_add_b196k_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1287,11 +1368,12 @@ def test_add_b196k_add_b196k_i(save_xml):
         instance="msData/additional/fixed3a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196j_add_b196j_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1303,11 +1385,12 @@ def test_add_b196j_add_b196j_i(save_xml):
         instance="msData/additional/fixed2b.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196i_add_b196i_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1319,11 +1402,12 @@ def test_add_b196i_add_b196i_i(save_xml):
         instance="msData/additional/fixed2a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196h_add_b196h_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1335,11 +1419,12 @@ def test_add_b196h_add_b196h_v(save_xml):
         instance="msData/additional/fixed1d.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196g_add_b196g_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1351,11 +1436,12 @@ def test_add_b196g_add_b196g_i(save_xml):
         instance="msData/additional/fixed1c.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196f_add_b196f_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1367,11 +1453,12 @@ def test_add_b196f_add_b196f_v(save_xml):
         instance="msData/additional/fixed1b.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196e_add_b196e_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1383,11 +1470,12 @@ def test_add_b196e_add_b196e_i(save_xml):
         instance="msData/additional/fixed1a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196d_add_b196d_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1399,11 +1487,12 @@ def test_add_b196d_add_b196d_i(save_xml):
         instance="msData/additional/fixed1d.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196c_add_b196c_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1415,11 +1504,12 @@ def test_add_b196c_add_b196c_v(save_xml):
         instance="msData/additional/fixed1c.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196b_add_b196b_i(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1431,11 +1521,12 @@ def test_add_b196b_add_b196b_i(save_xml):
         instance="msData/additional/fixed1b.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b196a_add_b196a_v(save_xml):
     """
     TEST :Adhoc XSD: : zero width unicode characeter test with fixed
@@ -1447,11 +1538,12 @@ def test_add_b196a_add_b196a_v(save_xml):
         instance="msData/additional/fixed1a.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b191_add_b191_v(save_xml):
     """
     TEST :Adhoc XSD: : XSD: During validation of an element schemas in
@@ -1465,11 +1557,12 @@ def test_add_b191_add_b191_v(save_xml):
         instance="msData/additional/addB191.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b188_add_b188_i(save_xml):
     """
     TEST :Adhoc XSD: : XSD: Support user specified schema for
@@ -1481,11 +1574,12 @@ def test_add_b188_add_b188_i(save_xml):
         instance="msData/additional/test264908_1i.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_add_b187_add_b187_v(save_xml):
     """
@@ -1498,11 +1592,12 @@ def test_add_b187_add_b187_v(save_xml):
         instance="msData/additional/test264908_1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b182_add_b182_v(save_xml):
     """
     TEST :Adhoc XSD: : id="schemaLocation for schema whose targetNamespace
@@ -1514,11 +1609,12 @@ def test_add_b182_add_b182_v(save_xml):
         instance="msData/additional/test111871.xml",
         instance_is_valid=True,
         class_name="Title",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b181_add_b181_i(save_xml):
     """
     TEST :Adhoc XSD: : id="validating an invalid xsd type"
@@ -1529,11 +1625,12 @@ def test_add_b181_add_b181_i(save_xml):
         instance="msData/additional/test109017.xml",
         instance_is_valid=False,
         class_name="Assembly",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b176_add_b176_v(save_xml):
     """
     TEST :Adhoc XSD: : id="102850" description="valid but ambigous schema"
@@ -1544,11 +1641,12 @@ def test_add_b176_add_b176_v(save_xml):
         instance="msData/additional/test102850_1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b175_add_b175_i(save_xml):
     """
     TEST :Adhoc XSD: : id="102433" description="Validation of xml
@@ -1560,11 +1658,12 @@ def test_add_b175_add_b175_i(save_xml):
         instance="msData/additional/test102433_6.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b174_add_b174_v(save_xml):
     """
     TEST :Adhoc XSD: : id="102433" description="Validation of xml
@@ -1576,11 +1675,12 @@ def test_add_b174_add_b174_v(save_xml):
         instance="msData/additional/test102433_5.xml",
         instance_is_valid=True,
         class_name="Bar",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b173_add_b173_i(save_xml):
     """
     TEST :Adhoc XSD: : id="102433" description="Validation of xml
@@ -1592,11 +1692,12 @@ def test_add_b173_add_b173_i(save_xml):
         instance="msData/additional/test102433_4.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b172_add_b172_i(save_xml):
     """
     TEST :Adhoc XSD: : id="102433" description="Validation of xml
@@ -1608,11 +1709,12 @@ def test_add_b172_add_b172_i(save_xml):
         instance="msData/additional/test102433_3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b171_add_b171_i(save_xml):
     """
     TEST :Adhoc XSD: : id="102433" description="Validation of xml
@@ -1624,11 +1726,12 @@ def test_add_b171_add_b171_i(save_xml):
         instance="msData/additional/test102433_2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b170_add_b170_i(save_xml):
     """
     TEST :Adhoc XSD: : id="102433" description="Validation of xml
@@ -1640,11 +1743,12 @@ def test_add_b170_add_b170_i(save_xml):
         instance="msData/additional/test102433_1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b169_1_add_b169_1_v(save_xml):
     """
     TEST :Adhoc XSD: : id="243307" description="test valid document with
@@ -1656,11 +1760,12 @@ def test_add_b169_1_add_b169_1_v(save_xml):
         instance="msData/additional/test93490_16.xml",
         instance_is_valid=True,
         class_name="MapInfo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b169_add_b169_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1672,11 +1777,12 @@ def test_add_b169_add_b169_v(save_xml):
         instance="msData/additional/test93490_15.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b168_add_b168_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1688,11 +1794,12 @@ def test_add_b168_add_b168_v(save_xml):
         instance="msData/additional/test93490_14.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b167_add_b167_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1705,11 +1812,12 @@ def test_add_b167_add_b167_i(save_xml):
         instance="msData/additional/test93490_13.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b166_add_b166_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1721,11 +1829,12 @@ def test_add_b166_add_b166_i(save_xml):
         instance="msData/additional/test93490_12.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b165_add_b165_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1737,11 +1846,12 @@ def test_add_b165_add_b165_v(save_xml):
         instance="msData/additional/test93490_11.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b164_add_b164_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1753,11 +1863,12 @@ def test_add_b164_add_b164_i(save_xml):
         instance="msData/additional/test93490_10.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b163_add_b163_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1769,11 +1880,12 @@ def test_add_b163_add_b163_v(save_xml):
         instance="msData/additional/test93490_9.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b162_add_b162_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1785,11 +1897,12 @@ def test_add_b162_add_b162_i(save_xml):
         instance="msData/additional/test93490_8.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b161_add_b161_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1801,11 +1914,12 @@ def test_add_b161_add_b161_i(save_xml):
         instance="msData/additional/test93490_7.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b160_add_b160_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1817,11 +1931,12 @@ def test_add_b160_add_b160_v(save_xml):
         instance="msData/additional/test93490_6.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b159_add_b159_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1833,11 +1948,12 @@ def test_add_b159_add_b159_i(save_xml):
         instance="msData/additional/test93490_5.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b158_add_b158_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1850,11 +1966,12 @@ def test_add_b158_add_b158_i(save_xml):
         instance="msData/additional/test93490_4.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b157_add_b157_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1866,11 +1983,12 @@ def test_add_b157_add_b157_v(save_xml):
         instance="msData/additional/test93490_3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b156_add_b156_i(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1883,11 +2001,12 @@ def test_add_b156_add_b156_i(save_xml):
         instance="msData/additional/test93490_2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b155_add_b155_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93490" description="test schema location or
@@ -1899,11 +2018,12 @@ def test_add_b155_add_b155_v(save_xml):
         instance="msData/additional/test93490_1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b149_add_b149_i(save_xml):
     """
     TEST :Adhoc XSD: : id="97822" description="complexContent element with
@@ -1916,11 +2036,12 @@ def test_add_b149_add_b149_i(save_xml):
         instance="msData/additional/test97822.xml",
         instance_is_valid=False,
         class_name="Root1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b148_add_b148_v(save_xml):
     """
     TEST :Adhoc XSD: : id="93276" description="XSD: should not overwrite
@@ -1933,11 +2054,12 @@ def test_add_b148_add_b148_v(save_xml):
         instance="msData/additional/test93276.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test93160_test93160_i(save_xml):
     """
     TEST :Adhoc XSD: : Whitespace is collapsed for element with type
@@ -1949,11 +2071,12 @@ def test_test93160_test93160_i(save_xml):
         instance="msData/additional/test93160.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b145_add_b145_v(save_xml):
     """
     TEST :Adhoc XSD: : id="87395" description="validateElement on XSD with
@@ -1967,11 +2090,12 @@ def test_add_b145_add_b145_v(save_xml):
         instance="msData/additional/test87395.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b143_add_b143_i(save_xml):
     """
     TEST :Adhoc XSD: : id="83452" description="Invalid lexical hexBinary
@@ -1984,11 +2108,12 @@ def test_add_b143_add_b143_i(save_xml):
         instance="msData/additional/test83452.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b142_add_b142_i(save_xml):
     """
     TEST :Adhoc XSD: : id="84613" description="validation xml with inline
@@ -2000,11 +2125,12 @@ def test_add_b142_add_b142_i(save_xml):
         instance="msData/additional/test84613.xml",
         instance_is_valid=False,
         class_name="Envelope",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b140_add_b140_v(save_xml):
     """
     TEST :Adhoc XSD: : id="78000" description="any and
@@ -2016,11 +2142,12 @@ def test_add_b140_add_b140_v(save_xml):
         instance="msData/additional/test78000.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b139_add_b139_i(save_xml):
     """
     TEST :Adhoc XSD: : id="84002" description="validating an XSD with
@@ -2032,11 +2159,12 @@ def test_add_b139_add_b139_i(save_xml):
         instance="msData/additional/test84002_b.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b138_add_b138_i(save_xml):
     """
     TEST :Adhoc XSD: : id="84002" description="validating an XSD with
@@ -2048,11 +2176,12 @@ def test_add_b138_add_b138_i(save_xml):
         instance="msData/additional/test84002_a.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b136_add_b136_v(save_xml):
     """
     TEST :Adhoc XSD: : id="84188" description="XSD: Attribute with
@@ -2064,11 +2193,12 @@ def test_add_b136_add_b136_v(save_xml):
         instance="msData/additional/test84188.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b135_add_b135_v(save_xml):
     """
     TEST :Adhoc XSD: : id="81662" description="xsd: test element matching
@@ -2080,11 +2210,12 @@ def test_add_b135_add_b135_v(save_xml):
         instance="msData/additional/test81662.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b134_add_b134_v(save_xml):
     """
     TEST :Adhoc XSD: : id="72131" description="XSD: test xml includes xsd
@@ -2096,11 +2227,12 @@ def test_add_b134_add_b134_v(save_xml):
         instance="msData/additional/test72131.xml",
         instance_is_valid=True,
         class_name="OrdersByCustomer",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b132_add_b132_v(save_xml):
     """
     TEST :Adhoc XSD: : id="66745" description="xsd validation:xsd
@@ -2112,11 +2244,12 @@ def test_add_b132_add_b132_v(save_xml):
         instance="msData/additional/test66745.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b131_add_b131_v(save_xml):
     """
     TEST :Adhoc XSD: : id="76423" description="test validation of keys
@@ -2128,11 +2261,12 @@ def test_add_b131_add_b131_v(save_xml):
         instance="msData/additional/test76423.xml",
         instance_is_valid=True,
         class_name="Jsml",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b130_add_b130_v(save_xml):
     """
     TEST :Adhoc XSD: : id="78162" description="attribute on xsd:any
@@ -2144,11 +2278,12 @@ def test_add_b130_add_b130_v(save_xml):
         instance="msData/additional/test78126.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b129_add_b129_v(save_xml):
     """
     TEST :Adhoc XSD: : id="74834" description="validate xml data when it
@@ -2160,11 +2295,12 @@ def test_add_b129_add_b129_v(save_xml):
         instance="msData/additional/test74834.xml",
         instance_is_valid=True,
         class_name="Datafile",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b125_add_b125_v(save_xml):
     """
     TEST :Adhoc XSD: : id="78898" description="xsd: wildcard: content type
@@ -2176,11 +2312,12 @@ def test_add_b125_add_b125_v(save_xml):
         instance="msData/additional/test78898.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b124_add_b124_i(save_xml):
     """
     TEST :Adhoc XSD: : id="79253" description="XSD: validating an XML with
@@ -2192,11 +2329,12 @@ def test_add_b124_add_b124_i(save_xml):
         instance="msData/additional/test79253.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b123_add_b123_i(save_xml):
     """
     TEST :Adhoc XSD: : id="79416" description="xsd: test violation of
@@ -2208,11 +2346,12 @@ def test_add_b123_add_b123_i(save_xml):
         instance="msData/additional/test79416.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b122_add_b122_v(save_xml):
     """
     TEST :Adhoc XSD: : id="78910" description="xsd: wildcard: content type
@@ -2224,11 +2363,12 @@ def test_add_b122_add_b122_v(save_xml):
         instance="msData/additional/addB122.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b120_add_b120_i(save_xml):
     """
     TEST :Adhoc XSD: : id="73456" description="xsd: test validating an XML
@@ -2240,11 +2380,12 @@ def test_add_b120_add_b120_i(save_xml):
         instance="msData/additional/test73456.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b116_add_b116_v(save_xml):
     """
     TEST :Adhoc XSD: : id="75092" description="xsd: 'any' with
@@ -2257,11 +2398,12 @@ def test_add_b116_add_b116_v(save_xml):
         instance="msData/additional/test75092.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b115_add_b115_i(save_xml):
     """
     TEST :Adhoc XSD: : id="75564" description="xsd: absolute string in
@@ -2274,11 +2416,12 @@ def test_add_b115_add_b115_i(save_xml):
         instance="msData/additional/addB115.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b114_add_b114_i(save_xml):
     """
     TEST :Adhoc XSD: : id="75808" description="xsd testing"
@@ -2289,11 +2432,12 @@ def test_add_b114_add_b114_i(save_xml):
         instance="msData/additional/addB114.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b109_add_b109_i(save_xml):
     """
     TEST :Adhoc XSD: : check that the local fixed value must be the same
@@ -2305,11 +2449,12 @@ def test_add_b109_add_b109_i(save_xml):
         instance="msData/additional/addB109.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b105_add_b105_i(save_xml):
     """
     TEST :Adhoc XSD: : test element's fixed value is not normalized
@@ -2320,11 +2465,12 @@ def test_add_b105_add_b105_i(save_xml):
         instance="msData/additional/addB105.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b104_add_b104_v(save_xml):
     """
     TEST :Adhoc XSD: : test attribute normalization of fixed value of an
@@ -2336,11 +2482,12 @@ def test_add_b104_add_b104_v(save_xml):
         instance="msData/additional/addB104.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b102_add_b102_i(save_xml):
     """
     TEST :Adhoc XSD: : id="60941" description="xsd: particle validation
@@ -2353,11 +2500,12 @@ def test_add_b102_add_b102_i(save_xml):
         instance="msData/additional/addB102.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b098_add_b098_i(save_xml):
     """
     TEST :Adhoc XSD: : id="61115" description="test when the content is
@@ -2369,11 +2517,12 @@ def test_add_b098_add_b098_i(save_xml):
         instance="msData/additional/addB098.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b096_add_b096_v(save_xml):
     """
     TEST :Adhoc XSD: : id="61053" description="xsd: test 'group' reference
@@ -2385,11 +2534,12 @@ def test_add_b096_add_b096_v(save_xml):
         instance="msData/additional/addB096.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b092_add_b092_i(save_xml):
     """
     TEST :Adhoc XSD: : id="62136" description="xsd: in an 'all' group,
@@ -2402,11 +2552,12 @@ def test_add_b092_add_b092_i(save_xml):
         instance="msData/additional/addB092.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b090_add_b090_v(save_xml):
     """
     TEST :Adhoc XSD: : id="61911" description="xsd: extension: when
@@ -2419,11 +2570,12 @@ def test_add_b090_add_b090_v(save_xml):
         instance="msData/additional/addB090.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b088_add_b088_v(save_xml):
     """
     TEST :Adhoc XSD: : id="61692" description="xsd:
@@ -2436,11 +2588,12 @@ def test_add_b088_add_b088_v(save_xml):
         instance="msData/additional/addB088.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b087_add_b087_i(save_xml):
     """
     TEST :Adhoc XSD: : id="61692" description="xsd:
@@ -2453,11 +2606,12 @@ def test_add_b087_add_b087_i(save_xml):
         instance="msData/additional/addB087.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b084_add_b084_v(save_xml):
     """
     TEST :Adhoc XSD: : id="61599" description="xsd:particle: all, test
@@ -2470,11 +2624,12 @@ def test_add_b084_add_b084_v(save_xml):
         instance="msData/additional/addB084.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b080_add_b080_i(save_xml):
     """
     TEST :Adhoc XSD: : id="72554" description="XSD: should disallow
@@ -2486,11 +2641,12 @@ def test_add_b080_add_b080_i(save_xml):
         instance="msData/additional/addB080.xml",
         instance_is_valid=False,
         class_name="Orders",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b076_add_b076_v(save_xml):
     """
     TEST :Adhoc XSD: : id="75028"
@@ -2501,11 +2657,12 @@ def test_add_b076_add_b076_v(save_xml):
         instance="msData/additional/addB076.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b075_add_b075_i(save_xml):
     """
     TEST :Adhoc XSD: : id="75564" description="xsd: we do not check for
@@ -2518,11 +2675,12 @@ def test_add_b075_add_b075_i(save_xml):
         instance="msData/additional/test75564.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b069_add_b069_i(save_xml):
     """
     TEST :Adhoc XSD: : id="63950" description="Validating instance
@@ -2534,11 +2692,12 @@ def test_add_b069_add_b069_i(save_xml):
         instance="msData/additional/test63950.xml",
         instance_is_valid=False,
         class_name="Zip",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b068_add_b068_i(save_xml):
     """
     TEST :Adhoc XSD: : id="73986" description="xsd: length of QName" TSTF
@@ -2550,11 +2709,12 @@ def test_add_b068_add_b068_i(save_xml):
         instance="msData/additional/test73986_2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b067_add_b067_v(save_xml):
     """
     TEST :Adhoc XSD: : id="73986" description="xsd: length of QName"
@@ -2565,11 +2725,12 @@ def test_add_b067_add_b067_v(save_xml):
         instance="msData/additional/test73986.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b066_add_b066_i(save_xml):
     """
     TEST :Adhoc XSD: : id="73850" description="xsd: test duplicated ID
@@ -2581,11 +2742,12 @@ def test_add_b066_add_b066_i(save_xml):
         instance="msData/additional/test73850.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b065_add_b065_i(save_xml):
     """
     TEST :Adhoc XSD: : id="73826" description="xsd: element, when nillable
@@ -2597,11 +2759,12 @@ def test_add_b065_add_b065_i(save_xml):
         instance="msData/additional/test73826.xml",
         instance_is_valid=False,
         class_name="R",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b063_add_b063_i(save_xml):
     """
     TEST :Adhoc XSD: : 72702 - test using or validating a not-wellformed
@@ -2613,11 +2776,12 @@ def test_add_b063_add_b063_i(save_xml):
         instance="msData/additional/test72702.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b059_add_b059_v(save_xml):
     r"""
     TEST :Adhoc XSD: : id="73666" description="xsd: Regular Expression:
@@ -2629,11 +2793,12 @@ def test_add_b059_add_b059_v(save_xml):
         instance="msData/additional/test73666.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b058_add_b058_v(save_xml):
     r"""
     TEST :Adhoc XSD: : id="73665" description="xsd: Regular Expression:
@@ -2645,11 +2810,12 @@ def test_add_b058_add_b058_v(save_xml):
         instance="msData/additional/test73665.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b057_add_b057_i(save_xml):
     r"""
     TEST :Adhoc XSD: : id="73715" description="xsd: Regular Expression:
@@ -2661,11 +2827,12 @@ def test_add_b057_add_b057_i(save_xml):
         instance="msData/additional/test73715i.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b056_add_b056_v(save_xml):
     r"""
     TEST :Adhoc XSD: : id="73715" description="xsd: Regular Expression:
@@ -2677,11 +2844,12 @@ def test_add_b056_add_b056_v(save_xml):
         instance="msData/additional/test73715v.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b054_add_b054_v(save_xml):
     """
     TEST :Adhoc XSD: : id="70948" description="xsd:invalid facets on
@@ -2693,11 +2861,12 @@ def test_add_b054_add_b054_v(save_xml):
         instance="msData/additional/test70948.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b050_add_b050_i(save_xml):
     """
     TEST :Adhoc XSD: : id="72232" description="xsd: keyref should be able
@@ -2709,11 +2878,12 @@ def test_add_b050_add_b050_i(save_xml):
         instance="msData/additional/test72232_2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b049_add_b049_v(save_xml):
     """
     TEST :Adhoc XSD: : id="72232" description="xsd: keyref should be able
@@ -2728,11 +2898,12 @@ def test_add_b049_add_b049_v(save_xml):
         instance="msData/additional/test72232_1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b047_add_b047_v(save_xml):
     """
     TEST :Adhoc XSD: : id="72597" description="xsd: valid xml and xsd"
@@ -2743,11 +2914,12 @@ def test_add_b047_add_b047_v(save_xml):
         instance="msData/additional/test72597.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b046_add_b046_v(save_xml):
     """
     TEST :Adhoc XSD: : id="72097" description="xsd: when there is no
@@ -2760,11 +2932,12 @@ def test_add_b046_add_b046_v(save_xml):
         instance="msData/additional/test72097.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b040_add_b040_v(save_xml):
     """
     TEST :Adhoc XSD: : id="72049" description="xsd: schemaLocation with
@@ -2776,11 +2949,12 @@ def test_add_b040_add_b040_v(save_xml):
         instance="msData/additional/test72049.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b037_add_b037_i(save_xml):
     """
     TEST :Adhoc XSD: : id="70130" description="XSD:text is not allowed
@@ -2792,11 +2966,12 @@ def test_add_b037_add_b037_i(save_xml):
         instance="msData/additional/test70130.xml",
         instance_is_valid=False,
         class_name="Type",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b034_add_b034_v(save_xml):
     """
     TEST :Adhoc XSD: : id="71818" description="xsd: when an attribute is
@@ -2809,11 +2984,12 @@ def test_add_b034_add_b034_v(save_xml):
         instance="msData/additional/test71818.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b31_add_b31_v(save_xml):
     """
     TEST :Adhoc XSD: : another test
@@ -2824,11 +3000,12 @@ def test_add_b31_add_b31_v(save_xml):
         instance="msData/additional/test69277.xml",
         instance_is_valid=True,
         class_name="Elt1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b028_add_b028_v(save_xml):
     """
     TEST :Adhoc XSD: : XSD: xsi:type when derived from xsi:type
@@ -2839,11 +3016,12 @@ def test_add_b028_add_b028_v(save_xml):
         instance="msData/additional/test69846.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b019_add_b019_v(save_xml):
     """
     TEST :Adhoc XSD: : id="68938" description="xsd: fractional digit and
@@ -2855,11 +3033,12 @@ def test_add_b019_add_b019_v(save_xml):
         instance="msData/additional/test68938.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b013_add_b013_i(save_xml):
     """
     TEST :Adhoc XSD: : id="67514" title="xsd: when processContents is
@@ -2871,11 +3050,12 @@ def test_add_b013_add_b013_i(save_xml):
         instance="msData/additional/test67514.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b012_add_b012_v(save_xml):
     """
     TEST :Adhoc XSD: : id="67500" title="xsd: checking QName datatype
@@ -2887,11 +3067,12 @@ def test_add_b012_add_b012_v(save_xml):
         instance="msData/additional/test67500.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b011_add_b011_i(save_xml):
     """
     TEST :Adhoc XSD: : id="66541" title="xsd: Regular Expression"
@@ -2902,11 +3083,12 @@ def test_add_b011_add_b011_i(save_xml):
         instance="msData/additional/test66541.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b003_add_b003_i(save_xml):
     """
     TEST :Adhoc XSD: : id="63389" title="loading invalid XML with empty
@@ -2918,11 +3100,12 @@ def test_add_b003_add_b003_i(save_xml):
         instance="msData/additional/test63389.xml",
         instance_is_valid=False,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_b002_add_b002_i(save_xml):
     """
     TEST :Adhoc XSD: : id="63569" title="test restrictions of simple
@@ -2934,11 +3117,12 @@ def test_add_b002_add_b002_i(save_xml):
         instance="msData/additional/test63569.xml",
         instance_is_valid=False,
         class_name="Zip",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_c001_add_c001_v(save_xml):
     """
     TEST :Adhoc XSD: : use of xml:base
@@ -2949,11 +3133,12 @@ def test_add_c001_add_c001_v(save_xml):
         instance="msData/additional/adhocAddC001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_a008_add_a008_v(save_xml):
     """
     TEST :Adhoc XSD: : uses substitution Element from the importing XSD(2)
@@ -2964,11 +3149,12 @@ def test_add_a008_add_a008_v(save_xml):
         instance="msData/additional/adhocAddB004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_adda007_adda007_v(save_xml):
     """
     TEST :Adhoc XSD: : uses substitution Element from the importing XSD
@@ -2979,11 +3165,12 @@ def test_adda007_adda007_v(save_xml):
         instance="msData/additional/adhocAddB003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_a006_add_a006_v(save_xml):
     """
     TEST :Adhoc XSD: : xsd: when both the imported and importing XSDs are
@@ -2996,11 +3183,12 @@ def test_add_a006_add_a006_v(save_xml):
         instance="msData/additional/adhocAddB002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_add_a005_add_a005_v(save_xml):
     """
     TEST :Adhoc XSD: : substitution group usage in the same XSD file with
@@ -3012,11 +3200,12 @@ def test_add_a005_add_a005_v(save_xml):
         instance="msData/additional/adhocAddB001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_z001_attg_z001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : xsd: global
@@ -3029,11 +3218,12 @@ def test_attg_z001_attg_z001_i(save_xml):
         instance="msData/attributeGroup/attgZ001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d042_attg_d042_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : AttributeGroup
@@ -3046,11 +3236,12 @@ def test_attg_d042_attg_d042_i(save_xml):
         instance="msData/attributeGroup/attgD042.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d036_attg_d036_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : complexType's
@@ -3064,11 +3255,12 @@ def test_attg_d036_attg_d036_v(save_xml):
         instance="msData/attributeGroup/attgD036.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d035_attg_d035_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : complexType's
@@ -3082,11 +3274,12 @@ def test_attg_d035_attg_d035_i(save_xml):
         instance="msData/attributeGroup/attgD035.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d034_attg_d034_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : AttributeGroup
@@ -3100,11 +3293,12 @@ def test_attg_d034_attg_d034_v(save_xml):
         instance="msData/attributeGroup/attgD034.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d033_attg_d033_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : AttributeGroup
@@ -3117,11 +3311,12 @@ def test_attg_d033_attg_d033_v(save_xml):
         instance="msData/attributeGroup/attgD033.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d032_attg_d032_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : AttributeGroup
@@ -3134,11 +3329,12 @@ def test_attg_d032_attg_d032_v(save_xml):
         instance="msData/attributeGroup/attgD032.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d031_attg_d031_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : AttributeGroup
@@ -3151,11 +3347,12 @@ def test_attg_d031_attg_d031_v(save_xml):
         instance="msData/attributeGroup/attgD031.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d030_attg_d030_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3169,11 +3366,12 @@ def test_attg_d030_attg_d030_i(save_xml):
         instance="msData/attributeGroup/attgD030.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d029_attg_d029_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3186,11 +3384,12 @@ def test_attg_d029_attg_d029_v(save_xml):
         instance="msData/attributeGroup/attgD029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d028_attg_d028_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3203,11 +3402,12 @@ def test_attg_d028_attg_d028_i(save_xml):
         instance="msData/attributeGroup/attgD028.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d027_attg_d027_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3220,11 +3420,12 @@ def test_attg_d027_attg_d027_v(save_xml):
         instance="msData/attributeGroup/attgD027.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d026_attg_d026_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3237,11 +3438,12 @@ def test_attg_d026_attg_d026_i(save_xml):
         instance="msData/attributeGroup/attgD026.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d025_attg_d025_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3254,11 +3456,12 @@ def test_attg_d025_attg_d025_v(save_xml):
         instance="msData/attributeGroup/attgD025.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d024_attg_d024_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3272,11 +3475,12 @@ def test_attg_d024_attg_d024_i(save_xml):
         instance="msData/attributeGroup/attgD024.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d023_attg_d023_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3290,11 +3494,12 @@ def test_attg_d023_attg_d023_i(save_xml):
         instance="msData/attributeGroup/attgD023.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d022_attg_d022_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3308,11 +3513,12 @@ def test_attg_d022_attg_d022_v(save_xml):
         instance="msData/attributeGroup/attgD022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d021_attg_d021_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3325,11 +3531,12 @@ def test_attg_d021_attg_d021_v(save_xml):
         instance="msData/attributeGroup/attgD021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d020_attg_d020_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3342,11 +3549,12 @@ def test_attg_d020_attg_d020_v(save_xml):
         instance="msData/attributeGroup/attgD020.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d019_attg_d019_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3358,11 +3566,12 @@ def test_attg_d019_attg_d019_v(save_xml):
         instance="msData/attributeGroup/attgD019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d018_attg_d018_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Basic
@@ -3374,11 +3583,12 @@ def test_attg_d018_attg_d018_v(save_xml):
         instance="msData/attributeGroup/attgD018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d005_attg_d005_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : attributeGroup
@@ -3391,11 +3601,12 @@ def test_attg_d005_attg_d005_v(save_xml):
         instance="msData/attributeGroup/attgD005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d004_attg_d004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : attributeGroup
@@ -3407,11 +3618,12 @@ def test_attg_d004_attg_d004_v(save_xml):
         instance="msData/attributeGroup/attgD004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_d003_attg_d003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : attributeGroup
@@ -3423,11 +3635,12 @@ def test_attg_d003_attg_d003_v(save_xml):
         instance="msData/attributeGroup/attgD003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c038_attg_c038_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3441,11 +3654,12 @@ def test_attg_c038_attg_c038_v(save_xml):
         instance="msData/attributeGroup/attgC038.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c037_attg_c037_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3459,11 +3673,12 @@ def test_attg_c037_attg_c037_v(save_xml):
         instance="msData/attributeGroup/attgC037.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c036_attg_c036_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3476,11 +3691,12 @@ def test_attg_c036_attg_c036_v(save_xml):
         instance="msData/attributeGroup/attgC036.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c035_attg_c035_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3493,11 +3709,12 @@ def test_attg_c035_attg_c035_v(save_xml):
         instance="msData/attributeGroup/attgC035.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c026_attg_c026_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3510,11 +3727,12 @@ def test_attg_c026_attg_c026_v(save_xml):
         instance="msData/attributeGroup/attgC026.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c025_attg_c025_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3527,11 +3745,12 @@ def test_attg_c025_attg_c025_i(save_xml):
         instance="msData/attributeGroup/attgC025.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c024_attg_c024_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3544,7 +3763,7 @@ def test_attg_c024_attg_c024_v(save_xml):
         instance="msData/attributeGroup/attgC024.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -3585,6 +3804,7 @@ def test_attg_c010_attg_c010b(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_attg_c007_attg_c007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3599,11 +3819,12 @@ def test_attg_c007_attg_c007_v(save_xml):
         instance="msData/attributeGroup/attgC007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attg_c006_attg_c006_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (ID) : Test
@@ -3618,11 +3839,12 @@ def test_attg_c006_attg_c006_i(save_xml):
         instance="msData/attributeGroup/attgC006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z015_att_z015_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : XSD: a
@@ -3635,11 +3857,12 @@ def test_att_z015_att_z015_v(save_xml):
         instance="msData/attribute/attZ015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z014b_att_z014b_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : XSD: No more
@@ -3652,11 +3875,12 @@ def test_att_z014b_att_z014b_i(save_xml):
         instance="msData/attribute/attZ014b.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z014a_att_z014a_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : XSD: No more
@@ -3669,11 +3893,12 @@ def test_att_z014a_att_z014a_i(save_xml):
         instance="msData/attribute/attZ014a.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z009_att_z009_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : when more
@@ -3685,11 +3910,12 @@ def test_att_z009_att_z009_i(save_xml):
         instance="msData/attribute/attZ009.xml",
         instance_is_valid=False,
         class_name="MyFields",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z007i_att_z007i_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : XSD:
@@ -3701,11 +3927,12 @@ def test_att_z007i_att_z007i_i(save_xml):
         instance="msData/attribute/attZ007i.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z007v_att_z007v_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : XSD:
@@ -3717,11 +3944,12 @@ def test_att_z007v_att_z007v_v(save_xml):
         instance="msData/attribute/attZ007v.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z005_att_z005_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : XSD: default
@@ -3733,11 +3961,12 @@ def test_att_z005_att_z005_v(save_xml):
         instance="msData/attribute/attZ005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z002_att_z002_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : prohibited
@@ -3749,11 +3978,12 @@ def test_att_z002_att_z002_v(save_xml):
         instance="msData/attribute/attZ002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_z001_att_z001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Redefine and
@@ -3765,11 +3995,12 @@ def test_att_z001_att_z001_i(save_xml):
         instance="msData/attribute/attZ001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_q019_att_q019_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : two
@@ -3781,11 +4012,12 @@ def test_att_q019_att_q019_v(save_xml):
         instance="msData/attribute/attQ019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_q014_att_q014_v(save_xml):
     r"""
     TEST :Syntax Checking for Attribute Declaration (form) :
@@ -3797,11 +4029,12 @@ def test_att_q014_att_q014_v(save_xml):
         instance="msData/attribute/attQ014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_q003_att_q003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -3813,11 +4046,12 @@ def test_att_q003_att_q003_v(save_xml):
         instance="msData/attribute/attQ003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p032_att_p032_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Test that
@@ -3830,11 +4064,12 @@ def test_att_p032_att_p032_v(save_xml):
         instance="msData/attribute/attP032.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p031_att_p031_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) :
@@ -3847,11 +4082,12 @@ def test_att_p031_att_p031_i(save_xml):
         instance="msData/attribute/attP031.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p029_att_p029_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) :
@@ -3865,11 +4101,12 @@ def test_att_p029_att_p029_v(save_xml):
         instance="msData/attribute/attP029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p028_att_p028_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) :
@@ -3883,11 +4120,12 @@ def test_att_p028_att_p028_v(save_xml):
         instance="msData/attribute/attP028.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p027_att_p027_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : name='foo'
@@ -3900,11 +4138,12 @@ def test_att_p027_att_p027_i(save_xml):
         instance="msData/attribute/attP027.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p026_att_p026_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -3917,11 +4156,12 @@ def test_att_p026_att_p026_v(save_xml):
         instance="msData/attribute/attP026.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p025_att_p025_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -3934,11 +4174,12 @@ def test_att_p025_att_p025_v(save_xml):
         instance="msData/attribute/attP025.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p024_att_p024_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -3951,11 +4192,12 @@ def test_att_p024_att_p024_v(save_xml):
         instance="msData/attribute/attP024.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p023_att_p023_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -3968,11 +4210,12 @@ def test_att_p023_att_p023_v(save_xml):
         instance="msData/attribute/attP023.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p022_att_p022_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -3985,11 +4228,12 @@ def test_att_p022_att_p022_v(save_xml):
         instance="msData/attribute/attP022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p021_att_p021_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -4002,11 +4246,12 @@ def test_att_p021_att_p021_v(save_xml):
         instance="msData/attribute/attP021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p020_att_p020_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -4019,11 +4264,12 @@ def test_att_p020_att_p020_i(save_xml):
         instance="msData/attribute/attP020.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p019_att_p019_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -4036,11 +4282,12 @@ def test_att_p019_att_p019_v(save_xml):
         instance="msData/attribute/attP019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p018_att_p018_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -4053,11 +4300,12 @@ def test_att_p018_att_p018_i(save_xml):
         instance="msData/attribute/attP018.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p017_att_p017_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=optional,
@@ -4070,11 +4318,12 @@ def test_att_p017_att_p017_v(save_xml):
         instance="msData/attribute/attP017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p016_att_p016_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -4087,11 +4336,12 @@ def test_att_p016_att_p016_i(save_xml):
         instance="msData/attribute/attP016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p015_att_p015_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -4104,11 +4354,12 @@ def test_att_p015_att_p015_v(save_xml):
         instance="msData/attribute/attP015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p014_att_p014_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -4121,11 +4372,12 @@ def test_att_p014_att_p014_i(save_xml):
         instance="msData/attribute/attP014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p013_att_p013_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=absent,
@@ -4138,11 +4390,12 @@ def test_att_p013_att_p013_v(save_xml):
         instance="msData/attribute/attP013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p012_att_p012_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=required,
@@ -4155,11 +4408,12 @@ def test_att_p012_att_p012_i(save_xml):
         instance="msData/attribute/attP012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p011_att_p011_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=required,
@@ -4172,11 +4426,12 @@ def test_att_p011_att_p011_v(save_xml):
         instance="msData/attribute/attP011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p010_att_p010_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=required,
@@ -4189,11 +4444,12 @@ def test_att_p010_att_p010_i(save_xml):
         instance="msData/attribute/attP010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p009_att_p009_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=required,
@@ -4206,11 +4462,12 @@ def test_att_p009_att_p009_i(save_xml):
         instance="msData/attribute/attP009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p008_att_p008_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=required,
@@ -4223,11 +4480,12 @@ def test_att_p008_att_p008_i(save_xml):
         instance="msData/attribute/attP008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p007_att_p007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : use=required,
@@ -4240,11 +4498,12 @@ def test_att_p007_att_p007_v(save_xml):
         instance="msData/attribute/attP007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p005_att_p005_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : type="my
@@ -4257,11 +4516,12 @@ def test_att_p005_att_p005_i(save_xml):
         instance="msData/attribute/attP005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_p004_att_p004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : type="my
@@ -4274,11 +4534,12 @@ def test_att_p004_att_p004_v(save_xml):
         instance="msData/attribute/attP004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md011_att_md011_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4290,11 +4551,12 @@ def test_att_md011_att_md011_i(save_xml):
         instance="msData/attribute/test108565_11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md010_att_md010_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4306,11 +4568,12 @@ def test_att_md010_att_md010_i(save_xml):
         instance="msData/attribute/test108565_10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md009_att_md009_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4322,11 +4585,12 @@ def test_att_md009_att_md009_i(save_xml):
         instance="msData/attribute/test108565_9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md008_att_md008_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4338,11 +4602,12 @@ def test_att_md008_att_md008_i(save_xml):
         instance="msData/attribute/test108565_8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md007_att_md007_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4354,11 +4619,12 @@ def test_att_md007_att_md007_i(save_xml):
         instance="msData/attribute/test108565_7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md006_att_md006_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4370,11 +4636,12 @@ def test_att_md006_att_md006_i(save_xml):
         instance="msData/attribute/test108565_6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md005_att_md005_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4386,11 +4653,12 @@ def test_att_md005_att_md005_i(save_xml):
         instance="msData/attribute/test108565_5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md004_att_md004_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4402,11 +4670,12 @@ def test_att_md004_att_md004_i(save_xml):
         instance="msData/attribute/test108565_4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md003_att_md003_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4418,11 +4687,12 @@ def test_att_md003_att_md003_i(save_xml):
         instance="msData/attribute/test108565_3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md002_att_md002_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4434,11 +4704,12 @@ def test_att_md002_att_md002_i(save_xml):
         instance="msData/attribute/test108565_2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_md001_att_md001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Attributes
@@ -4450,11 +4721,12 @@ def test_att_md001_att_md001_i(save_xml):
         instance="msData/attribute/test108565_1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc012_att_mc012_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4467,11 +4739,12 @@ def test_att_mc012_att_mc012_i(save_xml):
         instance="msData/attribute/attMc012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc011_att_mc011_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4484,11 +4757,12 @@ def test_att_mc011_att_mc011_i(save_xml):
         instance="msData/attribute/attMc011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc010_att_mc010_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4501,11 +4775,12 @@ def test_att_mc010_att_mc010_i(save_xml):
         instance="msData/attribute/attMc010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc009_att_mc009_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4519,11 +4794,12 @@ def test_att_mc009_att_mc009_v(save_xml):
         instance="msData/attribute/attMc009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc008_att_mc008_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4537,11 +4813,12 @@ def test_att_mc008_att_mc008_v(save_xml):
         instance="msData/attribute/attMc008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc007_att_mc007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4555,11 +4832,12 @@ def test_att_mc007_att_mc007_v(save_xml):
         instance="msData/attribute/attMc007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc006_att_mc006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4572,11 +4850,12 @@ def test_att_mc006_att_mc006_v(save_xml):
         instance="msData/attribute/attMc006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc005_att_mc005_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4589,11 +4868,12 @@ def test_att_mc005_att_mc005_v(save_xml):
         instance="msData/attribute/attMc005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc004_att_mc004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4606,11 +4886,12 @@ def test_att_mc004_att_mc004_v(save_xml):
         instance="msData/attribute/attMc004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc003_att_mc003_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4624,11 +4905,12 @@ def test_att_mc003_att_mc003_i(save_xml):
         instance="msData/attribute/attMc003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc002_att_mc002_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4642,11 +4924,12 @@ def test_att_mc002_att_mc002_i(save_xml):
         instance="msData/attribute/attMc002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mc001_att_mc001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4660,11 +4943,12 @@ def test_att_mc001_att_mc001_i(save_xml):
         instance="msData/attribute/attMc001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb012_att_mb012_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4677,11 +4961,12 @@ def test_att_mb012_att_mb012_i(save_xml):
         instance="msData/attribute/attMb012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb011_att_mb011_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4694,11 +4979,12 @@ def test_att_mb011_att_mb011_i(save_xml):
         instance="msData/attribute/attMb011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb010_att_mb010_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4711,11 +4997,12 @@ def test_att_mb010_att_mb010_i(save_xml):
         instance="msData/attribute/attMb010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb009_att_mb009_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4728,11 +5015,12 @@ def test_att_mb009_att_mb009_v(save_xml):
         instance="msData/attribute/attMb009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb008_att_mb008_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4746,11 +5034,12 @@ def test_att_mb008_att_mb008_v(save_xml):
         instance="msData/attribute/attMb008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb007_att_mb007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4764,11 +5053,12 @@ def test_att_mb007_att_mb007_v(save_xml):
         instance="msData/attribute/attMb007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb006_att_mb006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4781,11 +5071,12 @@ def test_att_mb006_att_mb006_v(save_xml):
         instance="msData/attribute/attMb006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb005_att_mb005_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4798,11 +5089,12 @@ def test_att_mb005_att_mb005_v(save_xml):
         instance="msData/attribute/attMb005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb004_att_mb004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4815,11 +5107,12 @@ def test_att_mb004_att_mb004_v(save_xml):
         instance="msData/attribute/attMb004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb003_att_mb003_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4833,11 +5126,12 @@ def test_att_mb003_att_mb003_i(save_xml):
         instance="msData/attribute/attMb003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb002_att_mb002_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4851,11 +5145,12 @@ def test_att_mb002_att_mb002_i(save_xml):
         instance="msData/attribute/attMb002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_mb001_att_mb001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4869,11 +5164,12 @@ def test_att_mb001_att_mb001_i(save_xml):
         instance="msData/attribute/attMb001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_ma004_att_ma004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4887,11 +5183,12 @@ def test_att_ma004_att_ma004_v(save_xml):
         instance="msData/attribute/attMa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_ma003_att_ma003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4905,11 +5202,12 @@ def test_att_ma003_att_ma003_v(save_xml):
         instance="msData/attribute/attMa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_ma002_att_ma002_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4923,11 +5221,12 @@ def test_att_ma002_att_ma002_i(save_xml):
         instance="msData/attribute/attMa002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_ma001_att_ma001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : parent is
@@ -4941,11 +5240,12 @@ def test_att_ma001_att_ma001_i(save_xml):
         instance="msData/attribute/attMa001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o012_att_o012_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -4958,11 +5258,12 @@ def test_att_o012_att_o012_i(save_xml):
         instance="msData/attribute/attO012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o011_att_o011_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -4976,11 +5277,12 @@ def test_att_o011_att_o011_v(save_xml):
         instance="msData/attribute/attO011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o010_att_o010_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -4994,11 +5296,12 @@ def test_att_o010_att_o010_v(save_xml):
         instance="msData/attribute/attO010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o009_att_o009_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5012,11 +5315,12 @@ def test_att_o009_att_o009_v(save_xml):
         instance="msData/attribute/attO009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o008_att_o008_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5029,11 +5333,12 @@ def test_att_o008_att_o008_i(save_xml):
         instance="msData/attribute/attO008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o007_att_o007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5046,11 +5351,12 @@ def test_att_o007_att_o007_v(save_xml):
         instance="msData/attribute/attO007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o006_att_o006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5063,11 +5369,12 @@ def test_att_o006_att_o006_v(save_xml):
         instance="msData/attribute/attO006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o004_att_o004_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5080,11 +5387,12 @@ def test_att_o004_att_o004_i(save_xml):
         instance="msData/attribute/attO004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_o001_att_o001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5096,11 +5404,12 @@ def test_att_o001_att_o001_i(save_xml):
         instance="msData/attribute/attO001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lc006_att_lc006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5113,11 +5422,12 @@ def test_att_lc006_att_lc006_v(save_xml):
         instance="msData/attribute/attLc006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lc005_att_lc005_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5130,11 +5440,12 @@ def test_att_lc005_att_lc005_i(save_xml):
         instance="msData/attribute/attLc005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lc004_att_lc004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5147,11 +5458,12 @@ def test_att_lc004_att_lc004_v(save_xml):
         instance="msData/attribute/attLc004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lc003_att_lc003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5164,11 +5476,12 @@ def test_att_lc003_att_lc003_v(save_xml):
         instance="msData/attribute/attLc003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lc002_att_lc002_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5181,11 +5494,12 @@ def test_att_lc002_att_lc002_v(save_xml):
         instance="msData/attribute/attLc002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lc001_att_lc001_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5198,11 +5512,12 @@ def test_att_lc001_att_lc001_v(save_xml):
         instance="msData/attribute/attLc001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lb006_att_lb006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5215,11 +5530,12 @@ def test_att_lb006_att_lb006_v(save_xml):
         instance="msData/attribute/attLb006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lb005_att_lb005_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5232,11 +5548,12 @@ def test_att_lb005_att_lb005_i(save_xml):
         instance="msData/attribute/attLb005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lb004_att_lb004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5249,11 +5566,12 @@ def test_att_lb004_att_lb004_v(save_xml):
         instance="msData/attribute/attLb004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lb003_att_lb003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5266,11 +5584,12 @@ def test_att_lb003_att_lb003_v(save_xml):
         instance="msData/attribute/attLb003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lb002_att_lb002_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5283,11 +5602,12 @@ def test_att_lb002_att_lb002_v(save_xml):
         instance="msData/attribute/attLb002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_lb001_att_lb001_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5300,11 +5620,12 @@ def test_att_lb001_att_lb001_v(save_xml):
         instance="msData/attribute/attLb001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_la006_att_la006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5317,11 +5638,12 @@ def test_att_la006_att_la006_v(save_xml):
         instance="msData/attribute/attLa006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_la005_att_la005_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5334,11 +5656,12 @@ def test_att_la005_att_la005_i(save_xml):
         instance="msData/attribute/attLa005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_la004_att_la004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5351,11 +5674,12 @@ def test_att_la004_att_la004_v(save_xml):
         instance="msData/attribute/attLa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_la003_att_la003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5368,11 +5692,12 @@ def test_att_la003_att_la003_v(save_xml):
         instance="msData/attribute/attLa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_la002_att_la002_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5385,11 +5710,12 @@ def test_att_la002_att_la002_v(save_xml):
         instance="msData/attribute/attLa002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_la001_att_la001_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Validation
@@ -5402,11 +5728,12 @@ def test_att_la001_att_la001_v(save_xml):
         instance="msData/attribute/attLa001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_i003_att_i003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Basic
@@ -5418,11 +5745,12 @@ def test_att_i003_att_i003_v(save_xml):
         instance="msData/attribute/attI003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j018_att_j018_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Basic
@@ -5435,11 +5763,12 @@ def test_att_j018_att_j018_v(save_xml):
         instance="msData/attribute/attJ018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j010_att_j010_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc do
@@ -5452,11 +5781,12 @@ def test_att_j010_att_j010_i(save_xml):
         instance="msData/attribute/attJ010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j009_att_j009_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc do
@@ -5469,11 +5799,12 @@ def test_att_j009_att_j009_i(save_xml):
         instance="msData/attribute/attJ009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j008_att_j008_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc do
@@ -5486,11 +5817,12 @@ def test_att_j008_att_j008_i(save_xml):
         instance="msData/attribute/attJ008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j007_att_j007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc
@@ -5503,11 +5835,12 @@ def test_att_j007_att_j007_v(save_xml):
         instance="msData/attribute/attJ007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j006_att_j006_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc
@@ -5519,11 +5852,12 @@ def test_att_j006_att_j006_v(save_xml):
         instance="msData/attribute/attJ006.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j005_att_j005_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc do
@@ -5535,11 +5869,12 @@ def test_att_j005_att_j005_v(save_xml):
         instance="msData/attribute/attJ005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j004_att_j004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc does
@@ -5552,11 +5887,12 @@ def test_att_j004_att_j004_v(save_xml):
         instance="msData/attribute/attJ004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j003_att_j003_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc
@@ -5569,11 +5905,12 @@ def test_att_j003_att_j003_i(save_xml):
         instance="msData/attribute/attJ003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j002_att_j002_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc
@@ -5585,11 +5922,12 @@ def test_att_j002_att_j002_i(save_xml):
         instance="msData/attribute/attJ002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_j001_att_j001_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : xml doc do
@@ -5602,11 +5940,12 @@ def test_att_j001_att_j001_v(save_xml):
         instance="msData/attribute/attJ001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_f003_att_f003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Test
@@ -5618,11 +5957,12 @@ def test_att_f003_att_f003_v(save_xml):
         instance="msData/attribute/attF003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_f002_att_f002_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Test
@@ -5634,11 +5974,12 @@ def test_att_f002_att_f002_v(save_xml):
         instance="msData/attribute/attF002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_f001_att_f001_i(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Test
@@ -5650,11 +5991,12 @@ def test_att_f001_att_f001_i(save_xml):
         instance="msData/attribute/attF001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_e001_att_e001_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Local
@@ -5666,11 +6008,12 @@ def test_att_e001_att_e001_v(save_xml):
         instance="msData/attribute/attE001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_d007_att_d007_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Global
@@ -5683,11 +6026,12 @@ def test_att_d007_att_d007_v(save_xml):
         instance="msData/attribute/attD007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_d004_att_d004_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Global
@@ -5699,11 +6043,12 @@ def test_att_d004_att_d004_v(save_xml):
         instance="msData/attribute/attD004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_att_d003_att_d003_v(save_xml):
     """
     TEST :Syntax Checking for Attribute Declaration (form) : Global
@@ -5716,11 +6061,12 @@ def test_att_d003_att_d003_v(save_xml):
         instance="msData/attribute/attD003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z013e_ct_z013e_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : fixed
@@ -5732,11 +6078,12 @@ def test_ct_z013e_ct_z013e_i(save_xml):
         instance="msData/complexType/ctZ013e.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z013d_ct_z013d_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : fixed
@@ -5748,11 +6095,12 @@ def test_ct_z013d_ct_z013d_i(save_xml):
         instance="msData/complexType/ctZ013d.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z013c_ct_z013c_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : fixed
@@ -5764,11 +6112,12 @@ def test_ct_z013c_ct_z013c_i(save_xml):
         instance="msData/complexType/ctZ013c.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z013b_ct_z013b_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : fixed
@@ -5780,11 +6129,12 @@ def test_ct_z013b_ct_z013b_v(save_xml):
         instance="msData/complexType/ctZ013b.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z013a_ct_z013a_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : fixed
@@ -5796,11 +6146,12 @@ def test_ct_z013a_ct_z013a_v(save_xml):
         instance="msData/complexType/ctZ013a.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z011_b_ct_z011_b_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5812,11 +6163,12 @@ def test_ct_z011_b_ct_z011_b_v(save_xml):
         instance="msData/complexType/ctZ011.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z011_a_ct_z011_a_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5828,11 +6180,12 @@ def test_ct_z011_a_ct_z011_a_v(save_xml):
         instance="msData/complexType/ctZ011.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z009_d_ct_z009_d_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5844,11 +6197,12 @@ def test_ct_z009_d_ct_z009_d_v(save_xml):
         instance="msData/complexType/ctZ009_d.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z009_c_ct_z009_c_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5860,11 +6214,12 @@ def test_ct_z009_c_ct_z009_c_i(save_xml):
         instance="msData/complexType/ctZ009_c.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z009_b_ct_z009_b_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5876,11 +6231,12 @@ def test_ct_z009_b_ct_z009_b_v(save_xml):
         instance="msData/complexType/ctZ009_b.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z009_a_ct_z009_a_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5892,11 +6248,12 @@ def test_ct_z009_a_ct_z009_a_v(save_xml):
         instance="msData/complexType/ctZ009_a.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z009_ct_z009_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5908,11 +6265,12 @@ def test_ct_z009_ct_z009_v(save_xml):
         instance="msData/complexType/ctZ009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z008_ct_z008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5924,11 +6282,12 @@ def test_ct_z008_ct_z008_v(save_xml):
         instance="msData/complexType/ctZ008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_z007_ct_z007_v(save_xml):
     """
@@ -5941,11 +6300,12 @@ def test_ct_z007_ct_z007_v(save_xml):
         instance="msData/complexType/ctZ007.xml",
         instance_is_valid=True,
         class_name="Customers",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z006_ct_z006_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5957,11 +6317,12 @@ def test_ct_z006_ct_z006_v(save_xml):
         instance="msData/complexType/ctZ006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z005_ct_z005_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5974,11 +6335,12 @@ def test_ct_z005_ct_z005_i(save_xml):
         instance="msData/complexType/ctZ005.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z003_ct_z003_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -5991,11 +6353,12 @@ def test_ct_z003_ct_z003_v(save_xml):
         instance="msData/complexType/ctZ003.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_z001_ct_z001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6007,11 +6370,12 @@ def test_ct_z001_ct_z001_v(save_xml):
         instance="msData/complexType/75039.xml",
         instance_is_valid=True,
         class_name="BagOfHeads",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_o006_ct_o006_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6024,11 +6388,12 @@ def test_ct_o006_ct_o006_v(save_xml):
         instance="msData/complexType/ctO006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_o003_ct_o003_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6041,11 +6406,12 @@ def test_ct_o003_ct_o003_v(save_xml):
         instance="msData/complexType/ctO003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_o001_ct_o001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6057,11 +6423,12 @@ def test_ct_o001_ct_o001_v(save_xml):
         instance="msData/complexType/ctO001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_n004_ct_n004_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6074,11 +6441,12 @@ def test_ct_n004_ct_n004_v(save_xml):
         instance="msData/complexType/ctN004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_n003_ct_n003_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6091,11 +6459,12 @@ def test_ct_n003_ct_n003_v(save_xml):
         instance="msData/complexType/ctN003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_n001_ct_n001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6107,11 +6476,12 @@ def test_ct_n001_ct_n001_v(save_xml):
         instance="msData/complexType/ctN001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_m002_ct_m002_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6123,11 +6493,12 @@ def test_ct_m002_ct_m002_v(save_xml):
         instance="msData/complexType/ctM002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_l022_ct_l022_v(save_xml):
     """
@@ -6140,11 +6511,12 @@ def test_ct_l022_ct_l022_v(save_xml):
         instance="msData/complexType/test67200.xml",
         instance_is_valid=True,
         class_name="Elt1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l021_ct_l021_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6157,11 +6529,12 @@ def test_ct_l021_ct_l021_v(save_xml):
         instance="msData/complexType/ctL021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l020_ct_l020_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6174,11 +6547,12 @@ def test_ct_l020_ct_l020_i(save_xml):
         instance="msData/complexType/ctL020.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l019_ct_l019_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6191,11 +6565,12 @@ def test_ct_l019_ct_l019_v(save_xml):
         instance="msData/complexType/ctL019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l018_ct_l018_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6208,11 +6583,12 @@ def test_ct_l018_ct_l018_v(save_xml):
         instance="msData/complexType/ctL018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l017_ct_l017_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6225,11 +6601,12 @@ def test_ct_l017_ct_l017_v(save_xml):
         instance="msData/complexType/ctL017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l016_ct_l016_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6242,11 +6619,12 @@ def test_ct_l016_ct_l016_v(save_xml):
         instance="msData/complexType/ctL016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l015_ct_l015_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6259,11 +6637,12 @@ def test_ct_l015_ct_l015_v(save_xml):
         instance="msData/complexType/ctL015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l014_ct_l014_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6275,11 +6654,12 @@ def test_ct_l014_ct_l014_v(save_xml):
         instance="msData/complexType/ctL014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l013_ct_l013_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6291,11 +6671,12 @@ def test_ct_l013_ct_l013_i(save_xml):
         instance="msData/complexType/ctL013.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l012_ct_l012_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6308,11 +6689,12 @@ def test_ct_l012_ct_l012_i(save_xml):
         instance="msData/complexType/ctL012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l011_ct_l011_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6324,11 +6706,12 @@ def test_ct_l011_ct_l011_v(save_xml):
         instance="msData/complexType/ctL011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l010_ct_l010_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6341,11 +6724,12 @@ def test_ct_l010_ct_l010_i(save_xml):
         instance="msData/complexType/ctL010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l009_ct_l009_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6358,11 +6742,12 @@ def test_ct_l009_ct_l009_i(save_xml):
         instance="msData/complexType/ctL009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l008_ct_l008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6375,11 +6760,12 @@ def test_ct_l008_ct_l008_v(save_xml):
         instance="msData/complexType/ctL008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l007_ct_l007_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6391,11 +6777,12 @@ def test_ct_l007_ct_l007_v(save_xml):
         instance="msData/complexType/ctL007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l006_ct_l006_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6407,11 +6794,12 @@ def test_ct_l006_ct_l006_i(save_xml):
         instance="msData/complexType/ctL006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l005_ct_l005_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6423,11 +6811,12 @@ def test_ct_l005_ct_l005_v(save_xml):
         instance="msData/complexType/ctL005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l004_ct_l004_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6439,11 +6828,12 @@ def test_ct_l004_ct_l004_i(save_xml):
         instance="msData/complexType/ctL004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l003_ct_l003_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6455,11 +6845,12 @@ def test_ct_l003_ct_l003_v(save_xml):
         instance="msData/complexType/ctL003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l002_ct_l002_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6471,11 +6862,12 @@ def test_ct_l002_ct_l002_i(save_xml):
         instance="msData/complexType/ctL002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_l001_ct_l001_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -6487,11 +6879,12 @@ def test_ct_l001_ct_l001_i(save_xml):
         instance="msData/complexType/ctL001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_k001_ct_k001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6504,11 +6897,12 @@ def test_ct_k001_ct_k001_v(save_xml):
         instance="msData/complexType/ctK001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_j001_ct_j001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6520,11 +6914,12 @@ def test_ct_j001_ct_j001_v(save_xml):
         instance="msData/complexType/ctJ001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i050_ct_i050_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6537,11 +6932,12 @@ def test_ct_i050_ct_i050_v(save_xml):
         instance="msData/complexType/ctI050.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i049_ct_i049_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6554,11 +6950,12 @@ def test_ct_i049_ct_i049_i(save_xml):
         instance="msData/complexType/ctI049.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i048_ct_i048_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6571,11 +6968,12 @@ def test_ct_i048_ct_i048_i(save_xml):
         instance="msData/complexType/ctI048.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i047_ct_i047_v(save_xml):
     """
@@ -6589,11 +6987,12 @@ def test_ct_i047_ct_i047_v(save_xml):
         instance="msData/complexType/ctI047.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i046_ct_i046_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6606,11 +7005,12 @@ def test_ct_i046_ct_i046_v(save_xml):
         instance="msData/complexType/ctI046.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i045_ct_i045_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6623,11 +7023,12 @@ def test_ct_i045_ct_i045_i(save_xml):
         instance="msData/complexType/ctI045.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i044_ct_i044_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6640,11 +7041,12 @@ def test_ct_i044_ct_i044_v(save_xml):
         instance="msData/complexType/ctI044.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i043_ct_i043_v(save_xml):
     """
@@ -6658,11 +7060,12 @@ def test_ct_i043_ct_i043_v(save_xml):
         instance="msData/complexType/ctI043.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i042_ct_i042_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6675,11 +7078,12 @@ def test_ct_i042_ct_i042_i(save_xml):
         instance="msData/complexType/ctI042.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i041_ct_i041_v(save_xml):
     """
@@ -6693,11 +7097,12 @@ def test_ct_i041_ct_i041_v(save_xml):
         instance="msData/complexType/ctI041.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i040_ct_i040_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6710,11 +7115,12 @@ def test_ct_i040_ct_i040_v(save_xml):
         instance="msData/complexType/ctI040.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i039_ct_i039_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6727,11 +7133,12 @@ def test_ct_i039_ct_i039_i(save_xml):
         instance="msData/complexType/ctI039.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i038_ct_i038_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6744,11 +7151,12 @@ def test_ct_i038_ct_i038_i(save_xml):
         instance="msData/complexType/ctI038.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i037_ct_i037_v(save_xml):
     """
@@ -6762,11 +7170,12 @@ def test_ct_i037_ct_i037_v(save_xml):
         instance="msData/complexType/ctI037.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i036_ct_i036_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6779,11 +7188,12 @@ def test_ct_i036_ct_i036_v(save_xml):
         instance="msData/complexType/ctI036.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i035_ct_i035_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6796,11 +7206,12 @@ def test_ct_i035_ct_i035_i(save_xml):
         instance="msData/complexType/ctI035.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i034_ct_i034_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6813,11 +7224,12 @@ def test_ct_i034_ct_i034_v(save_xml):
         instance="msData/complexType/ctI034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i033_ct_i033_v(save_xml):
     """
@@ -6831,11 +7243,12 @@ def test_ct_i033_ct_i033_v(save_xml):
         instance="msData/complexType/ctI033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i032_ct_i032_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6848,11 +7261,12 @@ def test_ct_i032_ct_i032_i(save_xml):
         instance="msData/complexType/ctI032.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i031_ct_i031_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6865,11 +7279,12 @@ def test_ct_i031_ct_i031_i(save_xml):
         instance="msData/complexType/ctI031.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i030_ct_i030_i(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6882,11 +7297,12 @@ def test_ct_i030_ct_i030_i(save_xml):
         instance="msData/complexType/ctI030.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i029_ct_i029_v(save_xml):
     """
@@ -6900,11 +7316,12 @@ def test_ct_i029_ct_i029_v(save_xml):
         instance="msData/complexType/ctI029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i028_ct_i028_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -6917,11 +7334,12 @@ def test_ct_i028_ct_i028_v(save_xml):
         instance="msData/complexType/ctI028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i027_ct_i027_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6934,11 +7352,12 @@ def test_ct_i027_ct_i027_v(save_xml):
         instance="msData/complexType/ctI027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i026_ct_i026_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6951,11 +7370,12 @@ def test_ct_i026_ct_i026_v(save_xml):
         instance="msData/complexType/ctI026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i025_ct_i025_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6968,11 +7388,12 @@ def test_ct_i025_ct_i025_v(save_xml):
         instance="msData/complexType/ctI025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i023_ct_i023_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -6984,11 +7405,12 @@ def test_ct_i023_ct_i023_v(save_xml):
         instance="msData/complexType/ctI023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i022_ct_i022_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -7001,11 +7423,12 @@ def test_ct_i022_ct_i022_v(save_xml):
         instance="msData/complexType/ctI022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i021_ct_i021_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -7017,11 +7440,12 @@ def test_ct_i021_ct_i021_v(save_xml):
         instance="msData/complexType/ctI021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i019_ct_i019_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -7034,11 +7458,12 @@ def test_ct_i019_ct_i019_v(save_xml):
         instance="msData/complexType/ctI019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i018_ct_i018_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -7051,11 +7476,12 @@ def test_ct_i018_ct_i018_v(save_xml):
         instance="msData/complexType/ctI018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i015_ct_i015_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -7067,11 +7493,12 @@ def test_ct_i015_ct_i015_v(save_xml):
         instance="msData/complexType/ctI015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i014_ct_i014_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : schema
@@ -7083,11 +7510,12 @@ def test_ct_i014_ct_i014_v(save_xml):
         instance="msData/complexType/ctI014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i010_ct_i010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7100,11 +7528,12 @@ def test_ct_i010_ct_i010_v(save_xml):
         instance="msData/complexType/ctI010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i009_ct_i009_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7117,11 +7546,12 @@ def test_ct_i009_ct_i009_v(save_xml):
         instance="msData/complexType/ctI009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i005_ct_i005_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7134,11 +7564,12 @@ def test_ct_i005_ct_i005_v(save_xml):
         instance="msData/complexType/ctI005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_i004_ct_i004_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7151,11 +7582,12 @@ def test_ct_i004_ct_i004_v(save_xml):
         instance="msData/complexType/ctI004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_i003_ct_i003_v(save_xml):
     """
@@ -7169,11 +7601,12 @@ def test_ct_i003_ct_i003_v(save_xml):
         instance="msData/complexType/ctI003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h082_ct_h082_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7186,11 +7619,12 @@ def test_ct_h082_ct_h082_v(save_xml):
         instance="msData/complexType/ctH082.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h071_ct_h071_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7202,11 +7636,12 @@ def test_ct_h071_ct_h071_v(save_xml):
         instance="msData/complexType/ctH071.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h069_ct_h069_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7219,11 +7654,12 @@ def test_ct_h069_ct_h069_v(save_xml):
         instance="msData/complexType/ctH069.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h068_ct_h068_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7236,11 +7672,12 @@ def test_ct_h068_ct_h068_v(save_xml):
         instance="msData/complexType/ctH068.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h067_ct_h067_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7253,11 +7690,12 @@ def test_ct_h067_ct_h067_v(save_xml):
         instance="msData/complexType/ctH067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h066_ct_h066_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7270,11 +7708,12 @@ def test_ct_h066_ct_h066_v(save_xml):
         instance="msData/complexType/ctH066.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h060_ct_h060_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7286,11 +7725,12 @@ def test_ct_h060_ct_h060_v(save_xml):
         instance="msData/complexType/ctH060.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h058_ct_h058_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7303,11 +7743,12 @@ def test_ct_h058_ct_h058_v(save_xml):
         instance="msData/complexType/ctH058.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h057_ct_h057_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7320,11 +7761,12 @@ def test_ct_h057_ct_h057_v(save_xml):
         instance="msData/complexType/ctH057.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h056_ct_h056_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7337,11 +7779,12 @@ def test_ct_h056_ct_h056_v(save_xml):
         instance="msData/complexType/ctH056.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h055_ct_h055_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7354,11 +7797,12 @@ def test_ct_h055_ct_h055_v(save_xml):
         instance="msData/complexType/ctH055.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h049_ct_h049_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7370,11 +7814,12 @@ def test_ct_h049_ct_h049_v(save_xml):
         instance="msData/complexType/ctH049.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h047_ct_h047_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7387,11 +7832,12 @@ def test_ct_h047_ct_h047_v(save_xml):
         instance="msData/complexType/ctH047.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h046_ct_h046_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7404,11 +7850,12 @@ def test_ct_h046_ct_h046_v(save_xml):
         instance="msData/complexType/ctH046.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h045_ct_h045_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7421,11 +7868,12 @@ def test_ct_h045_ct_h045_v(save_xml):
         instance="msData/complexType/ctH045.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h044_ct_h044_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7438,11 +7886,12 @@ def test_ct_h044_ct_h044_v(save_xml):
         instance="msData/complexType/ctH044.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h043_ct_h043_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7455,11 +7904,12 @@ def test_ct_h043_ct_h043_v(save_xml):
         instance="msData/complexType/ctH043.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h037_ct_h037_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7471,11 +7921,12 @@ def test_ct_h037_ct_h037_v(save_xml):
         instance="msData/complexType/ctH037.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h035_ct_h035_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7488,11 +7939,12 @@ def test_ct_h035_ct_h035_v(save_xml):
         instance="msData/complexType/ctH035.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h034_ct_h034_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7505,11 +7957,12 @@ def test_ct_h034_ct_h034_v(save_xml):
         instance="msData/complexType/ctH034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h033_ct_h033_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7522,11 +7975,12 @@ def test_ct_h033_ct_h033_v(save_xml):
         instance="msData/complexType/ctH033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h032_ct_h032_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7539,11 +7993,12 @@ def test_ct_h032_ct_h032_v(save_xml):
         instance="msData/complexType/ctH032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h031_ct_h031_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7556,11 +8011,12 @@ def test_ct_h031_ct_h031_v(save_xml):
         instance="msData/complexType/ctH031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h025_ct_h025_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7572,11 +8028,12 @@ def test_ct_h025_ct_h025_v(save_xml):
         instance="msData/complexType/ctH025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h011_ct_h011_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7589,11 +8046,12 @@ def test_ct_h011_ct_h011_v(save_xml):
         instance="msData/complexType/ctH011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h010_ct_h010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7606,11 +8064,12 @@ def test_ct_h010_ct_h010_v(save_xml):
         instance="msData/complexType/ctH010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h009_ct_h009_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7623,11 +8082,12 @@ def test_ct_h009_ct_h009_v(save_xml):
         instance="msData/complexType/ctH009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h008_ct_h008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7640,11 +8100,12 @@ def test_ct_h008_ct_h008_v(save_xml):
         instance="msData/complexType/ctH008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h007_ct_h007_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7657,11 +8118,12 @@ def test_ct_h007_ct_h007_v(save_xml):
         instance="msData/complexType/ctH007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_h001_ct_h001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7673,11 +8135,12 @@ def test_ct_h001_ct_h001_v(save_xml):
         instance="msData/complexType/ctH001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g071_ct_g071_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7689,11 +8152,12 @@ def test_ct_g071_ct_g071_v(save_xml):
         instance="msData/complexType/ctG071.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g069_ct_g069_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7706,11 +8170,12 @@ def test_ct_g069_ct_g069_v(save_xml):
         instance="msData/complexType/ctG069.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g068_ct_g068_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7723,11 +8188,12 @@ def test_ct_g068_ct_g068_v(save_xml):
         instance="msData/complexType/ctG068.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g067_ct_g067_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7740,11 +8206,12 @@ def test_ct_g067_ct_g067_v(save_xml):
         instance="msData/complexType/ctG067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g066_ct_g066_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7757,11 +8224,12 @@ def test_ct_g066_ct_g066_v(save_xml):
         instance="msData/complexType/ctG066.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g060_ct_g060_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7773,11 +8241,12 @@ def test_ct_g060_ct_g060_v(save_xml):
         instance="msData/complexType/ctG060.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g058_ct_g058_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7790,11 +8259,12 @@ def test_ct_g058_ct_g058_v(save_xml):
         instance="msData/complexType/ctG058.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g057_ct_g057_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7807,11 +8277,12 @@ def test_ct_g057_ct_g057_v(save_xml):
         instance="msData/complexType/ctG057.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g056_ct_g056_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7824,11 +8295,12 @@ def test_ct_g056_ct_g056_v(save_xml):
         instance="msData/complexType/ctG056.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g055_ct_g055_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7841,11 +8313,12 @@ def test_ct_g055_ct_g055_v(save_xml):
         instance="msData/complexType/ctG055.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g049_ct_g049_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7857,11 +8330,12 @@ def test_ct_g049_ct_g049_v(save_xml):
         instance="msData/complexType/ctG049.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g047_ct_g047_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7874,11 +8348,12 @@ def test_ct_g047_ct_g047_v(save_xml):
         instance="msData/complexType/ctG047.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g046_ct_g046_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7891,11 +8366,12 @@ def test_ct_g046_ct_g046_v(save_xml):
         instance="msData/complexType/ctG046.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g045_ct_g045_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7908,11 +8384,12 @@ def test_ct_g045_ct_g045_v(save_xml):
         instance="msData/complexType/ctG045.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g044_ct_g044_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7925,11 +8402,12 @@ def test_ct_g044_ct_g044_v(save_xml):
         instance="msData/complexType/ctG044.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g043_ct_g043_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7942,11 +8420,12 @@ def test_ct_g043_ct_g043_v(save_xml):
         instance="msData/complexType/ctG043.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g037_ct_g037_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7958,11 +8437,12 @@ def test_ct_g037_ct_g037_v(save_xml):
         instance="msData/complexType/ctG037.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g035_ct_g035_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7975,11 +8455,12 @@ def test_ct_g035_ct_g035_v(save_xml):
         instance="msData/complexType/ctG035.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g034_ct_g034_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -7992,11 +8473,12 @@ def test_ct_g034_ct_g034_v(save_xml):
         instance="msData/complexType/ctG034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g033_ct_g033_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8009,11 +8491,12 @@ def test_ct_g033_ct_g033_v(save_xml):
         instance="msData/complexType/ctG033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g032_ct_g032_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8026,11 +8509,12 @@ def test_ct_g032_ct_g032_v(save_xml):
         instance="msData/complexType/ctG032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g031_ct_g031_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8043,11 +8527,12 @@ def test_ct_g031_ct_g031_v(save_xml):
         instance="msData/complexType/ctG031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g025_ct_g025_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8059,11 +8544,12 @@ def test_ct_g025_ct_g025_v(save_xml):
         instance="msData/complexType/ctG025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g023_ct_g023_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8076,11 +8562,12 @@ def test_ct_g023_ct_g023_v(save_xml):
         instance="msData/complexType/ctG023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g022_ct_g022_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8093,11 +8580,12 @@ def test_ct_g022_ct_g022_v(save_xml):
         instance="msData/complexType/ctG022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g021_ct_g021_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8110,11 +8598,12 @@ def test_ct_g021_ct_g021_v(save_xml):
         instance="msData/complexType/ctG021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g020_ct_g020_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8127,11 +8616,12 @@ def test_ct_g020_ct_g020_v(save_xml):
         instance="msData/complexType/ctG020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g019_ct_g019_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8144,11 +8634,12 @@ def test_ct_g019_ct_g019_v(save_xml):
         instance="msData/complexType/ctG019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g013_ct_g013_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8160,11 +8651,12 @@ def test_ct_g013_ct_g013_v(save_xml):
         instance="msData/complexType/ctG013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g011_ct_g011_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8178,11 +8670,12 @@ def test_ct_g011_ct_g011_v(save_xml):
         instance="msData/complexType/ctG011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g010_ct_g010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8196,11 +8689,12 @@ def test_ct_g010_ct_g010_v(save_xml):
         instance="msData/complexType/ctG010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g009_ct_g009_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8214,11 +8708,12 @@ def test_ct_g009_ct_g009_v(save_xml):
         instance="msData/complexType/ctG009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g008_ct_g008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8232,11 +8727,12 @@ def test_ct_g008_ct_g008_v(save_xml):
         instance="msData/complexType/ctG008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g007_ct_g007_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8250,11 +8746,12 @@ def test_ct_g007_ct_g007_v(save_xml):
         instance="msData/complexType/ctG007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_g001_ct_g001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8267,11 +8764,12 @@ def test_ct_g001_ct_g001_v(save_xml):
         instance="msData/complexType/ctG001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_f014_ct_f014_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8283,11 +8781,12 @@ def test_ct_f014_ct_f014_v(save_xml):
         instance="msData/complexType/ctF014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_f013_ct_f013_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8299,11 +8798,12 @@ def test_ct_f013_ct_f013_v(save_xml):
         instance="msData/complexType/ctF013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_f011_ct_f011_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8316,11 +8816,12 @@ def test_ct_f011_ct_f011_v(save_xml):
         instance="msData/complexType/ctF011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_f010_ct_f010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8333,11 +8834,12 @@ def test_ct_f010_ct_f010_v(save_xml):
         instance="msData/complexType/ctF010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_f007_ct_f007_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8350,11 +8852,12 @@ def test_ct_f007_ct_f007_v(save_xml):
         instance="msData/complexType/ctF007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_f001_ct_f001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8366,11 +8869,12 @@ def test_ct_f001_ct_f001_v(save_xml):
         instance="msData/complexType/ctF001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e019_ct_e019_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8382,11 +8886,12 @@ def test_ct_e019_ct_e019_v(save_xml):
         instance="msData/complexType/ctE019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e018_ct_e018_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8398,11 +8903,12 @@ def test_ct_e018_ct_e018_v(save_xml):
         instance="msData/complexType/ctE018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e017_ct_e017_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8415,11 +8921,12 @@ def test_ct_e017_ct_e017_v(save_xml):
         instance="msData/complexType/ctE017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e010_ct_e010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8432,11 +8939,12 @@ def test_ct_e010_ct_e010_v(save_xml):
         instance="msData/complexType/ctE010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e008_ct_e008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8449,11 +8957,12 @@ def test_ct_e008_ct_e008_v(save_xml):
         instance="msData/complexType/ctE008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e007_ct_e007_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8466,11 +8975,12 @@ def test_ct_e007_ct_e007_v(save_xml):
         instance="msData/complexType/ctE007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e006_ct_e006_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8483,11 +8993,12 @@ def test_ct_e006_ct_e006_v(save_xml):
         instance="msData/complexType/ctE006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e002_ct_e002_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8500,11 +9011,12 @@ def test_ct_e002_ct_e002_v(save_xml):
         instance="msData/complexType/ctE002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_e001_ct_e001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8516,11 +9028,12 @@ def test_ct_e001_ct_e001_v(save_xml):
         instance="msData/complexType/ctE001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d035_ct_d035_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8533,11 +9046,12 @@ def test_ct_d035_ct_d035_v(save_xml):
         instance="msData/complexType/ctD035.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d033_ct_d033_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8549,11 +9063,12 @@ def test_ct_d033_ct_d033_v(save_xml):
         instance="msData/complexType/ctD033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d032_ct_d032_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8566,11 +9081,12 @@ def test_ct_d032_ct_d032_v(save_xml):
         instance="msData/complexType/ctD032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d031_ct_d031_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8582,11 +9098,12 @@ def test_ct_d031_ct_d031_v(save_xml):
         instance="msData/complexType/ctD031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d030_ct_d030_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8598,11 +9115,12 @@ def test_ct_d030_ct_d030_v(save_xml):
         instance="msData/complexType/ctD030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d029_ct_d029_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8614,11 +9132,12 @@ def test_ct_d029_ct_d029_v(save_xml):
         instance="msData/complexType/ctD029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d028_ct_d028_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8630,11 +9149,12 @@ def test_ct_d028_ct_d028_v(save_xml):
         instance="msData/complexType/ctD028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d027_ct_d027_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8646,11 +9166,12 @@ def test_ct_d027_ct_d027_v(save_xml):
         instance="msData/complexType/ctD027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d026_ct_d026_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8662,11 +9183,12 @@ def test_ct_d026_ct_d026_v(save_xml):
         instance="msData/complexType/ctD026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d025_ct_d025_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8678,11 +9200,12 @@ def test_ct_d025_ct_d025_v(save_xml):
         instance="msData/complexType/ctD025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d023_ct_d023_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8694,11 +9217,12 @@ def test_ct_d023_ct_d023_v(save_xml):
         instance="msData/complexType/ctD023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d022_ct_d022_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8710,11 +9234,12 @@ def test_ct_d022_ct_d022_v(save_xml):
         instance="msData/complexType/ctD022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d021_ct_d021_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8726,11 +9251,12 @@ def test_ct_d021_ct_d021_v(save_xml):
         instance="msData/complexType/ctD021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d020_ct_d020_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8742,11 +9268,12 @@ def test_ct_d020_ct_d020_v(save_xml):
         instance="msData/complexType/ctD020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d019_ct_d019_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8758,11 +9285,12 @@ def test_ct_d019_ct_d019_v(save_xml):
         instance="msData/complexType/ctD019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d018_ct_d018_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8774,11 +9302,12 @@ def test_ct_d018_ct_d018_v(save_xml):
         instance="msData/complexType/ctD018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d017_ct_d017_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8790,11 +9319,12 @@ def test_ct_d017_ct_d017_v(save_xml):
         instance="msData/complexType/ctD017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d016_ct_d016_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8806,11 +9336,12 @@ def test_ct_d016_ct_d016_v(save_xml):
         instance="msData/complexType/ctD016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d015_ct_d015_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8822,11 +9353,12 @@ def test_ct_d015_ct_d015_v(save_xml):
         instance="msData/complexType/ctD015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d012_ct_d012_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8839,11 +9371,12 @@ def test_ct_d012_ct_d012_v(save_xml):
         instance="msData/complexType/ctD012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d010_ct_d010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8856,11 +9389,12 @@ def test_ct_d010_ct_d010_v(save_xml):
         instance="msData/complexType/ctD010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d008_ct_d008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8872,11 +9406,12 @@ def test_ct_d008_ct_d008_v(save_xml):
         instance="msData/complexType/ctD008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d006_ct_d006_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8888,11 +9423,12 @@ def test_ct_d006_ct_d006_v(save_xml):
         instance="msData/complexType/ctD006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d005_ct_d005_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8904,11 +9440,12 @@ def test_ct_d005_ct_d005_v(save_xml):
         instance="msData/complexType/ctD005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_d002_ct_d002_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8920,11 +9457,12 @@ def test_ct_d002_ct_d002_v(save_xml):
         instance="msData/complexType/ctD002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_c012_ct_c012_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8936,11 +9474,12 @@ def test_ct_c012_ct_c012_v(save_xml):
         instance="msData/complexType/ctC012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_c008_ct_c008_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8952,11 +9491,12 @@ def test_ct_c008_ct_c008_v(save_xml):
         instance="msData/complexType/ctC008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_c007_ct_c007_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8968,11 +9508,12 @@ def test_ct_c007_ct_c007_v(save_xml):
         instance="msData/complexType/ctC007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_c006_ct_c006_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -8984,11 +9525,12 @@ def test_ct_c006_ct_c006_v(save_xml):
         instance="msData/complexType/ctC006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_c001_ct_c001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9000,11 +9542,12 @@ def test_ct_c001_ct_c001_v(save_xml):
         instance="msData/complexType/ctC001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b113_ct_b113_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9016,11 +9559,12 @@ def test_ct_b113_ct_b113_v(save_xml):
         instance="msData/complexType/ctB113.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b111_ct_b111_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9032,11 +9576,12 @@ def test_ct_b111_ct_b111_v(save_xml):
         instance="msData/complexType/ctB111.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b110_ct_b110_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9048,11 +9593,12 @@ def test_ct_b110_ct_b110_v(save_xml):
         instance="msData/complexType/ctB110.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b109_ct_b109_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9064,11 +9610,12 @@ def test_ct_b109_ct_b109_v(save_xml):
         instance="msData/complexType/ctB109.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b108_ct_b108_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9080,11 +9627,12 @@ def test_ct_b108_ct_b108_v(save_xml):
         instance="msData/complexType/ctB108.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b100_ct_b100_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9096,11 +9644,12 @@ def test_ct_b100_ct_b100_v(save_xml):
         instance="msData/complexType/ctB100.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b098_ct_b098_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9112,11 +9661,12 @@ def test_ct_b098_ct_b098_v(save_xml):
         instance="msData/complexType/ctB098.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b097_ct_b097_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9128,11 +9678,12 @@ def test_ct_b097_ct_b097_v(save_xml):
         instance="msData/complexType/ctB097.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b096_ct_b096_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9144,11 +9695,12 @@ def test_ct_b096_ct_b096_v(save_xml):
         instance="msData/complexType/ctB096.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b095_ct_b095_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9160,11 +9712,12 @@ def test_ct_b095_ct_b095_v(save_xml):
         instance="msData/complexType/ctB095.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b087_ct_b087_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9176,11 +9729,12 @@ def test_ct_b087_ct_b087_v(save_xml):
         instance="msData/complexType/ctB087.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b085_ct_b085_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9192,11 +9746,12 @@ def test_ct_b085_ct_b085_v(save_xml):
         instance="msData/complexType/ctB085.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b084_ct_b084_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9208,11 +9763,12 @@ def test_ct_b084_ct_b084_v(save_xml):
         instance="msData/complexType/ctB084.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b083_ct_b083_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9224,11 +9780,12 @@ def test_ct_b083_ct_b083_v(save_xml):
         instance="msData/complexType/ctB083.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b082_ct_b082_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9240,11 +9797,12 @@ def test_ct_b082_ct_b082_v(save_xml):
         instance="msData/complexType/ctB082.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b081_ct_b081_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9256,11 +9814,12 @@ def test_ct_b081_ct_b081_v(save_xml):
         instance="msData/complexType/ctB081.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b073_ct_b073_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9272,11 +9831,12 @@ def test_ct_b073_ct_b073_v(save_xml):
         instance="msData/complexType/ctB073.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b071_ct_b071_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9288,11 +9848,12 @@ def test_ct_b071_ct_b071_v(save_xml):
         instance="msData/complexType/ctB071.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b070_ct_b070_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9304,11 +9865,12 @@ def test_ct_b070_ct_b070_v(save_xml):
         instance="msData/complexType/ctB070.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b069_ct_b069_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9320,11 +9882,12 @@ def test_ct_b069_ct_b069_v(save_xml):
         instance="msData/complexType/ctB069.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b068_ct_b068_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9336,11 +9899,12 @@ def test_ct_b068_ct_b068_v(save_xml):
         instance="msData/complexType/ctB068.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b067_ct_b067_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9352,11 +9916,12 @@ def test_ct_b067_ct_b067_v(save_xml):
         instance="msData/complexType/ctB067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b059_ct_b059_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9368,11 +9933,12 @@ def test_ct_b059_ct_b059_v(save_xml):
         instance="msData/complexType/ctB059.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b057_ct_b057_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9384,11 +9950,12 @@ def test_ct_b057_ct_b057_v(save_xml):
         instance="msData/complexType/ctB057.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b056_ct_b056_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9400,11 +9967,12 @@ def test_ct_b056_ct_b056_v(save_xml):
         instance="msData/complexType/ctB056.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b055_ct_b055_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9416,11 +9984,12 @@ def test_ct_b055_ct_b055_v(save_xml):
         instance="msData/complexType/ctB055.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b054_ct_b054_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9432,11 +10001,12 @@ def test_ct_b054_ct_b054_v(save_xml):
         instance="msData/complexType/ctB054.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b053_ct_b053_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9448,11 +10018,12 @@ def test_ct_b053_ct_b053_v(save_xml):
         instance="msData/complexType/ctB053.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b045_ct_b045_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9464,11 +10035,12 @@ def test_ct_b045_ct_b045_v(save_xml):
         instance="msData/complexType/ctB045.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b043_ct_b043_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9480,11 +10052,12 @@ def test_ct_b043_ct_b043_v(save_xml):
         instance="msData/complexType/ctB043.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b042_ct_b042_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9496,11 +10069,12 @@ def test_ct_b042_ct_b042_v(save_xml):
         instance="msData/complexType/ctB042.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b041_ct_b041_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9512,11 +10086,12 @@ def test_ct_b041_ct_b041_v(save_xml):
         instance="msData/complexType/ctB041.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b040_ct_b040_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9528,11 +10103,12 @@ def test_ct_b040_ct_b040_v(save_xml):
         instance="msData/complexType/ctB040.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b039_ct_b039_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9544,11 +10120,12 @@ def test_ct_b039_ct_b039_v(save_xml):
         instance="msData/complexType/ctB039.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b031_ct_b031_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9560,11 +10137,12 @@ def test_ct_b031_ct_b031_v(save_xml):
         instance="msData/complexType/ctB031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b017_ct_b017_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9576,11 +10154,12 @@ def test_ct_b017_ct_b017_v(save_xml):
         instance="msData/complexType/ctB017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b003_ct_b003_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9592,11 +10171,12 @@ def test_ct_b003_ct_b003_v(save_xml):
         instance="msData/complexType/ctB003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_b001_ct_b001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration : content
@@ -9608,11 +10188,12 @@ def test_ct_b001_ct_b001_v(save_xml):
         instance="msData/complexType/ctB001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a049_ct_a049_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9624,11 +10205,12 @@ def test_ct_a049_ct_a049_v(save_xml):
         instance="msData/complexType/ctA049.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a048_ct_a048_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9640,11 +10222,12 @@ def test_ct_a048_ct_a048_v(save_xml):
         instance="msData/complexType/ctA048.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a047_ct_a047_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9656,11 +10239,12 @@ def test_ct_a047_ct_a047_v(save_xml):
         instance="msData/complexType/ctA047.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a045_ct_a045_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9672,11 +10256,12 @@ def test_ct_a045_ct_a045_v(save_xml):
         instance="msData/complexType/ctA045.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a041_ct_a041_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9688,11 +10273,12 @@ def test_ct_a041_ct_a041_v(save_xml):
         instance="msData/complexType/ctA041.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a037_ct_a037_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9704,11 +10290,12 @@ def test_ct_a037_ct_a037_v(save_xml):
         instance="msData/complexType/ctA037.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a035_ct_a035_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9720,11 +10307,12 @@ def test_ct_a035_ct_a035_v(save_xml):
         instance="msData/complexType/ctA035.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a034_ct_a034_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9736,11 +10324,12 @@ def test_ct_a034_ct_a034_v(save_xml):
         instance="msData/complexType/ctA034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a033_ct_a033_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9752,11 +10341,12 @@ def test_ct_a033_ct_a033_v(save_xml):
         instance="msData/complexType/ctA033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a032_ct_a032_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9769,11 +10359,12 @@ def test_ct_a032_ct_a032_v(save_xml):
         instance="msData/complexType/ctA032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a027_ct_a027_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9785,11 +10376,12 @@ def test_ct_a027_ct_a027_v(save_xml):
         instance="msData/complexType/ctA027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a026_ct_a026_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9801,11 +10393,12 @@ def test_ct_a026_ct_a026_v(save_xml):
         instance="msData/complexType/ctA026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a022_ct_a022_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9817,11 +10410,12 @@ def test_ct_a022_ct_a022_v(save_xml):
         instance="msData/complexType/ctA022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a021_ct_a021_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9833,11 +10427,12 @@ def test_ct_a021_ct_a021_v(save_xml):
         instance="msData/complexType/ctA021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a020_ct_a020_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9849,11 +10444,12 @@ def test_ct_a020_ct_a020_v(save_xml):
         instance="msData/complexType/ctA020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a019_ct_a019_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9865,11 +10461,12 @@ def test_ct_a019_ct_a019_v(save_xml):
         instance="msData/complexType/ctA019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a018_ct_a018_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9881,11 +10478,12 @@ def test_ct_a018_ct_a018_v(save_xml):
         instance="msData/complexType/ctA018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a017_ct_a017_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9897,11 +10495,12 @@ def test_ct_a017_ct_a017_v(save_xml):
         instance="msData/complexType/ctA017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a013_ct_a013_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9913,11 +10512,12 @@ def test_ct_a013_ct_a013_v(save_xml):
         instance="msData/complexType/ctA013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a012_ct_a012_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9929,11 +10529,12 @@ def test_ct_a012_ct_a012_v(save_xml):
         instance="msData/complexType/ctA012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a011_ct_a011_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9945,11 +10546,12 @@ def test_ct_a011_ct_a011_v(save_xml):
         instance="msData/complexType/ctA011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a010_ct_a010_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9961,11 +10563,12 @@ def test_ct_a010_ct_a010_v(save_xml):
         instance="msData/complexType/ctA010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a009_ct_a009_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9977,11 +10580,12 @@ def test_ct_a009_ct_a009_v(save_xml):
         instance="msData/complexType/ctA009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a005_ct_a005_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -9993,11 +10597,12 @@ def test_ct_a005_ct_a005_v(save_xml):
         instance="msData/complexType/ctA005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_a003_ct_a003_v(save_xml):
     """
@@ -10010,11 +10615,12 @@ def test_ct_a003_ct_a003_v(save_xml):
         instance="msData/complexType/ctA003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_ct_a002_ct_a002_v(save_xml):
     """
@@ -10027,11 +10633,12 @@ def test_ct_a002_ct_a002_v(save_xml):
         instance="msData/complexType/ctA002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ct_a001_ct_a001_v(save_xml):
     """
     TEST :Syntax Checking for top level complexType Declaration :
@@ -10043,11 +10650,12 @@ def test_ct_a001_ct_a001_v(save_xml):
         instance="msData/complexType/ctA001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_dt_z86723_2246_dt_z86723_2246_i(save_xml):
     """
     TEST :Facet Schemas for string : Validation: xsi:type with built-in
@@ -10059,7 +10667,7 @@ def test_dt_z86723_2246_dt_z86723_2246_i(save_xml):
         instance="msData/datatypes/test86723.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -10083,6 +10691,7 @@ def test_dt_z107447_a_2245_dt_z107447_a_2245_i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_dt_z107447_1_2244_dt_z107447_1_2244_v(save_xml):
     """
     TEST :Facet Schemas for string : XSD:whitespace handling for xs:token
@@ -10094,11 +10703,12 @@ def test_dt_z107447_1_2244_dt_z107447_1_2244_v(save_xml):
         instance="msData/datatypes/test107447_1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_dt_z107447_2243_dt_z107447_2243_v(save_xml):
     """
     TEST :Facet Schemas for string : XSD:whitespace handling for xs:token
@@ -10110,11 +10720,12 @@ def test_dt_z107447_2243_dt_z107447_2243_v(save_xml):
         instance="msData/datatypes/test107447.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_dt_z100507_2242_dt_z100507_2242_i(save_xml):
     """
     TEST :Facet Schemas for string : xs:ENTITY is not derived from
@@ -10126,11 +10737,12 @@ def test_dt_z100507_2242_dt_z100507_2242_i(save_xml):
         instance="msData/datatypes/test100507.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_test70681_2241_id_test70681_2241_v(save_xml):
     """
     TEST :Facet Schemas for string : ID/IDREF should not allow heading or
@@ -10142,11 +10754,12 @@ def test_id_test70681_2241_id_test70681_2241_v(save_xml):
         instance="msData/datatypes/ID_test70681.xml",
         instance_is_valid=True,
         class_name="Data",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_test64335_2240_id_test64335_2240_v(save_xml):
     """
     TEST :Facet Schemas for string : ID data type validation
@@ -10157,11 +10770,12 @@ def test_id_test64335_2240_id_test64335_2240_v(save_xml):
         instance="msData/datatypes/ID_test64335.xml",
         instance_is_valid=True,
         class_name="Products",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer005_2239_positive_integer005_2239_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12345678901234567890123456789
@@ -10172,11 +10786,12 @@ def test_positive_integer005_2239_positive_integer005_2239_v(save_xml):
         instance="msData/datatypes/positiveInteger005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer004_2238_positive_integer004_2238_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -10187,11 +10802,12 @@ def test_positive_integer004_2238_positive_integer004_2238_v(save_xml):
         instance="msData/datatypes/positiveInteger004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer003_2237_positive_integer003_2237_i(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10202,11 +10818,12 @@ def test_positive_integer003_2237_positive_integer003_2237_i(save_xml):
         instance="msData/datatypes/positiveInteger003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer002_2236_positive_integer002_2236_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10217,11 +10834,12 @@ def test_positive_integer002_2236_positive_integer002_2236_i(save_xml):
         instance="msData/datatypes/positiveInteger002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer001_2235_positive_integer001_2235_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10232,11 +10850,12 @@ def test_positive_integer001_2235_positive_integer001_2235_i(save_xml):
         instance="msData/datatypes/positiveInteger001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte007_2234_unsigned_byte007_2234_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of
@@ -10248,11 +10867,12 @@ def test_unsigned_byte007_2234_unsigned_byte007_2234_v(save_xml):
         instance="msData/datatypes/unsignedByte007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte006_2233_unsigned_byte006_2233_i(save_xml):
     """
     TEST :Facet Schemas for string : value=256
@@ -10263,11 +10883,12 @@ def test_unsigned_byte006_2233_unsigned_byte006_2233_i(save_xml):
         instance="msData/datatypes/unsignedByte006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte005_2232_unsigned_byte005_2232_v(save_xml):
     """
     TEST :Facet Schemas for string : value=255
@@ -10278,11 +10899,12 @@ def test_unsigned_byte005_2232_unsigned_byte005_2232_v(save_xml):
         instance="msData/datatypes/unsignedByte005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte004_2231_unsigned_byte004_2231_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -10293,11 +10915,12 @@ def test_unsigned_byte004_2231_unsigned_byte004_2231_v(save_xml):
         instance="msData/datatypes/unsignedByte004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte003_2230_unsigned_byte003_2230_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10308,11 +10931,12 @@ def test_unsigned_byte003_2230_unsigned_byte003_2230_v(save_xml):
         instance="msData/datatypes/unsignedByte003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte002_2229_unsigned_byte002_2229_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10323,11 +10947,12 @@ def test_unsigned_byte002_2229_unsigned_byte002_2229_i(save_xml):
         instance="msData/datatypes/unsignedByte002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte001_2228_unsigned_byte001_2228_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10338,11 +10963,12 @@ def test_unsigned_byte001_2228_unsigned_byte001_2228_i(save_xml):
         instance="msData/datatypes/unsignedByte001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short007_2227_unsigned_short007_2227_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of
@@ -10354,11 +10980,12 @@ def test_unsigned_short007_2227_unsigned_short007_2227_v(save_xml):
         instance="msData/datatypes/unsignedShort007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short006_2226_unsigned_short006_2226_i(save_xml):
     """
     TEST :Facet Schemas for string : value=65536
@@ -10369,11 +10996,12 @@ def test_unsigned_short006_2226_unsigned_short006_2226_i(save_xml):
         instance="msData/datatypes/unsignedShort006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short005_2225_unsigned_short005_2225_v(save_xml):
     """
     TEST :Facet Schemas for string : value=65535
@@ -10384,11 +11012,12 @@ def test_unsigned_short005_2225_unsigned_short005_2225_v(save_xml):
         instance="msData/datatypes/unsignedShort005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short004_2224_unsigned_short004_2224_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -10399,11 +11028,12 @@ def test_unsigned_short004_2224_unsigned_short004_2224_v(save_xml):
         instance="msData/datatypes/unsignedShort004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short003_2223_unsigned_short003_2223_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10414,11 +11044,12 @@ def test_unsigned_short003_2223_unsigned_short003_2223_v(save_xml):
         instance="msData/datatypes/unsignedShort003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short002_2222_unsigned_short002_2222_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10429,11 +11060,12 @@ def test_unsigned_short002_2222_unsigned_short002_2222_i(save_xml):
         instance="msData/datatypes/unsignedShort002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short001_2221_unsigned_short001_2221_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10444,11 +11076,12 @@ def test_unsigned_short001_2221_unsigned_short001_2221_i(save_xml):
         instance="msData/datatypes/unsignedShort001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int007_2220_unsigned_int007_2220_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of
@@ -10460,11 +11093,12 @@ def test_unsigned_int007_2220_unsigned_int007_2220_v(save_xml):
         instance="msData/datatypes/unsignedInt007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int006_2219_unsigned_int006_2219_i(save_xml):
     """
     TEST :Facet Schemas for string : value=4294967296
@@ -10475,11 +11109,12 @@ def test_unsigned_int006_2219_unsigned_int006_2219_i(save_xml):
         instance="msData/datatypes/unsignedInt006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int005_2218_unsigned_int005_2218_v(save_xml):
     """
     TEST :Facet Schemas for string : value=4294967295
@@ -10490,11 +11125,12 @@ def test_unsigned_int005_2218_unsigned_int005_2218_v(save_xml):
         instance="msData/datatypes/unsignedInt005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int004_2217_unsigned_int004_2217_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -10505,11 +11141,12 @@ def test_unsigned_int004_2217_unsigned_int004_2217_v(save_xml):
         instance="msData/datatypes/unsignedInt004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int003_2216_unsigned_int003_2216_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10520,11 +11157,12 @@ def test_unsigned_int003_2216_unsigned_int003_2216_v(save_xml):
         instance="msData/datatypes/unsignedInt003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int002_2215_unsigned_int002_2215_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10535,11 +11173,12 @@ def test_unsigned_int002_2215_unsigned_int002_2215_i(save_xml):
         instance="msData/datatypes/unsignedInt002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int001_2214_unsigned_int001_2214_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10550,11 +11189,12 @@ def test_unsigned_int001_2214_unsigned_int001_2214_i(save_xml):
         instance="msData/datatypes/unsignedInt001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long007_2213_unsigned_long007_2213_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of
@@ -10566,11 +11206,12 @@ def test_unsigned_long007_2213_unsigned_long007_2213_v(save_xml):
         instance="msData/datatypes/unsignedLong007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long006_2212_unsigned_long006_2212_i(save_xml):
     """
     TEST :Facet Schemas for string : value=18446744073709551616
@@ -10581,11 +11222,12 @@ def test_unsigned_long006_2212_unsigned_long006_2212_i(save_xml):
         instance="msData/datatypes/unsignedLong006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long005_2211_unsigned_long005_2211_v(save_xml):
     """
     TEST :Facet Schemas for string : value=18446744073709551615
@@ -10596,11 +11238,12 @@ def test_unsigned_long005_2211_unsigned_long005_2211_v(save_xml):
         instance="msData/datatypes/unsignedLong005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long004_2210_unsigned_long004_2210_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -10611,11 +11254,12 @@ def test_unsigned_long004_2210_unsigned_long004_2210_v(save_xml):
         instance="msData/datatypes/unsignedLong004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long003_2209_unsigned_long003_2209_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10626,11 +11270,12 @@ def test_unsigned_long003_2209_unsigned_long003_2209_v(save_xml):
         instance="msData/datatypes/unsignedLong003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long002_2208_unsigned_long002_2208_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10641,11 +11286,12 @@ def test_unsigned_long002_2208_unsigned_long002_2208_i(save_xml):
         instance="msData/datatypes/unsignedLong002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long001_2207_unsigned_long001_2207_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10656,11 +11302,12 @@ def test_unsigned_long001_2207_unsigned_long001_2207_i(save_xml):
         instance="msData/datatypes/unsignedLong001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer005_2206_non_negative_integer005_2206_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12345678901234567890123456789
@@ -10671,11 +11318,12 @@ def test_non_negative_integer005_2206_non_negative_integer005_2206_v(save_xml):
         instance="msData/datatypes/nonNegativeInteger005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer004_2205_non_negative_integer004_2205_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -10686,11 +11334,12 @@ def test_non_negative_integer004_2205_non_negative_integer004_2205_v(save_xml):
         instance="msData/datatypes/nonNegativeInteger004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer003_2204_non_negative_integer003_2204_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10701,11 +11350,12 @@ def test_non_negative_integer003_2204_non_negative_integer003_2204_v(save_xml):
         instance="msData/datatypes/nonNegativeInteger003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer002_2203_non_negative_integer002_2203_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10716,11 +11366,12 @@ def test_non_negative_integer002_2203_non_negative_integer002_2203_i(save_xml):
         instance="msData/datatypes/nonNegativeInteger002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer001_2202_non_negative_integer001_2202_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10731,11 +11382,12 @@ def test_non_negative_integer001_2202_non_negative_integer001_2202_i(save_xml):
         instance="msData/datatypes/nonNegativeInteger001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte009_2201_byte009_2201_v(save_xml):
     """
     TEST :Facet Schemas for string : Test simpleType List of byte
@@ -10746,11 +11398,12 @@ def test_byte009_2201_byte009_2201_v(save_xml):
         instance="msData/datatypes/byte009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte008_2200_byte008_2200_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-129
@@ -10761,11 +11414,12 @@ def test_byte008_2200_byte008_2200_i(save_xml):
         instance="msData/datatypes/byte008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte007_2199_byte007_2199_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-128
@@ -10776,11 +11430,12 @@ def test_byte007_2199_byte007_2199_v(save_xml):
         instance="msData/datatypes/byte007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte006_2198_byte006_2198_i(save_xml):
     """
     TEST :Facet Schemas for string : value=128
@@ -10791,11 +11446,12 @@ def test_byte006_2198_byte006_2198_i(save_xml):
         instance="msData/datatypes/byte006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte005_2197_byte005_2197_v(save_xml):
     """
     TEST :Facet Schemas for string : value=127
@@ -10806,11 +11462,12 @@ def test_byte005_2197_byte005_2197_v(save_xml):
         instance="msData/datatypes/byte005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte004_2196_byte004_2196_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -10821,11 +11478,12 @@ def test_byte004_2196_byte004_2196_v(save_xml):
         instance="msData/datatypes/byte004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte003_2195_byte003_2195_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10836,11 +11494,12 @@ def test_byte003_2195_byte003_2195_v(save_xml):
         instance="msData/datatypes/byte003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte002_2194_byte002_2194_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10851,11 +11510,12 @@ def test_byte002_2194_byte002_2194_v(save_xml):
         instance="msData/datatypes/byte002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte001_2193_byte001_2193_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -10866,11 +11526,12 @@ def test_byte001_2193_byte001_2193_i(save_xml):
         instance="msData/datatypes/byte001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short009_2192_short009_2192_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of short
@@ -10881,11 +11542,12 @@ def test_short009_2192_short009_2192_v(save_xml):
         instance="msData/datatypes/short009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short008_2191_short008_2191_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-32769
@@ -10896,11 +11558,12 @@ def test_short008_2191_short008_2191_i(save_xml):
         instance="msData/datatypes/short008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short007_2190_short007_2190_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-32768
@@ -10911,11 +11574,12 @@ def test_short007_2190_short007_2190_v(save_xml):
         instance="msData/datatypes/short007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short006_2189_short006_2189_i(save_xml):
     """
     TEST :Facet Schemas for string : value=32768
@@ -10926,11 +11590,12 @@ def test_short006_2189_short006_2189_i(save_xml):
         instance="msData/datatypes/short006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short005_2188_short005_2188_v(save_xml):
     """
     TEST :Facet Schemas for string : value=32767
@@ -10941,11 +11606,12 @@ def test_short005_2188_short005_2188_v(save_xml):
         instance="msData/datatypes/short005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short004_2187_short004_2187_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -10956,11 +11622,12 @@ def test_short004_2187_short004_2187_v(save_xml):
         instance="msData/datatypes/short004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short003_2186_short003_2186_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -10971,11 +11638,12 @@ def test_short003_2186_short003_2186_v(save_xml):
         instance="msData/datatypes/short003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short002_2185_short002_2185_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -10986,11 +11654,12 @@ def test_short002_2185_short002_2185_v(save_xml):
         instance="msData/datatypes/short002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short001_2184_short001_2184_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11001,11 +11670,12 @@ def test_short001_2184_short001_2184_i(save_xml):
         instance="msData/datatypes/short001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int008_2183_int008_2183_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-2147483649
@@ -11016,11 +11686,12 @@ def test_int008_2183_int008_2183_i(save_xml):
         instance="msData/datatypes/int008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int007_2182_int007_2182_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-2147483648
@@ -11031,11 +11702,12 @@ def test_int007_2182_int007_2182_v(save_xml):
         instance="msData/datatypes/int007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int006_2181_int006_2181_i(save_xml):
     """
     TEST :Facet Schemas for string : value=2147483648
@@ -11046,11 +11718,12 @@ def test_int006_2181_int006_2181_i(save_xml):
         instance="msData/datatypes/int006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int005_2180_int005_2180_v(save_xml):
     """
     TEST :Facet Schemas for string : value=2147483647
@@ -11061,11 +11734,12 @@ def test_int005_2180_int005_2180_v(save_xml):
         instance="msData/datatypes/int005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int004_2179_int004_2179_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -11076,11 +11750,12 @@ def test_int004_2179_int004_2179_v(save_xml):
         instance="msData/datatypes/int004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int003_2178_int003_2178_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -11091,11 +11766,12 @@ def test_int003_2178_int003_2178_v(save_xml):
         instance="msData/datatypes/int003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int002_2177_int002_2177_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -11106,11 +11782,12 @@ def test_int002_2177_int002_2177_v(save_xml):
         instance="msData/datatypes/int002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int001_2176_int001_2176_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11121,11 +11798,12 @@ def test_int001_2176_int001_2176_i(save_xml):
         instance="msData/datatypes/int001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long009_2175_long009_2175_v(save_xml):
     """
     TEST :Facet Schemas for string : Test for simpleType list of Long
@@ -11136,11 +11814,12 @@ def test_long009_2175_long009_2175_v(save_xml):
         instance="msData/datatypes/long009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long008_2174_long008_2174_i(save_xml):
     """
     TEST :Facet Schemas for string : value=9223372036854775808
@@ -11151,11 +11830,12 @@ def test_long008_2174_long008_2174_i(save_xml):
         instance="msData/datatypes/long008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long007_2173_long007_2173_v(save_xml):
     """
     TEST :Facet Schemas for string : value=9223372036854775807
@@ -11166,11 +11846,12 @@ def test_long007_2173_long007_2173_v(save_xml):
         instance="msData/datatypes/long007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long006_2172_long006_2172_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-9223372036854775809
@@ -11181,11 +11862,12 @@ def test_long006_2172_long006_2172_i(save_xml):
         instance="msData/datatypes/long006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long005_2171_long005_2171_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-9223372036854775808
@@ -11196,11 +11878,12 @@ def test_long005_2171_long005_2171_v(save_xml):
         instance="msData/datatypes/long005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long004_2170_long004_2170_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -11211,11 +11894,12 @@ def test_long004_2170_long004_2170_v(save_xml):
         instance="msData/datatypes/long004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long003_2169_long003_2169_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -11226,11 +11910,12 @@ def test_long003_2169_long003_2169_v(save_xml):
         instance="msData/datatypes/long003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long002_2168_long002_2168_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -11241,11 +11926,12 @@ def test_long002_2168_long002_2168_v(save_xml):
         instance="msData/datatypes/long002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long001_2167_long001_2167_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11256,11 +11942,12 @@ def test_long001_2167_long001_2167_i(save_xml):
         instance="msData/datatypes/long001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer005_2166_negative_integer005_2166_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-12345678901234567890123456789
@@ -11271,11 +11958,12 @@ def test_negative_integer005_2166_negative_integer005_2166_v(save_xml):
         instance="msData/datatypes/negativeInteger005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer004_2165_negative_integer004_2165_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -11286,11 +11974,12 @@ def test_negative_integer004_2165_negative_integer004_2165_i(save_xml):
         instance="msData/datatypes/negativeInteger004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer003_2164_negative_integer003_2164_i(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -11301,11 +11990,12 @@ def test_negative_integer003_2164_negative_integer003_2164_i(save_xml):
         instance="msData/datatypes/negativeInteger003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer002_2163_negative_integer002_2163_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -11316,11 +12006,12 @@ def test_negative_integer002_2163_negative_integer002_2163_v(save_xml):
         instance="msData/datatypes/negativeInteger002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer001_2162_negative_integer001_2162_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11331,11 +12022,12 @@ def test_negative_integer001_2162_negative_integer001_2162_i(save_xml):
         instance="msData/datatypes/negativeInteger001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer005_2161_non_positive_integer005_2161_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-12345678901234567890123456789
@@ -11346,11 +12038,12 @@ def test_non_positive_integer005_2161_non_positive_integer005_2161_v(save_xml):
         instance="msData/datatypes/nonPositiveInteger005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer004_2160_non_positive_integer004_2160_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -11361,11 +12054,12 @@ def test_non_positive_integer004_2160_non_positive_integer004_2160_i(save_xml):
         instance="msData/datatypes/nonPositiveInteger004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer003_2159_non_positive_integer003_2159_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -11376,11 +12070,12 @@ def test_non_positive_integer003_2159_non_positive_integer003_2159_v(save_xml):
         instance="msData/datatypes/nonPositiveInteger003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer002_2158_non_positive_integer002_2158_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -11391,11 +12086,12 @@ def test_non_positive_integer002_2158_non_positive_integer002_2158_v(save_xml):
         instance="msData/datatypes/nonPositiveInteger002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer001_2157_non_positive_integer001_2157_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11406,11 +12102,12 @@ def test_non_positive_integer001_2157_non_positive_integer001_2157_i(save_xml):
         instance="msData/datatypes/nonPositiveInteger001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer016_2156_integer016_2156_i(save_xml):
     """
     TEST :Facet Schemas for string : value=ABCDEF
@@ -11421,11 +12118,12 @@ def test_integer016_2156_integer016_2156_i(save_xml):
         instance="msData/datatypes/integer016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer015_2155_integer015_2155_i(save_xml):
     """
     TEST :Facet Schemas for string : value=NaN
@@ -11436,11 +12134,12 @@ def test_integer015_2155_integer015_2155_i(save_xml):
         instance="msData/datatypes/integer015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer014_2154_integer014_2154_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-INF
@@ -11451,11 +12150,12 @@ def test_integer014_2154_integer014_2154_i(save_xml):
         instance="msData/datatypes/integer014.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer013_2153_integer013_2153_i(save_xml):
     """
     TEST :Facet Schemas for string : value=INF
@@ -11466,11 +12166,12 @@ def test_integer013_2153_integer013_2153_i(save_xml):
         instance="msData/datatypes/integer013.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer012_2152_integer012_2152_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1E4
@@ -11481,11 +12182,12 @@ def test_integer012_2152_integer012_2152_i(save_xml):
         instance="msData/datatypes/integer012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer011_2151_integer011_2151_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12345678901234567890123456789
@@ -11496,11 +12198,12 @@ def test_integer011_2151_integer011_2151_v(save_xml):
         instance="msData/datatypes/integer011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer010_2150_integer010_2150_v(save_xml):
     """
     TEST :Facet Schemas for string : value=10000000
@@ -11511,11 +12214,12 @@ def test_integer010_2150_integer010_2150_v(save_xml):
         instance="msData/datatypes/integer010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer009_2149_integer009_2149_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12678967543233
@@ -11526,11 +12230,12 @@ def test_integer009_2149_integer009_2149_v(save_xml):
         instance="msData/datatypes/integer009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer008_2148_integer008_2148_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -11541,11 +12246,12 @@ def test_integer008_2148_integer008_2148_v(save_xml):
         instance="msData/datatypes/integer008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer007_2147_integer007_2147_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -11556,11 +12262,12 @@ def test_integer007_2147_integer007_2147_v(save_xml):
         instance="msData/datatypes/integer007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer006_2146_integer006_2146_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+0.0
@@ -11571,11 +12278,12 @@ def test_integer006_2146_integer006_2146_i(save_xml):
         instance="msData/datatypes/integer006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer005_2145_integer005_2145_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0
@@ -11586,11 +12294,12 @@ def test_integer005_2145_integer005_2145_v(save_xml):
         instance="msData/datatypes/integer005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer004_2144_integer004_2144_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0
@@ -11601,11 +12310,12 @@ def test_integer004_2144_integer004_2144_v(save_xml):
         instance="msData/datatypes/integer004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer003_2143_integer003_2143_i(save_xml):
     """
     TEST :Facet Schemas for string : value=3.14159
@@ -11616,11 +12326,12 @@ def test_integer003_2143_integer003_2143_i(save_xml):
         instance="msData/datatypes/integer003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer002_2142_integer002_2142_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-3.14159
@@ -11631,11 +12342,12 @@ def test_integer002_2142_integer002_2142_i(save_xml):
         instance="msData/datatypes/integer002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer001_2141_integer001_2141_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11646,11 +12358,12 @@ def test_integer001_2141_integer001_2141_i(save_xml):
         instance="msData/datatypes/integer001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname011_2140_ncname011_2140_i(save_xml):
     """
     TEST :Facet Schemas for string : value=//foo
@@ -11661,11 +12374,12 @@ def test_ncname011_2140_ncname011_2140_i(save_xml):
         instance="msData/datatypes/NCName011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname010_2139_ncname010_2139_i(save_xml):
     """
     TEST :Facet Schemas for string : value=@test
@@ -11676,11 +12390,12 @@ def test_ncname010_2139_ncname010_2139_i(save_xml):
         instance="msData/datatypes/NCName010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname009_2138_ncname009_2138_i(save_xml):
     """
     TEST :Facet Schemas for string : value=:foo
@@ -11691,11 +12406,12 @@ def test_ncname009_2138_ncname009_2138_i(save_xml):
         instance="msData/datatypes/NCName009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname008_2137_ncname008_2137_i(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:foo
@@ -11706,11 +12422,12 @@ def test_ncname008_2137_ncname008_2137_i(save_xml):
         instance="msData/datatypes/NCName008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname007_2136_ncname007_2136_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo_124-.sda3
@@ -11721,11 +12438,12 @@ def test_ncname007_2136_ncname007_2136_v(save_xml):
         instance="msData/datatypes/NCName007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname006_2135_ncname006_2135_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-foo
@@ -11736,11 +12454,12 @@ def test_ncname006_2135_ncname006_2135_i(save_xml):
         instance="msData/datatypes/NCName006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname005_2134_ncname005_2134_i(save_xml):
     """
     TEST :Facet Schemas for string : value=.foo
@@ -11751,11 +12470,12 @@ def test_ncname005_2134_ncname005_2134_i(save_xml):
         instance="msData/datatypes/NCName005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname004_2133_ncname004_2133_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1fo
@@ -11766,11 +12486,12 @@ def test_ncname004_2133_ncname004_2133_i(save_xml):
         instance="msData/datatypes/NCName004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname003_2132_ncname003_2132_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo124
@@ -11781,11 +12502,12 @@ def test_ncname003_2132_ncname003_2132_v(save_xml):
         instance="msData/datatypes/NCName003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname002_2131_ncname002_2131_v(save_xml):
     """
     TEST :Facet Schemas for string : value=_foo
@@ -11796,11 +12518,12 @@ def test_ncname002_2131_ncname002_2131_v(save_xml):
         instance="msData/datatypes/NCName002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname001_2130_ncname001_2130_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -11811,11 +12534,12 @@ def test_ncname001_2130_ncname001_2130_i(save_xml):
         instance="msData/datatypes/NCName001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name018_2129_name018_2129_i(save_xml):
     """
     TEST :Facet Schemas for string : value=//foo
@@ -11826,11 +12550,12 @@ def test_name018_2129_name018_2129_i(save_xml):
         instance="msData/datatypes/Name018.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name017_2128_name017_2128_i(save_xml):
     """
     TEST :Facet Schemas for string : value=@test
@@ -11841,11 +12566,12 @@ def test_name017_2128_name017_2128_i(save_xml):
         instance="msData/datatypes/Name017.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name016_2127_name016_2127_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:fo_124-.s:da3
@@ -11856,11 +12582,12 @@ def test_name016_2127_name016_2127_v(save_xml):
         instance="msData/datatypes/Name016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name015_2126_name015_2126_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:fo_124-.sda3
@@ -11871,11 +12598,12 @@ def test_name015_2126_name015_2126_v(save_xml):
         instance="msData/datatypes/Name015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name014_2125_name014_2125_i(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:'-foo
@@ -11886,11 +12614,12 @@ def test_name014_2125_name014_2125_i(save_xml):
         instance="msData/datatypes/Name014.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name013_2124_name013_2124_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:.foo
@@ -11901,11 +12630,12 @@ def test_name013_2124_name013_2124_v(save_xml):
         instance="msData/datatypes/Name013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name012_2123_name012_2123_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:1fo
@@ -11916,11 +12646,12 @@ def test_name012_2123_name012_2123_v(save_xml):
         instance="msData/datatypes/Name012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name011_2122_name011_2122_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:fo124
@@ -11931,11 +12662,12 @@ def test_name011_2122_name011_2122_v(save_xml):
         instance="msData/datatypes/Name011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name010_2121_name010_2121_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:_foo
@@ -11946,11 +12678,12 @@ def test_name010_2121_name010_2121_v(save_xml):
         instance="msData/datatypes/Name010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name009_2120_name009_2120_v(save_xml):
     """
     TEST :Facet Schemas for string : value=:foo
@@ -11961,11 +12694,12 @@ def test_name009_2120_name009_2120_v(save_xml):
         instance="msData/datatypes/Name009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name008_2119_name008_2119_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:foo
@@ -11976,11 +12710,12 @@ def test_name008_2119_name008_2119_v(save_xml):
         instance="msData/datatypes/Name008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name007_2118_name007_2118_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo_124-.sda3
@@ -11991,11 +12726,12 @@ def test_name007_2118_name007_2118_v(save_xml):
         instance="msData/datatypes/Name007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name006_2117_name006_2117_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-foo
@@ -12006,11 +12742,12 @@ def test_name006_2117_name006_2117_i(save_xml):
         instance="msData/datatypes/Name006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name005_2116_name005_2116_i(save_xml):
     """
     TEST :Facet Schemas for string : value=.foo
@@ -12021,11 +12758,12 @@ def test_name005_2116_name005_2116_i(save_xml):
         instance="msData/datatypes/Name005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name004_2115_name004_2115_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1fo
@@ -12036,11 +12774,12 @@ def test_name004_2115_name004_2115_i(save_xml):
         instance="msData/datatypes/Name004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name003_2114_name003_2114_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo124
@@ -12051,11 +12790,12 @@ def test_name003_2114_name003_2114_v(save_xml):
         instance="msData/datatypes/Name003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name002_2113_name002_2113_v(save_xml):
     """
     TEST :Facet Schemas for string : value=_foo
@@ -12066,11 +12806,12 @@ def test_name002_2113_name002_2113_v(save_xml):
         instance="msData/datatypes/Name002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name001_2112_name001_2112_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12081,11 +12822,12 @@ def test_name001_2112_name001_2112_i(save_xml):
         instance="msData/datatypes/Name001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language010_2111_language010_2111_i(save_xml):
     """
     TEST :Facet Schemas for string : xsd:language doesn't quite follow the
@@ -12097,11 +12839,12 @@ def test_language010_2111_language010_2111_i(save_xml):
         instance="msData/datatypes/language010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language009_2110_language009_2110_v(save_xml):
     """
     TEST :Facet Schemas for string : value=X-2o
@@ -12112,11 +12855,12 @@ def test_language009_2110_language009_2110_v(save_xml):
         instance="msData/datatypes/language009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language008_2109_language008_2109_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1ko
@@ -12127,11 +12871,12 @@ def test_language008_2109_language008_2109_i(save_xml):
         instance="msData/datatypes/language008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language007_2108_language007_2108_v(save_xml):
     """
     TEST :Facet Schemas for string : value=I-en-us
@@ -12142,11 +12887,12 @@ def test_language007_2108_language007_2108_v(save_xml):
         instance="msData/datatypes/language007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language006_2107_language006_2107_v(save_xml):
     """
     TEST :Facet Schemas for string : value=spanish
@@ -12157,11 +12903,12 @@ def test_language006_2107_language006_2107_v(save_xml):
         instance="msData/datatypes/language006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language005_2106_language005_2106_v(save_xml):
     """
     TEST :Facet Schemas for string : value=en
@@ -12172,11 +12919,12 @@ def test_language005_2106_language005_2106_v(save_xml):
         instance="msData/datatypes/language005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language004_2105_language004_2105_v(save_xml):
     """
     TEST :Facet Schemas for string : value=en-us
@@ -12187,11 +12935,12 @@ def test_language004_2105_language004_2105_v(save_xml):
         instance="msData/datatypes/language004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language003_2104_language003_2104_v(save_xml):
     """
     TEST :Facet Schemas for string : value=EN-US
@@ -12202,11 +12951,12 @@ def test_language003_2104_language003_2104_v(save_xml):
         instance="msData/datatypes/language003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language002_2103_language002_2103_v(save_xml):
     """
     TEST :Facet Schemas for string : value=EN
@@ -12217,11 +12967,12 @@ def test_language002_2103_language002_2103_v(save_xml):
         instance="msData/datatypes/language002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language001_2102_language001_2102_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12232,11 +12983,12 @@ def test_language001_2102_language001_2102_i(save_xml):
         instance="msData/datatypes/language001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token004_2101_token004_2101_v(save_xml):
     """
     TEST :Facet Schemas for string : value=a b
@@ -12247,11 +12999,12 @@ def test_token004_2101_token004_2101_v(save_xml):
         instance="msData/datatypes/token004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token003_2100_token003_2100_v(save_xml):
     """
     TEST :Facet Schemas for string : value=a b
@@ -12262,11 +13015,12 @@ def test_token003_2100_token003_2100_v(save_xml):
         instance="msData/datatypes/token003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token002_2099_token002_2099_v(save_xml):
     """
     TEST :Facet Schemas for string : value=a b
@@ -12277,11 +13031,12 @@ def test_token002_2099_token002_2099_v(save_xml):
         instance="msData/datatypes/token002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token001_2098_token001_2098_v(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12292,11 +13047,12 @@ def test_token001_2098_token001_2098_v(save_xml):
         instance="msData/datatypes/token001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string003_2097_normalized_string003_2097_v(save_xml):
     """
     TEST :Facet Schemas for string : value=test line
@@ -12307,11 +13063,12 @@ def test_normalized_string003_2097_normalized_string003_2097_v(save_xml):
         instance="msData/datatypes/normalizedString003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string002_2096_normalized_string002_2096_v(save_xml):
     """
     TEST :Facet Schemas for string : value=test line
@@ -12322,11 +13079,12 @@ def test_normalized_string002_2096_normalized_string002_2096_v(save_xml):
         instance="msData/datatypes/normalizedString002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string001_2095_normalized_string001_2095_v(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12337,11 +13095,12 @@ def test_normalized_string001_2095_normalized_string001_2095_v(save_xml):
         instance="msData/datatypes/normalizedString001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname011_2094_qname011_2094_i(save_xml):
     """
     TEST :Facet Schemas for string : value=//foo
@@ -12352,11 +13111,12 @@ def test_qname011_2094_qname011_2094_i(save_xml):
         instance="msData/datatypes/QName011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname010_2093_qname010_2093_i(save_xml):
     """
     TEST :Facet Schemas for string : value=@test
@@ -12367,11 +13127,12 @@ def test_qname010_2093_qname010_2093_i(save_xml):
         instance="msData/datatypes/QName010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname009_2092_qname009_2092_v(save_xml):
     """
     TEST :Facet Schemas for string : value=xmlns:xsi WG decided on
@@ -12384,11 +13145,12 @@ def test_qname009_2092_qname009_2092_v(save_xml):
         instance="msData/datatypes/QName009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname008_2091_qname008_2091_i(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:1fo
@@ -12399,11 +13161,12 @@ def test_qname008_2091_qname008_2091_i(save_xml):
         instance="msData/datatypes/QName008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname007_2090_qname007_2090_i(save_xml):
     """
     TEST :Facet Schemas for string : value=:foo
@@ -12414,11 +13177,12 @@ def test_qname007_2090_qname007_2090_i(save_xml):
         instance="msData/datatypes/QName007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname006_2089_qname006_2089_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo:foo
@@ -12429,11 +13193,12 @@ def test_qname006_2089_qname006_2089_v(save_xml):
         instance="msData/datatypes/QName006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname005_2088_qname005_2088_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-foo
@@ -12444,11 +13209,12 @@ def test_qname005_2088_qname005_2088_i(save_xml):
         instance="msData/datatypes/QName005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname004_2087_qname004_2087_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1fo
@@ -12459,11 +13225,12 @@ def test_qname004_2087_qname004_2087_i(save_xml):
         instance="msData/datatypes/QName004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname003_2086_qname003_2086_v(save_xml):
     """
     TEST :Facet Schemas for string : value=fo124
@@ -12474,11 +13241,12 @@ def test_qname003_2086_qname003_2086_v(save_xml):
         instance="msData/datatypes/QName003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname002_2085_qname002_2085_v(save_xml):
     """
     TEST :Facet Schemas for string : value=_foo
@@ -12489,11 +13257,12 @@ def test_qname002_2085_qname002_2085_v(save_xml):
         instance="msData/datatypes/QName002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname001_2084_qname001_2084_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12504,11 +13273,12 @@ def test_qname001_2084_qname001_2084_i(save_xml):
         instance="msData/datatypes/QName001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri011_2083_any_uri011_2083_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of anyURI
@@ -12519,11 +13289,12 @@ def test_any_uri011_2083_any_uri011_2083_v(save_xml):
         instance="msData/datatypes/anyURI011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri010_2082_any_uri010_2082_v(save_xml):
     """
     TEST :Facet Schemas for string : value=C:/TestSuites/XSD%20Spec/CR-
@@ -12535,11 +13306,12 @@ def test_any_uri010_2082_any_uri010_2082_v(save_xml):
         instance="msData/datatypes/anyURI010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri009_2081_any_uri009_2081_v(save_xml):
     """
     TEST :Facet Schemas for string :
@@ -12552,11 +13324,12 @@ def test_any_uri009_2081_any_uri009_2081_v(save_xml):
         instance="msData/datatypes/anyURI009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri008_2080_any_uri008_2080_v(save_xml):
     """
     TEST :Facet Schemas for string : value=telnet://melvyl.ucop.edu/
@@ -12567,11 +13340,12 @@ def test_any_uri008_2080_any_uri008_2080_v(save_xml):
         instance="msData/datatypes/anyURI008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri007_2079_any_uri007_2079_v(save_xml):
     """
     TEST :Facet Schemas for string :
@@ -12583,11 +13357,12 @@ def test_any_uri007_2079_any_uri007_2079_v(save_xml):
         instance="msData/datatypes/anyURI007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri006_2078_any_uri006_2078_v(save_xml):
     """
     TEST :Facet Schemas for string : value=gopher://spinaltap.micro.umn.ed
@@ -12599,11 +13374,12 @@ def test_any_uri006_2078_any_uri006_2078_v(save_xml):
         instance="msData/datatypes/anyURI006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri005_2077_any_uri005_2077_v(save_xml):
     """
     TEST :Facet Schemas for string :
@@ -12615,11 +13391,12 @@ def test_any_uri005_2077_any_uri005_2077_v(save_xml):
         instance="msData/datatypes/anyURI005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri004_2076_any_uri004_2076_v(save_xml):
     """
     TEST :Facet Schemas for string :
@@ -12632,11 +13409,12 @@ def test_any_uri004_2076_any_uri004_2076_v(save_xml):
         instance="msData/datatypes/anyURI004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri003_2075_any_uri003_2075_v(save_xml):
     """
     TEST :Facet Schemas for string :
@@ -12648,11 +13426,12 @@ def test_any_uri003_2075_any_uri003_2075_v(save_xml):
         instance="msData/datatypes/anyURI003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri002_2074_any_uri002_2074_v(save_xml):
     """
     TEST :Facet Schemas for string : value=mailto:davebrow@microsoft.com
@@ -12663,11 +13442,12 @@ def test_any_uri002_2074_any_uri002_2074_v(save_xml):
         instance="msData/datatypes/anyURI002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri001_2073_any_uri001_2073_v(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12678,11 +13458,12 @@ def test_any_uri001_2073_any_uri001_2073_v(save_xml):
         instance="msData/datatypes/anyURI001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary002_2072_base64_binary002_2072_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType list of
@@ -12694,11 +13475,12 @@ def test_base64_binary002_2072_base64_binary002_2072_v(save_xml):
         instance="msData/datatypes/base64Binary002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary001_2071_base64_binary001_2071_v(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12709,11 +13491,12 @@ def test_base64_binary001_2071_base64_binary001_2071_v(save_xml):
         instance="msData/datatypes/base64Binary001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary004_2070_hex_binary004_2070_i(save_xml):
     """
     TEST :Facet Schemas for string : Test for HexBinary value with
@@ -12725,11 +13508,12 @@ def test_hex_binary004_2070_hex_binary004_2070_i(save_xml):
         instance="msData/datatypes/hexBinary004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary003_2069_hex_binary003_2069_v(save_xml):
     """
     TEST :Facet Schemas for string : Test for HexBinary value with
@@ -12741,11 +13525,12 @@ def test_hex_binary003_2069_hex_binary003_2069_v(save_xml):
         instance="msData/datatypes/hexBinary003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary002_2068_hex_binary002_2068_v(save_xml):
     """
     TEST :Facet Schemas for string : test for simpleType List of hexBinary
@@ -12756,11 +13541,12 @@ def test_hex_binary002_2068_hex_binary002_2068_v(save_xml):
         instance="msData/datatypes/hexBinary002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary001_2067_hex_binary001_2067_v(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12771,11 +13557,12 @@ def test_hex_binary001_2067_hex_binary001_2067_v(save_xml):
         instance="msData/datatypes/hexBinary001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month007_2066_g_month007_2066_i(save_xml):
     """
     TEST :Facet Schemas for string : value=- -15- -
@@ -12786,11 +13573,12 @@ def test_g_month007_2066_g_month007_2066_i(save_xml):
         instance="msData/datatypes/gMonth007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month006_2065_g_month006_2065_i(save_xml):
     """
     TEST :Facet Schemas for string : value=- -3- -
@@ -12801,11 +13589,12 @@ def test_g_month006_2065_g_month006_2065_i(save_xml):
         instance="msData/datatypes/gMonth006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month005_2064_g_month005_2064_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-10
@@ -12816,11 +13605,12 @@ def test_g_month005_2064_g_month005_2064_i(save_xml):
         instance="msData/datatypes/gMonth005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month004_2063_g_month004_2063_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- -05- - -05:00
@@ -12831,11 +13621,12 @@ def test_g_month004_2063_g_month004_2063_v(save_xml):
         instance="msData/datatypes/gMonth004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month003_2062_g_month003_2062_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05- -
@@ -12846,11 +13637,12 @@ def test_g_month003_2062_g_month003_2062_i(save_xml):
         instance="msData/datatypes/gMonth003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month002_2061_g_month002_2061_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- -03- -
@@ -12861,11 +13653,12 @@ def test_g_month002_2061_g_month002_2061_v(save_xml):
         instance="msData/datatypes/gMonth002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month001_2060_g_month001_2060_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12876,11 +13669,12 @@ def test_g_month001_2060_g_month001_2060_i(save_xml):
         instance="msData/datatypes/gMonth001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day005_2059_g_day005_2059_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -12891,11 +13685,12 @@ def test_g_day005_2059_g_day005_2059_i(save_xml):
         instance="msData/datatypes/gDay005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day004_2058_g_day004_2058_i(save_xml):
     """
     TEST :Facet Schemas for string : value=- -15
@@ -12906,11 +13701,12 @@ def test_g_day004_2058_g_day004_2058_i(save_xml):
         instance="msData/datatypes/gDay004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day003_2057_g_day003_2057_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- - -15-05:00
@@ -12921,11 +13717,12 @@ def test_g_day003_2057_g_day003_2057_v(save_xml):
         instance="msData/datatypes/gDay003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day002_2056_g_day002_2056_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- - -29
@@ -12936,11 +13733,12 @@ def test_g_day002_2056_g_day002_2056_v(save_xml):
         instance="msData/datatypes/gDay002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day001_2055_g_day001_2055_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- - -15
@@ -12951,11 +13749,12 @@ def test_g_day001_2055_g_day001_2055_v(save_xml):
         instance="msData/datatypes/gDay001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day006_2054_g_month_day006_2054_i(save_xml):
     """
     TEST :Facet Schemas for string : gMonthDay should disallow "--02-30"
@@ -12967,11 +13766,12 @@ def test_g_month_day006_2054_g_month_day006_2054_i(save_xml):
         instance="msData/datatypes/gMonthDay006.xml",
         instance_is_valid=False,
         class_name="Data",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day005_2053_g_month_day005_2053_i(save_xml):
     """
     TEST :Facet Schemas for string : value=- - -03-15
@@ -12982,11 +13782,12 @@ def test_g_month_day005_2053_g_month_day005_2053_i(save_xml):
         instance="msData/datatypes/gMonthDay005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day004_2052_g_month_day004_2052_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- -02-29
@@ -12997,11 +13798,12 @@ def test_g_month_day004_2052_g_month_day004_2052_v(save_xml):
         instance="msData/datatypes/gMonthDay004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day003_2051_g_month_day003_2051_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- -03-15-05:00
@@ -13012,11 +13814,12 @@ def test_g_month_day003_2051_g_month_day003_2051_v(save_xml):
         instance="msData/datatypes/gMonthDay003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day002_2050_g_month_day002_2050_v(save_xml):
     """
     TEST :Facet Schemas for string : value=- -03-15
@@ -13027,11 +13830,12 @@ def test_g_month_day002_2050_g_month_day002_2050_v(save_xml):
         instance="msData/datatypes/gMonthDay002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day001_2049_g_month_day001_2049_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -13042,11 +13846,12 @@ def test_g_month_day001_2049_g_month_day001_2049_i(save_xml):
         instance="msData/datatypes/gMonthDay001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year006_2048_g_year006_2048_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05:00
@@ -13057,11 +13862,12 @@ def test_g_year006_2048_g_year006_2048_v(save_xml):
         instance="msData/datatypes/gYear006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year005_2047_g_year005_2047_i(save_xml):
     """
     TEST :Facet Schemas for string : value=2000-00
@@ -13072,11 +13878,12 @@ def test_g_year005_2047_g_year005_2047_i(save_xml):
         instance="msData/datatypes/gYear005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year002_2046_g_year002_2046_v(save_xml):
     """
     TEST :Facet Schemas for string : value=2000
@@ -13087,11 +13894,12 @@ def test_g_year002_2046_g_year002_2046_v(save_xml):
         instance="msData/datatypes/gYear002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year001_2045_g_year001_2045_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -13102,11 +13910,12 @@ def test_g_year001_2045_g_year001_2045_i(save_xml):
         instance="msData/datatypes/gYear001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month006_2044_g_year_month006_2044_i(save_xml):
     """
     TEST :Facet Schemas for string : value=99-10
@@ -13117,11 +13926,12 @@ def test_g_year_month006_2044_g_year_month006_2044_i(save_xml):
         instance="msData/datatypes/gYearMonth006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month004_2043_g_year_month004_2043_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-15
@@ -13132,11 +13942,12 @@ def test_g_year_month004_2043_g_year_month004_2043_i(save_xml):
         instance="msData/datatypes/gYearMonth004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month003_2042_g_year_month003_2042_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-10-05:00
@@ -13147,11 +13958,12 @@ def test_g_year_month003_2042_g_year_month003_2042_v(save_xml):
         instance="msData/datatypes/gYearMonth003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month002_2041_g_year_month002_2041_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-10
@@ -13162,11 +13974,12 @@ def test_g_year_month002_2041_g_year_month002_2041_v(save_xml):
         instance="msData/datatypes/gYearMonth002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month001_2040_g_year_month001_2040_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -13177,11 +13990,12 @@ def test_g_year_month001_2040_g_year_month001_2040_i(save_xml):
         instance="msData/datatypes/gYearMonth001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date011_2039_date011_2039_i(save_xml):
     """
     TEST :Facet Schemas for string : value=123456
@@ -13192,11 +14006,12 @@ def test_date011_2039_date011_2039_i(save_xml):
         instance="msData/datatypes/date011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date010_2038_date010_2038_v(save_xml):
     """
     TEST :Facet Schemas for string : value=2000-10-05-05:00
@@ -13207,11 +14022,12 @@ def test_date010_2038_date010_2038_v(save_xml):
         instance="msData/datatypes/date010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date009_2037_date009_2037_i(save_xml):
     """
     TEST :Facet Schemas for string : value=2000-13-14
@@ -13222,11 +14038,12 @@ def test_date009_2037_date009_2037_i(save_xml):
         instance="msData/datatypes/date009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date006_2036_date006_2036_i(save_xml):
     """
     TEST :Facet Schemas for string : value=01-01-01
@@ -13237,11 +14054,12 @@ def test_date006_2036_date006_2036_i(save_xml):
         instance="msData/datatypes/date006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date005_2035_date005_2035_v(save_xml):
     """
     TEST :Facet Schemas for string : value=2000-02-29
@@ -13252,11 +14070,12 @@ def test_date005_2035_date005_2035_v(save_xml):
         instance="msData/datatypes/date005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date004_2034_date004_2034_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-02-29
@@ -13267,11 +14086,12 @@ def test_date004_2034_date004_2034_i(save_xml):
         instance="msData/datatypes/date004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date003_2033_date003_2033_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-32
@@ -13282,11 +14102,12 @@ def test_date003_2033_date003_2033_i(save_xml):
         instance="msData/datatypes/date003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date002_2032_date002_2032_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31
@@ -13297,11 +14118,12 @@ def test_date002_2032_date002_2032_v(save_xml):
         instance="msData/datatypes/date002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date001_2031_date001_2031_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -13312,11 +14134,12 @@ def test_date001_2031_date001_2031_i(save_xml):
         instance="msData/datatypes/date001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time022_2030_time022_2030_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+13:20:00
@@ -13327,11 +14150,12 @@ def test_time022_2030_time022_2030_i(save_xml):
         instance="msData/datatypes/time022.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time021_2029_time021_2029_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-13:20:00
@@ -13342,11 +14166,12 @@ def test_time021_2029_time021_2029_i(save_xml):
         instance="msData/datatypes/time021.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time020_2028_time020_2028_i(save_xml):
     """
     TEST :Facet Schemas for string : value=0:0:00
@@ -13357,11 +14182,12 @@ def test_time020_2028_time020_2028_i(save_xml):
         instance="msData/datatypes/time020.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time019_2027_time019_2027_i(save_xml):
     """
     TEST :Facet Schemas for string : value=0:20:00
@@ -13372,11 +14198,12 @@ def test_time019_2027_time019_2027_i(save_xml):
         instance="msData/datatypes/time019.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time018_2026_time018_2026_i(save_xml):
     """
     TEST :Facet Schemas for string : value=25:20:00
@@ -13387,11 +14214,12 @@ def test_time018_2026_time018_2026_i(save_xml):
         instance="msData/datatypes/time018.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time017_2025_time017_2025_i(save_xml):
     """
     TEST :Facet Schemas for string : value=13:60:00
@@ -13402,11 +14230,12 @@ def test_time017_2025_time017_2025_i(save_xml):
         instance="msData/datatypes/time017.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time016_2024_time016_2024_i(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:60
@@ -13417,11 +14246,12 @@ def test_time016_2024_time016_2024_i(save_xml):
         instance="msData/datatypes/time016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time015_2023_time015_2023_i(save_xml):
     """
     TEST :Facet Schemas for string : value=13.4:20:00
@@ -13432,11 +14262,12 @@ def test_time015_2023_time015_2023_i(save_xml):
         instance="msData/datatypes/time015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time014_2022_time014_2022_i(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20.4:00
@@ -13447,11 +14278,12 @@ def test_time014_2022_time014_2022_i(save_xml):
         instance="msData/datatypes/time014.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time013_2021_time013_2021_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00.34
@@ -13462,11 +14294,12 @@ def test_time013_2021_time013_2021_v(save_xml):
         instance="msData/datatypes/time013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time012_2020_time012_2020_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00
@@ -13477,11 +14310,12 @@ def test_time012_2020_time012_2020_v(save_xml):
         instance="msData/datatypes/time012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time011_2019_time011_2019_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00Z
@@ -13492,11 +14326,12 @@ def test_time011_2019_time011_2019_v(save_xml):
         instance="msData/datatypes/time011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time009_2018_time009_2018_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00+05:59
@@ -13507,11 +14342,12 @@ def test_time009_2018_time009_2018_v(save_xml):
         instance="msData/datatypes/time009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time008_2017_time008_2017_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00-05:59
@@ -13522,11 +14358,12 @@ def test_time008_2017_time008_2017_v(save_xml):
         instance="msData/datatypes/time008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time007_2016_time007_2016_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00+05:00
@@ -13537,11 +14374,12 @@ def test_time007_2016_time007_2016_v(save_xml):
         instance="msData/datatypes/time007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time006_2015_time006_2015_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00-05:00
@@ -13552,11 +14390,12 @@ def test_time006_2015_time006_2015_v(save_xml):
         instance="msData/datatypes/time006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time005_2014_time005_2014_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00+05:00
@@ -13567,11 +14406,12 @@ def test_time005_2014_time005_2014_v(save_xml):
         instance="msData/datatypes/time005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time004_2013_time004_2013_v(save_xml):
     """
     TEST :Facet Schemas for string : value=13:20:00-05:00
@@ -13582,11 +14422,12 @@ def test_time004_2013_time004_2013_v(save_xml):
         instance="msData/datatypes/time004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time003_2012_time003_2012_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1985-04-12T10:30
@@ -13597,11 +14438,12 @@ def test_time003_2012_time003_2012_i(save_xml):
         instance="msData/datatypes/time003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time002_2011_time002_2011_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00-05:00
@@ -13612,11 +14454,12 @@ def test_time002_2011_time002_2011_i(save_xml):
         instance="msData/datatypes/time002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time001_2010_time001_2010_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -13627,11 +14470,12 @@ def test_time001_2010_time001_2010_i(save_xml):
         instance="msData/datatypes/time001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time013_2009_date_time013_2009_i(save_xml):
     """
     TEST :Facet Schemas for string : should we allow '+'(plus sign)
@@ -13643,11 +14487,12 @@ def test_date_time013_2009_date_time013_2009_i(save_xml):
         instance="msData/datatypes/dateTime013.xml",
         instance_is_valid=False,
         class_name="Data",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time011_2008_date_time011_2008_i(save_xml):
     """
     TEST :Facet Schemas for string : value=0000-01-01T00:00:00 Year zero
@@ -13659,11 +14504,12 @@ def test_date_time011_2008_date_time011_2008_i(save_xml):
         instance="msData/datatypes/dateTime011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time010_2007_date_time010_2007_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00Z
@@ -13674,11 +14520,12 @@ def test_date_time010_2007_date_time010_2007_v(save_xml):
         instance="msData/datatypes/dateTime010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time008_2006_date_time008_2006_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00-5:45
@@ -13689,11 +14536,12 @@ def test_date_time008_2006_date_time008_2006_v(save_xml):
         instance="msData/datatypes/dateTime008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time007_2005_date_time007_2005_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00+5:45
@@ -13704,11 +14552,12 @@ def test_date_time007_2005_date_time007_2005_v(save_xml):
         instance="msData/datatypes/dateTime007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time006_2004_date_time006_2004_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00+05:00
@@ -13719,11 +14568,12 @@ def test_date_time006_2004_date_time006_2004_v(save_xml):
         instance="msData/datatypes/dateTime006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time005_2003_date_time005_2003_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00-05:00
@@ -13734,11 +14584,12 @@ def test_date_time005_2003_date_time005_2003_v(save_xml):
         instance="msData/datatypes/dateTime005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time004_2002_date_time004_2002_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1985-102T23:50:30
@@ -13749,11 +14600,12 @@ def test_date_time004_2002_date_time004_2002_i(save_xml):
         instance="msData/datatypes/dateTime004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time003_2001_date_time003_2001_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1985-04-12T10:30:00
@@ -13764,11 +14616,12 @@ def test_date_time003_2001_date_time003_2001_v(save_xml):
         instance="msData/datatypes/dateTime003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time002_2000_date_time002_2000_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1999-05-31T13:20:00-05:00
@@ -13779,11 +14632,12 @@ def test_date_time002_2000_date_time002_2000_v(save_xml):
         instance="msData/datatypes/dateTime002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time001_1999_date_time001_1999_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -13794,11 +14648,12 @@ def test_date_time001_1999_date_time001_1999_i(save_xml):
         instance="msData/datatypes/dateTime001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration030_1998_duration030_1998_i(save_xml):
     """
     TEST :Facet Schemas for string : For duration, the number and its
@@ -13810,11 +14665,12 @@ def test_duration030_1998_duration030_1998_i(save_xml):
         instance="msData/datatypes/duration030.xml",
         instance_is_valid=False,
         class_name="Data",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration029_1997_duration029_1997_i(save_xml):
     """
     TEST :Facet Schemas for string : For duration, the designator 'T'
@@ -13826,11 +14682,12 @@ def test_duration029_1997_duration029_1997_i(save_xml):
         instance="msData/datatypes/duration029.xml",
         instance_is_valid=False,
         class_name="Data",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration028_1996_duration028_1996_i(save_xml):
     """
     TEST :Facet Schemas for string : string 'P' for duration should raise
@@ -13842,11 +14699,12 @@ def test_duration028_1996_duration028_1996_i(save_xml):
         instance="msData/datatypes/duration028.xml",
         instance_is_valid=False,
         class_name="Data",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration027_1995_duration027_1995_v(save_xml):
     """
     TEST :Facet Schemas for string : Test for simpleType of duration
@@ -13857,11 +14715,12 @@ def test_duration027_1995_duration027_1995_v(save_xml):
         instance="msData/datatypes/duration027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration026_1994_duration026_1994_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P2000Y2M29DT10H30M
@@ -13872,11 +14731,12 @@ def test_duration026_1994_duration026_1994_v(save_xml):
         instance="msData/datatypes/duration026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration025_1993_duration025_1993_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y2M15DT11H60M
@@ -13887,11 +14747,12 @@ def test_duration025_1993_duration025_1993_v(save_xml):
         instance="msData/datatypes/duration025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration024_1992_duration024_1992_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y2M15DT25H30M
@@ -13902,11 +14763,12 @@ def test_duration024_1992_duration024_1992_v(save_xml):
         instance="msData/datatypes/duration024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration023_1991_duration023_1991_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y2M32DT12H30M
@@ -13917,11 +14779,12 @@ def test_duration023_1991_duration023_1991_v(save_xml):
         instance="msData/datatypes/duration023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration022_1990_duration022_1990_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y13M15DT12H30M
@@ -13932,11 +14795,12 @@ def test_duration022_1990_duration022_1990_v(save_xml):
         instance="msData/datatypes/duration022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration021_1989_duration021_1989_i(save_xml):
     """
     TEST :Facet Schemas for string : value=P0Y0M0DT0H-0M0.0001S
@@ -13947,11 +14811,12 @@ def test_duration021_1989_duration021_1989_i(save_xml):
         instance="msData/datatypes/duration021.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration020_1988_duration020_1988_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P0Y0M0DT0H0M0.0001S
@@ -13962,11 +14827,12 @@ def test_duration020_1988_duration020_1988_v(save_xml):
         instance="msData/datatypes/duration020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration019_1987_duration019_1987_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P0Y0M0D
@@ -13977,11 +14843,12 @@ def test_duration019_1987_duration019_1987_v(save_xml):
         instance="msData/datatypes/duration019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration018_1986_duration018_1986_v(save_xml):
     """
     TEST :Facet Schemas for string : value=PT31S
@@ -13992,11 +14859,12 @@ def test_duration018_1986_duration018_1986_v(save_xml):
         instance="msData/datatypes/duration018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration017_1985_duration017_1985_v(save_xml):
     """
     TEST :Facet Schemas for string : value=PT31M
@@ -14007,11 +14875,12 @@ def test_duration017_1985_duration017_1985_v(save_xml):
         instance="msData/datatypes/duration017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration016_1984_duration016_1984_v(save_xml):
     """
     TEST :Facet Schemas for string : value=PT31H
@@ -14022,11 +14891,12 @@ def test_duration016_1984_duration016_1984_v(save_xml):
         instance="msData/datatypes/duration016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration015_1983_duration015_1983_i(save_xml):
     """
     TEST :Facet Schemas for string : value=T312H
@@ -14037,11 +14907,12 @@ def test_duration015_1983_duration015_1983_i(save_xml):
         instance="msData/datatypes/duration015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration014_1982_duration014_1982_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P0Y0M3D
@@ -14052,11 +14923,12 @@ def test_duration014_1982_duration014_1982_v(save_xml):
         instance="msData/datatypes/duration014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration013_1981_duration013_1981_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1234Y
@@ -14067,11 +14939,12 @@ def test_duration013_1981_duration013_1981_i(save_xml):
         instance="msData/datatypes/duration013.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration012_1980_duration012_1980_v(save_xml):
     """
     TEST :Facet Schemas for string : value=PT2153.5S
@@ -14082,11 +14955,12 @@ def test_duration012_1980_duration012_1980_v(save_xml):
         instance="msData/datatypes/duration012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration011_1979_duration011_1979_i(save_xml):
     """
     TEST :Facet Schemas for string : value=P200.5Y
@@ -14097,11 +14971,12 @@ def test_duration011_1979_duration011_1979_i(save_xml):
         instance="msData/datatypes/duration011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration010_1978_duration010_1978_i(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y2MT
@@ -14112,11 +14987,12 @@ def test_duration010_1978_duration010_1978_i(save_xml):
         instance="msData/datatypes/duration010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration009_1977_duration009_1977_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-P1347M
@@ -14127,11 +15003,12 @@ def test_duration009_1977_duration009_1977_v(save_xml):
         instance="msData/datatypes/duration009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration008_1976_duration008_1976_i(save_xml):
     """
     TEST :Facet Schemas for string : value=P-1347M
@@ -14142,11 +15019,12 @@ def test_duration008_1976_duration008_1976_i(save_xml):
         instance="msData/datatypes/duration008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration007_1975_duration007_1975_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P0Y1347M0D
@@ -14157,11 +15035,12 @@ def test_duration007_1975_duration007_1975_v(save_xml):
         instance="msData/datatypes/duration007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration006_1974_duration006_1974_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P0Y1347M
@@ -14172,11 +15051,12 @@ def test_duration006_1974_duration006_1974_v(save_xml):
         instance="msData/datatypes/duration006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration005_1973_duration005_1973_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y2MT2H
@@ -14187,11 +15067,12 @@ def test_duration005_1973_duration005_1973_v(save_xml):
         instance="msData/datatypes/duration005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration004_1972_duration004_1972_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1347M
@@ -14202,11 +15083,12 @@ def test_duration004_1972_duration004_1972_v(save_xml):
         instance="msData/datatypes/duration004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration003_1971_duration003_1971_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1347Y
@@ -14217,11 +15099,12 @@ def test_duration003_1971_duration003_1971_v(save_xml):
         instance="msData/datatypes/duration003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration002_1970_duration002_1970_v(save_xml):
     """
     TEST :Facet Schemas for string : value=P1Y2M3DT10H30M
@@ -14232,11 +15115,12 @@ def test_duration002_1970_duration002_1970_v(save_xml):
         instance="msData/datatypes/duration002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration001_1969_duration001_1969_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -14247,11 +15131,12 @@ def test_duration001_1969_duration001_1969_i(save_xml):
         instance="msData/datatypes/duration001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double030_1968_double030_1968_v(save_xml):
     """
     TEST :Facet Schemas for string : all valid double values
@@ -14262,11 +15147,12 @@ def test_double030_1968_double030_1968_v(save_xml):
         instance="msData/datatypes/double030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double029_1967_double029_1967_i(save_xml):
     """
     TEST :Facet Schemas for string : value=ABCDEF
@@ -14277,11 +15163,12 @@ def test_double029_1967_double029_1967_i(save_xml):
         instance="msData/datatypes/double029.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double028_1966_double028_1966_v(save_xml):
     """
     TEST :Facet Schemas for string : value=2.22e-308
@@ -14292,11 +15179,12 @@ def test_double028_1966_double028_1966_v(save_xml):
         instance="msData/datatypes/double028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double027_1965_double027_1965_v(save_xml):
     """
     TEST :Facet Schemas for string : value=8.98e307
@@ -14307,11 +15195,12 @@ def test_double027_1965_double027_1965_v(save_xml):
         instance="msData/datatypes/double027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double026_1964_double026_1964_i(save_xml):
     """
     TEST :Facet Schemas for string : value=NAN
@@ -14322,11 +15211,12 @@ def test_double026_1964_double026_1964_i(save_xml):
         instance="msData/datatypes/double026.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double025_1963_double025_1963_i(save_xml):
     """
     TEST :Facet Schemas for string : value=nan
@@ -14337,11 +15227,12 @@ def test_double025_1963_double025_1963_i(save_xml):
         instance="msData/datatypes/double025.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double024_1962_double024_1962_i(save_xml):
     """
     TEST :Facet Schemas for string : value=inf
@@ -14352,11 +15243,12 @@ def test_double024_1962_double024_1962_i(save_xml):
         instance="msData/datatypes/double024.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double023_1961_double023_1961_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-NaN
@@ -14367,11 +15259,12 @@ def test_double023_1961_double023_1961_i(save_xml):
         instance="msData/datatypes/double023.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double022_1960_double022_1960_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+NaN
@@ -14382,11 +15275,12 @@ def test_double022_1960_double022_1960_i(save_xml):
         instance="msData/datatypes/double022.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double021_1959_double021_1959_v(save_xml):
     """
     TEST :Facet Schemas for string : value=NaN
@@ -14397,11 +15291,12 @@ def test_double021_1959_double021_1959_v(save_xml):
         instance="msData/datatypes/double021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double020_1958_double020_1958_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-INF
@@ -14412,11 +15307,12 @@ def test_double020_1958_double020_1958_v(save_xml):
         instance="msData/datatypes/double020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double019_1957_double019_1957_v(save_xml):
     """
     TEST :Facet Schemas for string : value=INF
@@ -14427,11 +15323,12 @@ def test_double019_1957_double019_1957_v(save_xml):
         instance="msData/datatypes/double019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double018_1956_double018_1956_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+INF Becomes valid in XSD 1.1 -
@@ -14443,11 +15340,12 @@ def test_double018_1956_double018_1956_i(save_xml):
         instance="msData/datatypes/double018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double017_1955_double017_1955_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1E4
@@ -14458,11 +15356,12 @@ def test_double017_1955_double017_1955_v(save_xml):
         instance="msData/datatypes/double017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double016_1954_double016_1954_i(save_xml):
     """
     TEST :Facet Schemas for string : value=E
@@ -14473,11 +15372,12 @@ def test_double016_1954_double016_1954_i(save_xml):
         instance="msData/datatypes/double016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double015_1953_double015_1953_i(save_xml):
     """
     TEST :Facet Schemas for string : value=e
@@ -14488,11 +15388,12 @@ def test_double015_1953_double015_1953_i(save_xml):
         instance="msData/datatypes/double015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double014_1952_double014_1952_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -14503,11 +15404,12 @@ def test_double014_1952_double014_1952_v(save_xml):
         instance="msData/datatypes/double014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double013_1951_double013_1951_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -14518,11 +15420,12 @@ def test_double013_1951_double013_1951_v(save_xml):
         instance="msData/datatypes/double013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double012_1950_double012_1950_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -14533,11 +15436,12 @@ def test_double012_1950_double012_1950_v(save_xml):
         instance="msData/datatypes/double012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double011_1949_double011_1949_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1.0
@@ -14548,11 +15452,12 @@ def test_double011_1949_double011_1949_v(save_xml):
         instance="msData/datatypes/double011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double010_1948_double010_1948_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0.0
@@ -14563,11 +15468,12 @@ def test_double010_1948_double010_1948_v(save_xml):
         instance="msData/datatypes/double010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double009_1947_double009_1947_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0.0
@@ -14578,11 +15484,12 @@ def test_double009_1947_double009_1947_v(save_xml):
         instance="msData/datatypes/double009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double008_1946_double008_1946_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0
@@ -14593,11 +15500,12 @@ def test_double008_1946_double008_1946_v(save_xml):
         instance="msData/datatypes/double008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double007_1945_double007_1945_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0
@@ -14608,11 +15516,12 @@ def test_double007_1945_double007_1945_v(save_xml):
         instance="msData/datatypes/double007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double006_1944_double006_1944_v(save_xml):
     """
     TEST :Facet Schemas for string : value=3.14159
@@ -14623,11 +15532,12 @@ def test_double006_1944_double006_1944_v(save_xml):
         instance="msData/datatypes/double006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double005_1943_double005_1943_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-3.14159
@@ -14638,11 +15548,12 @@ def test_double005_1943_double005_1943_v(save_xml):
         instance="msData/datatypes/double005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double004_1942_double004_1942_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1e2
@@ -14653,11 +15564,12 @@ def test_double004_1942_double004_1942_v(save_xml):
         instance="msData/datatypes/double004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double003_1941_double003_1941_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1E2
@@ -14668,11 +15580,12 @@ def test_double003_1941_double003_1941_v(save_xml):
         instance="msData/datatypes/double003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double002_1940_double002_1940_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1.0
@@ -14683,11 +15596,12 @@ def test_double002_1940_double002_1940_v(save_xml):
         instance="msData/datatypes/double002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double001_1939_double001_1939_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -14698,11 +15612,12 @@ def test_double001_1939_double001_1939_i(save_xml):
         instance="msData/datatypes/double001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float039_1938_float039_1938_v(save_xml):
     """
     TEST :Facet Schemas for string : all valid float values
@@ -14713,11 +15628,12 @@ def test_float039_1938_float039_1938_v(save_xml):
         instance="msData/datatypes/float039.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float038_1937_float038_1937_v(save_xml):
     """
     TEST :Facet Schemas for string : Test for simpleType of float
@@ -14728,11 +15644,12 @@ def test_float038_1937_float038_1937_v(save_xml):
         instance="msData/datatypes/float038.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float037_1936_float037_1936_i(save_xml):
     """
     TEST :Facet Schemas for string : value=ABCDEF
@@ -14743,11 +15660,12 @@ def test_float037_1936_float037_1936_i(save_xml):
         instance="msData/datatypes/float037.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float036_1935_float036_1935_i(save_xml):
     """
     TEST :Facet Schemas for string : value=13.1513.561
@@ -14758,11 +15676,12 @@ def test_float036_1935_float036_1935_i(save_xml):
         instance="msData/datatypes/float036.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float035_1934_float035_1934_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1E4.4
@@ -14773,11 +15692,12 @@ def test_float035_1934_float035_1934_i(save_xml):
         instance="msData/datatypes/float035.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float034_1933_float034_1933_v(save_xml):
     """
     TEST :Facet Schemas for string : value=00.00
@@ -14788,11 +15708,12 @@ def test_float034_1933_float034_1933_v(save_xml):
         instance="msData/datatypes/float034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float033_1932_float033_1932_v(save_xml):
     """
     TEST :Facet Schemas for string : value=021.22
@@ -14803,11 +15724,12 @@ def test_float033_1932_float033_1932_v(save_xml):
         instance="msData/datatypes/float033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float032_1931_float032_1931_v(save_xml):
     """
     TEST :Facet Schemas for string : value=00.121
@@ -14818,11 +15740,12 @@ def test_float032_1931_float032_1931_v(save_xml):
         instance="msData/datatypes/float032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float031_1930_float031_1930_v(save_xml):
     """
     TEST :Facet Schemas for string : value=3.4e38
@@ -14833,11 +15756,12 @@ def test_float031_1930_float031_1930_v(save_xml):
         instance="msData/datatypes/float031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float030_1929_float030_1929_v(save_xml):
     """
     TEST :Facet Schemas for string : value=2.3e-38
@@ -14848,11 +15772,12 @@ def test_float030_1929_float030_1929_v(save_xml):
         instance="msData/datatypes/float030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float029_1928_float029_1928_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12.78E-2
@@ -14863,11 +15788,12 @@ def test_float029_1928_float029_1928_v(save_xml):
         instance="msData/datatypes/float029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float028_1927_float028_1927_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1267.43233E12
@@ -14878,11 +15804,12 @@ def test_float028_1927_float028_1927_v(save_xml):
         instance="msData/datatypes/float028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float027_1926_float027_1926_i(save_xml):
     """
     TEST :Facet Schemas for string : value=1267.432x10
@@ -14893,11 +15820,12 @@ def test_float027_1926_float027_1926_i(save_xml):
         instance="msData/datatypes/float027.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float026_1925_float026_1925_i(save_xml):
     """
     TEST :Facet Schemas for string : value=NAN
@@ -14908,11 +15836,12 @@ def test_float026_1925_float026_1925_i(save_xml):
         instance="msData/datatypes/float026.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float025_1924_float025_1924_i(save_xml):
     """
     TEST :Facet Schemas for string : value=nan
@@ -14923,11 +15852,12 @@ def test_float025_1924_float025_1924_i(save_xml):
         instance="msData/datatypes/float025.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float024_1923_float024_1923_i(save_xml):
     """
     TEST :Facet Schemas for string : value=inf
@@ -14938,11 +15868,12 @@ def test_float024_1923_float024_1923_i(save_xml):
         instance="msData/datatypes/float024.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float023_1922_float023_1922_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-NaN
@@ -14953,11 +15884,12 @@ def test_float023_1922_float023_1922_i(save_xml):
         instance="msData/datatypes/float023.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float022_1921_float022_1921_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+NaN
@@ -14968,11 +15900,12 @@ def test_float022_1921_float022_1921_i(save_xml):
         instance="msData/datatypes/float022.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float021_1920_float021_1920_v(save_xml):
     """
     TEST :Facet Schemas for string : value=NaN
@@ -14983,11 +15916,12 @@ def test_float021_1920_float021_1920_v(save_xml):
         instance="msData/datatypes/float021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float020_1919_float020_1919_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-INF
@@ -14998,11 +15932,12 @@ def test_float020_1919_float020_1919_v(save_xml):
         instance="msData/datatypes/float020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float019_1918_float019_1918_v(save_xml):
     """
     TEST :Facet Schemas for string : value=INF
@@ -15013,11 +15948,12 @@ def test_float019_1918_float019_1918_v(save_xml):
         instance="msData/datatypes/float019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float018_1917_float018_1917_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+INF Becomes valid in XSD 1.1 -
@@ -15029,11 +15965,12 @@ def test_float018_1917_float018_1917_i(save_xml):
         instance="msData/datatypes/float018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float017_1916_float017_1916_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1E4
@@ -15044,11 +15981,12 @@ def test_float017_1916_float017_1916_v(save_xml):
         instance="msData/datatypes/float017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float016_1915_float016_1915_i(save_xml):
     """
     TEST :Facet Schemas for string : value=E
@@ -15059,11 +15997,12 @@ def test_float016_1915_float016_1915_i(save_xml):
         instance="msData/datatypes/float016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float015_1914_float015_1914_i(save_xml):
     """
     TEST :Facet Schemas for string : value=e
@@ -15074,11 +16013,12 @@ def test_float015_1914_float015_1914_i(save_xml):
         instance="msData/datatypes/float015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float014_1913_float014_1913_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -15089,11 +16029,12 @@ def test_float014_1913_float014_1913_v(save_xml):
         instance="msData/datatypes/float014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float013_1912_float013_1912_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -15104,11 +16045,12 @@ def test_float013_1912_float013_1912_v(save_xml):
         instance="msData/datatypes/float013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float012_1911_float012_1911_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -15119,11 +16061,12 @@ def test_float012_1911_float012_1911_v(save_xml):
         instance="msData/datatypes/float012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float011_1910_float011_1910_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1.0
@@ -15134,11 +16077,12 @@ def test_float011_1910_float011_1910_v(save_xml):
         instance="msData/datatypes/float011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float010_1909_float010_1909_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0.0
@@ -15149,11 +16093,12 @@ def test_float010_1909_float010_1909_v(save_xml):
         instance="msData/datatypes/float010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float009_1908_float009_1908_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0.0
@@ -15164,11 +16109,12 @@ def test_float009_1908_float009_1908_v(save_xml):
         instance="msData/datatypes/float009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float008_1907_float008_1907_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0
@@ -15179,11 +16125,12 @@ def test_float008_1907_float008_1907_v(save_xml):
         instance="msData/datatypes/float008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float007_1906_float007_1906_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0
@@ -15194,11 +16141,12 @@ def test_float007_1906_float007_1906_v(save_xml):
         instance="msData/datatypes/float007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float006_1905_float006_1905_v(save_xml):
     """
     TEST :Facet Schemas for string : value=3.14159
@@ -15209,11 +16157,12 @@ def test_float006_1905_float006_1905_v(save_xml):
         instance="msData/datatypes/float006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float005_1904_float005_1904_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-3.14159
@@ -15224,11 +16173,12 @@ def test_float005_1904_float005_1904_v(save_xml):
         instance="msData/datatypes/float005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float004_1903_float004_1903_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1e2
@@ -15239,11 +16189,12 @@ def test_float004_1903_float004_1903_v(save_xml):
         instance="msData/datatypes/float004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float003_1902_float003_1902_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1E2
@@ -15254,11 +16205,12 @@ def test_float003_1902_float003_1902_v(save_xml):
         instance="msData/datatypes/float003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float002_1901_float002_1901_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1.0
@@ -15269,11 +16221,12 @@ def test_float002_1901_float002_1901_v(save_xml):
         instance="msData/datatypes/float002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float001_1900_float001_1900_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -15284,11 +16237,12 @@ def test_float001_1900_float001_1900_i(save_xml):
         instance="msData/datatypes/float001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal025_1899_decimal025_1899_i(save_xml):
     """
     TEST :Facet Schemas for string : value=123.456E4
@@ -15299,11 +16253,12 @@ def test_decimal025_1899_decimal025_1899_i(save_xml):
         instance="msData/datatypes/decimal025.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal024_1898_decimal024_1898_i(save_xml):
     """
     TEST :Facet Schemas for string : value=ABCDEF
@@ -15314,11 +16269,12 @@ def test_decimal024_1898_decimal024_1898_i(save_xml):
         instance="msData/datatypes/decimal024.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal023_1897_decimal023_1897_i(save_xml):
     """
     TEST :Facet Schemas for string : value=13.1513.561
@@ -15329,11 +16285,12 @@ def test_decimal023_1897_decimal023_1897_i(save_xml):
         instance="msData/datatypes/decimal023.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal022_1896_decimal022_1896_i(save_xml):
     """
     TEST :Facet Schemas for string : value=NaN
@@ -15344,11 +16301,12 @@ def test_decimal022_1896_decimal022_1896_i(save_xml):
         instance="msData/datatypes/decimal022.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal021_1895_decimal021_1895_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-INF
@@ -15359,11 +16317,12 @@ def test_decimal021_1895_decimal021_1895_i(save_xml):
         instance="msData/datatypes/decimal021.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal020_1894_decimal020_1894_i(save_xml):
     """
     TEST :Facet Schemas for string : value=INF
@@ -15374,11 +16333,12 @@ def test_decimal020_1894_decimal020_1894_i(save_xml):
         instance="msData/datatypes/decimal020.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal019_1893_decimal019_1893_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1E4
@@ -15389,11 +16349,12 @@ def test_decimal019_1893_decimal019_1893_i(save_xml):
         instance="msData/datatypes/decimal019.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal018_1892_decimal018_1892_i(save_xml):
     """
     TEST :Facet Schemas for string : value=E
@@ -15404,11 +16365,12 @@ def test_decimal018_1892_decimal018_1892_i(save_xml):
         instance="msData/datatypes/decimal018.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal017_1891_decimal017_1891_i(save_xml):
     """
     TEST :Facet Schemas for string : value=e
@@ -15419,11 +16381,12 @@ def test_decimal017_1891_decimal017_1891_i(save_xml):
         instance="msData/datatypes/decimal017.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal016_1890_decimal016_1890_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12345678901234567890123456789
@@ -15434,11 +16397,12 @@ def test_decimal016_1890_decimal016_1890_v(save_xml):
         instance="msData/datatypes/decimal016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal015_1889_decimal015_1889_v(save_xml):
     """
     TEST :Facet Schemas for string : value=9876543210987654321098765432
@@ -15449,11 +16413,12 @@ def test_decimal015_1889_decimal015_1889_v(save_xml):
         instance="msData/datatypes/decimal015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal014_1888_decimal014_1888_v(save_xml):
     """
     TEST :Facet Schemas for string : value=987654321098765432
@@ -15464,11 +16429,12 @@ def test_decimal014_1888_decimal014_1888_v(save_xml):
         instance="msData/datatypes/decimal014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal013_1887_decimal013_1887_v(save_xml):
     """
     TEST :Facet Schemas for string : value=100000.00
@@ -15479,11 +16445,12 @@ def test_decimal013_1887_decimal013_1887_v(save_xml):
         instance="msData/datatypes/decimal013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal012_1886_decimal012_1886_v(save_xml):
     """
     TEST :Facet Schemas for string : value=12678967.543233
@@ -15494,11 +16461,12 @@ def test_decimal012_1886_decimal012_1886_v(save_xml):
         instance="msData/datatypes/decimal012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal011_1885_decimal011_1885_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -15509,11 +16477,12 @@ def test_decimal011_1885_decimal011_1885_v(save_xml):
         instance="msData/datatypes/decimal011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal010_1884_decimal010_1884_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -15524,11 +16493,12 @@ def test_decimal010_1884_decimal010_1884_v(save_xml):
         instance="msData/datatypes/decimal010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal009_1883_decimal009_1883_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -15539,11 +16509,12 @@ def test_decimal009_1883_decimal009_1883_v(save_xml):
         instance="msData/datatypes/decimal009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal008_1882_decimal008_1882_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-1.0
@@ -15554,11 +16525,12 @@ def test_decimal008_1882_decimal008_1882_v(save_xml):
         instance="msData/datatypes/decimal008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal007_1881_decimal007_1881_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0.0
@@ -15569,11 +16541,12 @@ def test_decimal007_1881_decimal007_1881_v(save_xml):
         instance="msData/datatypes/decimal007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal006_1880_decimal006_1880_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0.0
@@ -15584,11 +16557,12 @@ def test_decimal006_1880_decimal006_1880_v(save_xml):
         instance="msData/datatypes/decimal006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal005_1879_decimal005_1879_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-0
@@ -15599,11 +16573,12 @@ def test_decimal005_1879_decimal005_1879_v(save_xml):
         instance="msData/datatypes/decimal005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal004_1878_decimal004_1878_v(save_xml):
     """
     TEST :Facet Schemas for string : value=+0
@@ -15614,11 +16589,12 @@ def test_decimal004_1878_decimal004_1878_v(save_xml):
         instance="msData/datatypes/decimal004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal003_1877_decimal003_1877_v(save_xml):
     """
     TEST :Facet Schemas for string : value=3.14159
@@ -15629,11 +16605,12 @@ def test_decimal003_1877_decimal003_1877_v(save_xml):
         instance="msData/datatypes/decimal003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal002_1876_decimal002_1876_v(save_xml):
     """
     TEST :Facet Schemas for string : value=-3.14159
@@ -15644,11 +16621,12 @@ def test_decimal002_1876_decimal002_1876_v(save_xml):
         instance="msData/datatypes/decimal002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal001_1875_decimal001_1875_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -15659,11 +16637,12 @@ def test_decimal001_1875_decimal001_1875_i(save_xml):
         instance="msData/datatypes/decimal001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean018_1874_boolean018_1874_v(save_xml):
     """
     TEST :Facet Schemas for string : Test simpleType list with boolean
@@ -15674,11 +16653,12 @@ def test_boolean018_1874_boolean018_1874_v(save_xml):
         instance="msData/datatypes/boolean018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean017_1873_boolean017_1873_i(save_xml):
     """
     TEST :Facet Schemas for string : value=F
@@ -15689,11 +16669,12 @@ def test_boolean017_1873_boolean017_1873_i(save_xml):
         instance="msData/datatypes/boolean017.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean016_1872_boolean016_1872_i(save_xml):
     """
     TEST :Facet Schemas for string : value=T
@@ -15704,11 +16685,12 @@ def test_boolean016_1872_boolean016_1872_i(save_xml):
         instance="msData/datatypes/boolean016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean015_1871_boolean015_1871_i(save_xml):
     """
     TEST :Facet Schemas for string : value=f
@@ -15719,11 +16701,12 @@ def test_boolean015_1871_boolean015_1871_i(save_xml):
         instance="msData/datatypes/boolean015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean014_1870_boolean014_1870_i(save_xml):
     """
     TEST :Facet Schemas for string : value=t
@@ -15734,11 +16717,12 @@ def test_boolean014_1870_boolean014_1870_i(save_xml):
         instance="msData/datatypes/boolean014.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean013_1869_boolean013_1869_i(save_xml):
     """
     TEST :Facet Schemas for string : value=FALSE
@@ -15749,11 +16733,12 @@ def test_boolean013_1869_boolean013_1869_i(save_xml):
         instance="msData/datatypes/boolean013.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean012_1868_boolean012_1868_i(save_xml):
     """
     TEST :Facet Schemas for string : value=TRUE
@@ -15764,11 +16749,12 @@ def test_boolean012_1868_boolean012_1868_i(save_xml):
         instance="msData/datatypes/boolean012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean011_1867_boolean011_1867_i(save_xml):
     """
     TEST :Facet Schemas for string : value=True
@@ -15779,11 +16765,12 @@ def test_boolean011_1867_boolean011_1867_i(save_xml):
         instance="msData/datatypes/boolean011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean010_1866_boolean010_1866_i(save_xml):
     """
     TEST :Facet Schemas for string : value=False
@@ -15794,11 +16781,12 @@ def test_boolean010_1866_boolean010_1866_i(save_xml):
         instance="msData/datatypes/boolean010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean009_1865_boolean009_1865_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+0
@@ -15809,11 +16797,12 @@ def test_boolean009_1865_boolean009_1865_i(save_xml):
         instance="msData/datatypes/boolean009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean008_1864_boolean008_1864_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-0
@@ -15824,11 +16813,12 @@ def test_boolean008_1864_boolean008_1864_i(save_xml):
         instance="msData/datatypes/boolean008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean007_1863_boolean007_1863_i(save_xml):
     """
     TEST :Facet Schemas for string : value=-1
@@ -15839,11 +16829,12 @@ def test_boolean007_1863_boolean007_1863_i(save_xml):
         instance="msData/datatypes/boolean007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean006_1862_boolean006_1862_i(save_xml):
     """
     TEST :Facet Schemas for string : value=+1
@@ -15854,11 +16845,12 @@ def test_boolean006_1862_boolean006_1862_i(save_xml):
         instance="msData/datatypes/boolean006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean005_1861_boolean005_1861_v(save_xml):
     """
     TEST :Facet Schemas for string : value=0
@@ -15869,11 +16861,12 @@ def test_boolean005_1861_boolean005_1861_v(save_xml):
         instance="msData/datatypes/boolean005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean004_1860_boolean004_1860_v(save_xml):
     """
     TEST :Facet Schemas for string : value=false
@@ -15884,11 +16877,12 @@ def test_boolean004_1860_boolean004_1860_v(save_xml):
         instance="msData/datatypes/boolean004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean003_1859_boolean003_1859_v(save_xml):
     """
     TEST :Facet Schemas for string : value=1
@@ -15899,11 +16893,12 @@ def test_boolean003_1859_boolean003_1859_v(save_xml):
         instance="msData/datatypes/boolean003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean002_1858_boolean002_1858_v(save_xml):
     """
     TEST :Facet Schemas for string : value=true
@@ -15914,11 +16909,12 @@ def test_boolean002_1858_boolean002_1858_v(save_xml):
         instance="msData/datatypes/boolean002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_boolean001_1857_boolean001_1857_i(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -15929,11 +16925,12 @@ def test_boolean001_1857_boolean001_1857_i(save_xml):
         instance="msData/datatypes/boolean001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string006_1856_string006_1856_v(save_xml):
     """
     TEST :Facet Schemas for string : value=BaseChar ::= [#x0041-#x005A] |
@@ -15960,6 +16957,6 @@ def test_string006_1856_string006_1856_v(save_xml):
         instance="msData/datatypes/string006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_ms_meta_2000.py
+++ b/tests/test_ms_meta_2000.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_string005_1855_string005_1855_v(save_xml):
     """
     TEST :Facet Schemas for string : value=#x20 | #xD | #xA | [a-zA-Z0-9]
@@ -14,11 +15,12 @@ def test_string005_1855_string005_1855_v(save_xml):
         instance="msData/datatypes/string005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string004_1854_string004_1854_v(save_xml):
     """
     TEST :Facet Schemas for string : value=sdflhksdgh;let vm'peoaivm'weiv'
@@ -29,11 +31,12 @@ def test_string004_1854_string004_1854_v(save_xml):
         instance="msData/datatypes/string004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string003_1853_string003_1853_v(save_xml):
     """
     TEST :Facet Schemas for string : value=!$%%*))*(
@@ -44,11 +47,12 @@ def test_string003_1853_string003_1853_v(save_xml):
         instance="msData/datatypes/string003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string002_1852_string002_1852_v(save_xml):
     """
     TEST :Facet Schemas for string : value=a_?>
@@ -59,11 +63,12 @@ def test_string002_1852_string002_1852_v(save_xml):
         instance="msData/datatypes/string002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string001_1851_string001_1851_v(save_xml):
     """
     TEST :Facet Schemas for string : value=
@@ -74,11 +79,12 @@ def test_string001_1851_string001_1851_v(save_xml):
         instance="msData/datatypes/string001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_total_digits003_1849_positive_integer_total_digits003_1849_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -90,11 +96,12 @@ def test_positive_integer_total_digits003_1849_positive_integer_total_digits003_
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_total_digits002_1848_positive_integer_total_digits002_1848_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -106,11 +113,12 @@ def test_positive_integer_total_digits002_1848_positive_integer_total_digits002_
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_total_digits001_1847_positive_integer_total_digits001_1847_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -122,11 +130,12 @@ def test_positive_integer_total_digits001_1847_positive_integer_total_digits001_
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_exclusive005_1846_positive_integer_min_exclusive005_1846_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -138,11 +147,12 @@ def test_positive_integer_min_exclusive005_1846_positive_integer_min_exclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_exclusive004_1845_positive_integer_min_exclusive004_1845_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -154,11 +164,12 @@ def test_positive_integer_min_exclusive004_1845_positive_integer_min_exclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_exclusive003_1844_positive_integer_min_exclusive003_1844_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -170,11 +181,12 @@ def test_positive_integer_min_exclusive003_1844_positive_integer_min_exclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_exclusive002_1843_positive_integer_min_exclusive002_1843_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -186,11 +198,12 @@ def test_positive_integer_min_exclusive002_1843_positive_integer_min_exclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_exclusive001_1842_positive_integer_min_exclusive001_1842_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -202,11 +215,12 @@ def test_positive_integer_min_exclusive001_1842_positive_integer_min_exclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_inclusive005_1841_positive_integer_min_inclusive005_1841_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -218,11 +232,12 @@ def test_positive_integer_min_inclusive005_1841_positive_integer_min_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_inclusive004_1840_positive_integer_min_inclusive004_1840_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -234,11 +249,12 @@ def test_positive_integer_min_inclusive004_1840_positive_integer_min_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_inclusive003_1839_positive_integer_min_inclusive003_1839_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -250,11 +266,12 @@ def test_positive_integer_min_inclusive003_1839_positive_integer_min_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_inclusive002_1838_positive_integer_min_inclusive002_1838_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -266,11 +283,12 @@ def test_positive_integer_min_inclusive002_1838_positive_integer_min_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_min_inclusive001_1837_positive_integer_min_inclusive001_1837_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -282,11 +300,12 @@ def test_positive_integer_min_inclusive001_1837_positive_integer_min_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_max_exclusive003_1836_positive_integer_max_exclusive003_1836_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -298,11 +317,12 @@ def test_positive_integer_max_exclusive003_1836_positive_integer_max_exclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_max_inclusive003_1833_positive_integer_max_inclusive003_1833_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -314,11 +334,12 @@ def test_positive_integer_max_inclusive003_1833_positive_integer_max_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_max_inclusive002_1832_positive_integer_max_inclusive002_1832_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -330,11 +351,12 @@ def test_positive_integer_max_inclusive002_1832_positive_integer_max_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_max_inclusive001_1831_positive_integer_max_inclusive001_1831_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -346,11 +368,12 @@ def test_positive_integer_max_inclusive001_1831_positive_integer_max_inclusive00
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_enumeration004_1830_positive_integer_enumeration004_1830_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=567 1 234
@@ -362,11 +385,12 @@ def test_positive_integer_enumeration004_1830_positive_integer_enumeration004_18
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_enumeration003_1829_positive_integer_enumeration003_1829_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=567 1 234
@@ -378,11 +402,12 @@ def test_positive_integer_enumeration003_1829_positive_integer_enumeration003_18
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_enumeration002_1828_positive_integer_enumeration002_1828_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=567 and
@@ -394,11 +419,12 @@ def test_positive_integer_enumeration002_1828_positive_integer_enumeration002_18
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_enumeration001_1827_positive_integer_enumeration001_1827_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=567 and
@@ -410,11 +436,12 @@ def test_positive_integer_enumeration001_1827_positive_integer_enumeration001_18
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_positive_integer_pattern001_1826_positive_integer_pattern001_1826_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -426,11 +453,12 @@ def test_positive_integer_pattern001_1826_positive_integer_pattern001_1826_v(sav
         instance="msData/datatypes/Facets/positiveInteger/positiveInteger_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_total_digits003_1825_unsigned_byte_total_digits003_1825_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -442,11 +470,12 @@ def test_unsigned_byte_total_digits003_1825_unsigned_byte_total_digits003_1825_v
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_total_digits002_1824_unsigned_byte_total_digits002_1824_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -458,11 +487,12 @@ def test_unsigned_byte_total_digits002_1824_unsigned_byte_total_digits002_1824_v
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_total_digits001_1823_unsigned_byte_total_digits001_1823_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -474,11 +504,12 @@ def test_unsigned_byte_total_digits001_1823_unsigned_byte_total_digits001_1823_i
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_exclusive005_1822_unsigned_byte_min_exclusive005_1822_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -490,11 +521,12 @@ def test_unsigned_byte_min_exclusive005_1822_unsigned_byte_min_exclusive005_1822
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_exclusive004_1821_unsigned_byte_min_exclusive004_1821_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -506,11 +538,12 @@ def test_unsigned_byte_min_exclusive004_1821_unsigned_byte_min_exclusive004_1821
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_exclusive003_1820_unsigned_byte_min_exclusive003_1820_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -522,11 +555,12 @@ def test_unsigned_byte_min_exclusive003_1820_unsigned_byte_min_exclusive003_1820
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_exclusive002_1819_unsigned_byte_min_exclusive002_1819_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -538,11 +572,12 @@ def test_unsigned_byte_min_exclusive002_1819_unsigned_byte_min_exclusive002_1819
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_exclusive001_1818_unsigned_byte_min_exclusive001_1818_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -554,11 +589,12 @@ def test_unsigned_byte_min_exclusive001_1818_unsigned_byte_min_exclusive001_1818
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_inclusive005_1817_unsigned_byte_min_inclusive005_1817_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -570,11 +606,12 @@ def test_unsigned_byte_min_inclusive005_1817_unsigned_byte_min_inclusive005_1817
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_inclusive004_1816_unsigned_byte_min_inclusive004_1816_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -586,11 +623,12 @@ def test_unsigned_byte_min_inclusive004_1816_unsigned_byte_min_inclusive004_1816
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_inclusive003_1815_unsigned_byte_min_inclusive003_1815_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -602,11 +640,12 @@ def test_unsigned_byte_min_inclusive003_1815_unsigned_byte_min_inclusive003_1815
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_inclusive002_1814_unsigned_byte_min_inclusive002_1814_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -618,11 +657,12 @@ def test_unsigned_byte_min_inclusive002_1814_unsigned_byte_min_inclusive002_1814
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_min_inclusive001_1813_unsigned_byte_min_inclusive001_1813_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -634,11 +674,12 @@ def test_unsigned_byte_min_inclusive001_1813_unsigned_byte_min_inclusive001_1813
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_max_exclusive003_1812_unsigned_byte_max_exclusive003_1812_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -650,11 +691,12 @@ def test_unsigned_byte_max_exclusive003_1812_unsigned_byte_max_exclusive003_1812
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_max_exclusive002_1811_unsigned_byte_max_exclusive002_1811_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -666,11 +708,12 @@ def test_unsigned_byte_max_exclusive002_1811_unsigned_byte_max_exclusive002_1811
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_max_exclusive001_1810_unsigned_byte_max_exclusive001_1810_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -682,11 +725,12 @@ def test_unsigned_byte_max_exclusive001_1810_unsigned_byte_max_exclusive001_1810
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_max_inclusive003_1809_unsigned_byte_max_inclusive003_1809_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -698,11 +742,12 @@ def test_unsigned_byte_max_inclusive003_1809_unsigned_byte_max_inclusive003_1809
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_max_inclusive002_1808_unsigned_byte_max_inclusive002_1808_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -714,11 +759,12 @@ def test_unsigned_byte_max_inclusive002_1808_unsigned_byte_max_inclusive002_1808
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_max_inclusive001_1807_unsigned_byte_max_inclusive001_1807_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -730,11 +776,12 @@ def test_unsigned_byte_max_inclusive001_1807_unsigned_byte_max_inclusive001_1807
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_enumeration004_1806_unsigned_byte_enumeration004_1806_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -746,11 +793,12 @@ def test_unsigned_byte_enumeration004_1806_unsigned_byte_enumeration004_1806_v(s
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_enumeration003_1805_unsigned_byte_enumeration003_1805_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -762,11 +810,12 @@ def test_unsigned_byte_enumeration003_1805_unsigned_byte_enumeration003_1805_i(s
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_enumeration002_1804_unsigned_byte_enumeration002_1804_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -778,11 +827,12 @@ def test_unsigned_byte_enumeration002_1804_unsigned_byte_enumeration002_1804_v(s
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_enumeration001_1803_unsigned_byte_enumeration001_1803_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -794,11 +844,12 @@ def test_unsigned_byte_enumeration001_1803_unsigned_byte_enumeration001_1803_i(s
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_byte_pattern001_1802_unsigned_byte_pattern001_1802_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -810,11 +861,12 @@ def test_unsigned_byte_pattern001_1802_unsigned_byte_pattern001_1802_v(save_xml)
         instance="msData/datatypes/Facets/unsignedByte/unsignedByte_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_total_digits003_1801_unsigned_short_total_digits003_1801_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -826,11 +878,12 @@ def test_unsigned_short_total_digits003_1801_unsigned_short_total_digits003_1801
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_total_digits002_1800_unsigned_short_total_digits002_1800_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -842,11 +895,12 @@ def test_unsigned_short_total_digits002_1800_unsigned_short_total_digits002_1800
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_total_digits001_1799_unsigned_short_total_digits001_1799_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -858,11 +912,12 @@ def test_unsigned_short_total_digits001_1799_unsigned_short_total_digits001_1799
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_exclusive005_1798_unsigned_short_min_exclusive005_1798_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -874,11 +929,12 @@ def test_unsigned_short_min_exclusive005_1798_unsigned_short_min_exclusive005_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_exclusive004_1797_unsigned_short_min_exclusive004_1797_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -890,11 +946,12 @@ def test_unsigned_short_min_exclusive004_1797_unsigned_short_min_exclusive004_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_exclusive003_1796_unsigned_short_min_exclusive003_1796_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -906,11 +963,12 @@ def test_unsigned_short_min_exclusive003_1796_unsigned_short_min_exclusive003_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_exclusive002_1795_unsigned_short_min_exclusive002_1795_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -922,11 +980,12 @@ def test_unsigned_short_min_exclusive002_1795_unsigned_short_min_exclusive002_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_exclusive001_1794_unsigned_short_min_exclusive001_1794_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -938,11 +997,12 @@ def test_unsigned_short_min_exclusive001_1794_unsigned_short_min_exclusive001_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_inclusive005_1793_unsigned_short_min_inclusive005_1793_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -954,11 +1014,12 @@ def test_unsigned_short_min_inclusive005_1793_unsigned_short_min_inclusive005_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_inclusive004_1792_unsigned_short_min_inclusive004_1792_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -970,11 +1031,12 @@ def test_unsigned_short_min_inclusive004_1792_unsigned_short_min_inclusive004_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_inclusive003_1791_unsigned_short_min_inclusive003_1791_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -986,11 +1048,12 @@ def test_unsigned_short_min_inclusive003_1791_unsigned_short_min_inclusive003_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_inclusive002_1790_unsigned_short_min_inclusive002_1790_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -1002,11 +1065,12 @@ def test_unsigned_short_min_inclusive002_1790_unsigned_short_min_inclusive002_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_min_inclusive001_1789_unsigned_short_min_inclusive001_1789_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -1018,11 +1082,12 @@ def test_unsigned_short_min_inclusive001_1789_unsigned_short_min_inclusive001_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_max_exclusive003_1788_unsigned_short_max_exclusive003_1788_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -1034,11 +1099,12 @@ def test_unsigned_short_max_exclusive003_1788_unsigned_short_max_exclusive003_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_max_exclusive002_1787_unsigned_short_max_exclusive002_1787_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -1050,11 +1116,12 @@ def test_unsigned_short_max_exclusive002_1787_unsigned_short_max_exclusive002_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_max_exclusive001_1786_unsigned_short_max_exclusive001_1786_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -1066,11 +1133,12 @@ def test_unsigned_short_max_exclusive001_1786_unsigned_short_max_exclusive001_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_max_inclusive003_1785_unsigned_short_max_inclusive003_1785_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -1082,11 +1150,12 @@ def test_unsigned_short_max_inclusive003_1785_unsigned_short_max_inclusive003_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_max_inclusive002_1784_unsigned_short_max_inclusive002_1784_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -1098,11 +1167,12 @@ def test_unsigned_short_max_inclusive002_1784_unsigned_short_max_inclusive002_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_max_inclusive001_1783_unsigned_short_max_inclusive001_1783_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -1114,11 +1184,12 @@ def test_unsigned_short_max_inclusive001_1783_unsigned_short_max_inclusive001_17
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_enumeration004_1782_unsigned_short_enumeration004_1782_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -1130,11 +1201,12 @@ def test_unsigned_short_enumeration004_1782_unsigned_short_enumeration004_1782_v
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_enumeration003_1781_unsigned_short_enumeration003_1781_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -1146,11 +1218,12 @@ def test_unsigned_short_enumeration003_1781_unsigned_short_enumeration003_1781_i
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_enumeration002_1780_unsigned_short_enumeration002_1780_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -1162,11 +1235,12 @@ def test_unsigned_short_enumeration002_1780_unsigned_short_enumeration002_1780_v
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_enumeration001_1779_unsigned_short_enumeration001_1779_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -1178,11 +1252,12 @@ def test_unsigned_short_enumeration001_1779_unsigned_short_enumeration001_1779_i
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_short_pattern001_1778_unsigned_short_pattern001_1778_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -1194,11 +1269,12 @@ def test_unsigned_short_pattern001_1778_unsigned_short_pattern001_1778_v(save_xm
         instance="msData/datatypes/Facets/unsignedShort/unsignedShort_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_total_digits003_1777_unsigned_int_total_digits003_1777_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -1210,11 +1286,12 @@ def test_unsigned_int_total_digits003_1777_unsigned_int_total_digits003_1777_v(s
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_total_digits002_1776_unsigned_int_total_digits002_1776_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -1226,11 +1303,12 @@ def test_unsigned_int_total_digits002_1776_unsigned_int_total_digits002_1776_v(s
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_total_digits001_1775_unsigned_int_total_digits001_1775_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -1242,11 +1320,12 @@ def test_unsigned_int_total_digits001_1775_unsigned_int_total_digits001_1775_i(s
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_exclusive005_1774_unsigned_int_min_exclusive005_1774_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -1258,11 +1337,12 @@ def test_unsigned_int_min_exclusive005_1774_unsigned_int_min_exclusive005_1774_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_exclusive004_1773_unsigned_int_min_exclusive004_1773_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -1274,11 +1354,12 @@ def test_unsigned_int_min_exclusive004_1773_unsigned_int_min_exclusive004_1773_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_exclusive003_1772_unsigned_int_min_exclusive003_1772_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -1290,11 +1371,12 @@ def test_unsigned_int_min_exclusive003_1772_unsigned_int_min_exclusive003_1772_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_exclusive002_1771_unsigned_int_min_exclusive002_1771_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -1306,11 +1388,12 @@ def test_unsigned_int_min_exclusive002_1771_unsigned_int_min_exclusive002_1771_i
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_exclusive001_1770_unsigned_int_min_exclusive001_1770_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -1322,11 +1405,12 @@ def test_unsigned_int_min_exclusive001_1770_unsigned_int_min_exclusive001_1770_i
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_inclusive005_1769_unsigned_int_min_inclusive005_1769_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -1338,11 +1422,12 @@ def test_unsigned_int_min_inclusive005_1769_unsigned_int_min_inclusive005_1769_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_inclusive004_1768_unsigned_int_min_inclusive004_1768_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -1354,11 +1439,12 @@ def test_unsigned_int_min_inclusive004_1768_unsigned_int_min_inclusive004_1768_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_inclusive003_1767_unsigned_int_min_inclusive003_1767_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -1370,11 +1456,12 @@ def test_unsigned_int_min_inclusive003_1767_unsigned_int_min_inclusive003_1767_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_inclusive002_1766_unsigned_int_min_inclusive002_1766_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -1386,11 +1473,12 @@ def test_unsigned_int_min_inclusive002_1766_unsigned_int_min_inclusive002_1766_i
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_min_inclusive001_1765_unsigned_int_min_inclusive001_1765_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -1402,11 +1490,12 @@ def test_unsigned_int_min_inclusive001_1765_unsigned_int_min_inclusive001_1765_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_max_exclusive003_1764_unsigned_int_max_exclusive003_1764_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -1418,11 +1507,12 @@ def test_unsigned_int_max_exclusive003_1764_unsigned_int_max_exclusive003_1764_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_max_exclusive002_1763_unsigned_int_max_exclusive002_1763_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -1434,11 +1524,12 @@ def test_unsigned_int_max_exclusive002_1763_unsigned_int_max_exclusive002_1763_i
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_max_exclusive001_1762_unsigned_int_max_exclusive001_1762_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -1450,11 +1541,12 @@ def test_unsigned_int_max_exclusive001_1762_unsigned_int_max_exclusive001_1762_i
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_max_inclusive003_1761_unsigned_int_max_inclusive003_1761_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -1466,11 +1558,12 @@ def test_unsigned_int_max_inclusive003_1761_unsigned_int_max_inclusive003_1761_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_max_inclusive002_1760_unsigned_int_max_inclusive002_1760_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -1482,11 +1575,12 @@ def test_unsigned_int_max_inclusive002_1760_unsigned_int_max_inclusive002_1760_i
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_max_inclusive001_1759_unsigned_int_max_inclusive001_1759_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -1498,11 +1592,12 @@ def test_unsigned_int_max_inclusive001_1759_unsigned_int_max_inclusive001_1759_v
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_enumeration004_1758_unsigned_int_enumeration004_1758_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -1514,11 +1609,12 @@ def test_unsigned_int_enumeration004_1758_unsigned_int_enumeration004_1758_v(sav
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_enumeration003_1757_unsigned_int_enumeration003_1757_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -1530,11 +1626,12 @@ def test_unsigned_int_enumeration003_1757_unsigned_int_enumeration003_1757_i(sav
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_enumeration002_1756_unsigned_int_enumeration002_1756_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -1546,11 +1643,12 @@ def test_unsigned_int_enumeration002_1756_unsigned_int_enumeration002_1756_v(sav
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_enumeration001_1755_unsigned_int_enumeration001_1755_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -1562,11 +1660,12 @@ def test_unsigned_int_enumeration001_1755_unsigned_int_enumeration001_1755_i(sav
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_int_pattern001_1754_unsigned_int_pattern001_1754_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -1578,11 +1677,12 @@ def test_unsigned_int_pattern001_1754_unsigned_int_pattern001_1754_v(save_xml):
         instance="msData/datatypes/Facets/unsignedInt/unsignedInt_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_total_digits003_1753_unsigned_long_total_digits003_1753_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -1594,11 +1694,12 @@ def test_unsigned_long_total_digits003_1753_unsigned_long_total_digits003_1753_v
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_total_digits002_1752_unsigned_long_total_digits002_1752_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -1610,11 +1711,12 @@ def test_unsigned_long_total_digits002_1752_unsigned_long_total_digits002_1752_v
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_total_digits001_1751_unsigned_long_total_digits001_1751_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -1626,11 +1728,12 @@ def test_unsigned_long_total_digits001_1751_unsigned_long_total_digits001_1751_i
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_exclusive005_1750_unsigned_long_min_exclusive005_1750_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -1642,11 +1745,12 @@ def test_unsigned_long_min_exclusive005_1750_unsigned_long_min_exclusive005_1750
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_exclusive004_1749_unsigned_long_min_exclusive004_1749_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -1658,11 +1762,12 @@ def test_unsigned_long_min_exclusive004_1749_unsigned_long_min_exclusive004_1749
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_exclusive003_1748_unsigned_long_min_exclusive003_1748_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -1674,11 +1779,12 @@ def test_unsigned_long_min_exclusive003_1748_unsigned_long_min_exclusive003_1748
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_exclusive002_1747_unsigned_long_min_exclusive002_1747_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -1690,11 +1796,12 @@ def test_unsigned_long_min_exclusive002_1747_unsigned_long_min_exclusive002_1747
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_exclusive001_1746_unsigned_long_min_exclusive001_1746_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -1706,11 +1813,12 @@ def test_unsigned_long_min_exclusive001_1746_unsigned_long_min_exclusive001_1746
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_inclusive005_1745_unsigned_long_min_inclusive005_1745_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -1722,11 +1830,12 @@ def test_unsigned_long_min_inclusive005_1745_unsigned_long_min_inclusive005_1745
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_inclusive004_1744_unsigned_long_min_inclusive004_1744_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -1738,11 +1847,12 @@ def test_unsigned_long_min_inclusive004_1744_unsigned_long_min_inclusive004_1744
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_inclusive003_1743_unsigned_long_min_inclusive003_1743_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -1754,11 +1864,12 @@ def test_unsigned_long_min_inclusive003_1743_unsigned_long_min_inclusive003_1743
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_inclusive002_1742_unsigned_long_min_inclusive002_1742_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -1770,11 +1881,12 @@ def test_unsigned_long_min_inclusive002_1742_unsigned_long_min_inclusive002_1742
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_min_inclusive001_1741_unsigned_long_min_inclusive001_1741_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -1786,11 +1898,12 @@ def test_unsigned_long_min_inclusive001_1741_unsigned_long_min_inclusive001_1741
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_max_exclusive003_1740_unsigned_long_max_exclusive003_1740_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -1802,11 +1915,12 @@ def test_unsigned_long_max_exclusive003_1740_unsigned_long_max_exclusive003_1740
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_max_exclusive002_1739_unsigned_long_max_exclusive002_1739_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -1818,11 +1932,12 @@ def test_unsigned_long_max_exclusive002_1739_unsigned_long_max_exclusive002_1739
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_max_exclusive001_1738_unsigned_long_max_exclusive001_1738_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -1834,11 +1949,12 @@ def test_unsigned_long_max_exclusive001_1738_unsigned_long_max_exclusive001_1738
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_max_inclusive003_1737_unsigned_long_max_inclusive003_1737_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -1850,11 +1966,12 @@ def test_unsigned_long_max_inclusive003_1737_unsigned_long_max_inclusive003_1737
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_max_inclusive002_1736_unsigned_long_max_inclusive002_1736_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -1866,11 +1983,12 @@ def test_unsigned_long_max_inclusive002_1736_unsigned_long_max_inclusive002_1736
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_max_inclusive001_1735_unsigned_long_max_inclusive001_1735_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -1882,11 +2000,12 @@ def test_unsigned_long_max_inclusive001_1735_unsigned_long_max_inclusive001_1735
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_enumeration004_1734_unsigned_long_enumeration004_1734_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -1898,11 +2017,12 @@ def test_unsigned_long_enumeration004_1734_unsigned_long_enumeration004_1734_v(s
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_enumeration003_1733_unsigned_long_enumeration003_1733_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 1 234
@@ -1914,11 +2034,12 @@ def test_unsigned_long_enumeration003_1733_unsigned_long_enumeration003_1733_i(s
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_enumeration002_1732_unsigned_long_enumeration002_1732_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -1930,11 +2051,12 @@ def test_unsigned_long_enumeration002_1732_unsigned_long_enumeration002_1732_v(s
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_enumeration001_1731_unsigned_long_enumeration001_1731_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -1946,11 +2068,12 @@ def test_unsigned_long_enumeration001_1731_unsigned_long_enumeration001_1731_i(s
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unsigned_long_pattern001_1730_unsigned_long_pattern001_1730_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -1962,11 +2085,12 @@ def test_unsigned_long_pattern001_1730_unsigned_long_pattern001_1730_v(save_xml)
         instance="msData/datatypes/Facets/unsignedLong/unsignedLong_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_total_digits003_1729_non_negative_integer_total_digits003_1729_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -1978,11 +2102,12 @@ def test_non_negative_integer_total_digits003_1729_non_negative_integer_total_di
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_total_digits002_1728_non_negative_integer_total_digits002_1728_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -1994,11 +2119,12 @@ def test_non_negative_integer_total_digits002_1728_non_negative_integer_total_di
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_total_digits001_1727_non_negative_integer_total_digits001_1727_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -2010,11 +2136,12 @@ def test_non_negative_integer_total_digits001_1727_non_negative_integer_total_di
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_exclusive005_1726_non_negative_integer_min_exclusive005_1726_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -2026,11 +2153,12 @@ def test_non_negative_integer_min_exclusive005_1726_non_negative_integer_min_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_exclusive004_1725_non_negative_integer_min_exclusive004_1725_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -2042,11 +2170,12 @@ def test_non_negative_integer_min_exclusive004_1725_non_negative_integer_min_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_exclusive003_1724_non_negative_integer_min_exclusive003_1724_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -2058,11 +2187,12 @@ def test_non_negative_integer_min_exclusive003_1724_non_negative_integer_min_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_exclusive002_1723_non_negative_integer_min_exclusive002_1723_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -2074,11 +2204,12 @@ def test_non_negative_integer_min_exclusive002_1723_non_negative_integer_min_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_exclusive001_1722_non_negative_integer_min_exclusive001_1722_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -2090,11 +2221,12 @@ def test_non_negative_integer_min_exclusive001_1722_non_negative_integer_min_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_inclusive005_1721_non_negative_integer_min_inclusive005_1721_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -2106,11 +2238,12 @@ def test_non_negative_integer_min_inclusive005_1721_non_negative_integer_min_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_inclusive004_1720_non_negative_integer_min_inclusive004_1720_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -2122,11 +2255,12 @@ def test_non_negative_integer_min_inclusive004_1720_non_negative_integer_min_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_inclusive003_1719_non_negative_integer_min_inclusive003_1719_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -2138,11 +2272,12 @@ def test_non_negative_integer_min_inclusive003_1719_non_negative_integer_min_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_inclusive002_1718_non_negative_integer_min_inclusive002_1718_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -2154,11 +2289,12 @@ def test_non_negative_integer_min_inclusive002_1718_non_negative_integer_min_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_min_inclusive001_1717_non_negative_integer_min_inclusive001_1717_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -2170,11 +2306,12 @@ def test_non_negative_integer_min_inclusive001_1717_non_negative_integer_min_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_max_exclusive003_1716_non_negative_integer_max_exclusive003_1716_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -2186,11 +2323,12 @@ def test_non_negative_integer_max_exclusive003_1716_non_negative_integer_max_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_max_exclusive002_1715_non_negative_integer_max_exclusive002_1715_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -2202,11 +2340,12 @@ def test_non_negative_integer_max_exclusive002_1715_non_negative_integer_max_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_max_exclusive001_1714_non_negative_integer_max_exclusive001_1714_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -2218,11 +2357,12 @@ def test_non_negative_integer_max_exclusive001_1714_non_negative_integer_max_exc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_max_inclusive003_1713_non_negative_integer_max_inclusive003_1713_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -2234,11 +2374,12 @@ def test_non_negative_integer_max_inclusive003_1713_non_negative_integer_max_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_max_inclusive002_1712_non_negative_integer_max_inclusive002_1712_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -2250,11 +2391,12 @@ def test_non_negative_integer_max_inclusive002_1712_non_negative_integer_max_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_max_inclusive001_1711_non_negative_integer_max_inclusive001_1711_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -2266,11 +2408,12 @@ def test_non_negative_integer_max_inclusive001_1711_non_negative_integer_max_inc
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_enumeration004_1710_non_negative_integer_enumeration004_1710_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=456 789 0
@@ -2282,11 +2425,12 @@ def test_non_negative_integer_enumeration004_1710_non_negative_integer_enumerati
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_enumeration003_1709_non_negative_integer_enumeration003_1709_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=456 789 0
@@ -2298,11 +2442,12 @@ def test_non_negative_integer_enumeration003_1709_non_negative_integer_enumerati
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_enumeration002_1708_non_negative_integer_enumeration002_1708_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=456 and
@@ -2314,11 +2459,12 @@ def test_non_negative_integer_enumeration002_1708_non_negative_integer_enumerati
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_enumeration001_1707_non_negative_integer_enumeration001_1707_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=456 and
@@ -2330,11 +2476,12 @@ def test_non_negative_integer_enumeration001_1707_non_negative_integer_enumerati
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_negative_integer_pattern001_1706_non_negative_integer_pattern001_1706_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -2346,11 +2493,12 @@ def test_non_negative_integer_pattern001_1706_non_negative_integer_pattern001_17
         instance="msData/datatypes/Facets/nonNegativeInteger/nonNegativeInteger_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_total_digits003_1705_byte_total_digits003_1705_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -2362,11 +2510,12 @@ def test_byte_total_digits003_1705_byte_total_digits003_1705_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_total_digits002_1704_byte_total_digits002_1704_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -2378,11 +2527,12 @@ def test_byte_total_digits002_1704_byte_total_digits002_1704_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_total_digits001_1703_byte_total_digits001_1703_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -2394,11 +2544,12 @@ def test_byte_total_digits001_1703_byte_total_digits001_1703_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_exclusive005_1702_byte_min_exclusive005_1702_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -2410,11 +2561,12 @@ def test_byte_min_exclusive005_1702_byte_min_exclusive005_1702_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_exclusive004_1701_byte_min_exclusive004_1701_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -2426,11 +2578,12 @@ def test_byte_min_exclusive004_1701_byte_min_exclusive004_1701_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_exclusive003_1700_byte_min_exclusive003_1700_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -2442,11 +2595,12 @@ def test_byte_min_exclusive003_1700_byte_min_exclusive003_1700_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_exclusive002_1699_byte_min_exclusive002_1699_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -2458,11 +2612,12 @@ def test_byte_min_exclusive002_1699_byte_min_exclusive002_1699_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_exclusive001_1698_byte_min_exclusive001_1698_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -2474,11 +2629,12 @@ def test_byte_min_exclusive001_1698_byte_min_exclusive001_1698_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_inclusive005_1697_byte_min_inclusive005_1697_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -2490,11 +2646,12 @@ def test_byte_min_inclusive005_1697_byte_min_inclusive005_1697_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_inclusive004_1696_byte_min_inclusive004_1696_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -2506,11 +2663,12 @@ def test_byte_min_inclusive004_1696_byte_min_inclusive004_1696_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_inclusive003_1695_byte_min_inclusive003_1695_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -2522,11 +2680,12 @@ def test_byte_min_inclusive003_1695_byte_min_inclusive003_1695_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_inclusive002_1694_byte_min_inclusive002_1694_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -2538,11 +2697,12 @@ def test_byte_min_inclusive002_1694_byte_min_inclusive002_1694_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_min_inclusive001_1693_byte_min_inclusive001_1693_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -2554,11 +2714,12 @@ def test_byte_min_inclusive001_1693_byte_min_inclusive001_1693_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_max_exclusive003_1692_byte_max_exclusive003_1692_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -2570,11 +2731,12 @@ def test_byte_max_exclusive003_1692_byte_max_exclusive003_1692_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_max_exclusive002_1691_byte_max_exclusive002_1691_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -2586,11 +2748,12 @@ def test_byte_max_exclusive002_1691_byte_max_exclusive002_1691_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_max_exclusive001_1690_byte_max_exclusive001_1690_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -2602,11 +2765,12 @@ def test_byte_max_exclusive001_1690_byte_max_exclusive001_1690_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_max_inclusive003_1689_byte_max_inclusive003_1689_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -2618,11 +2782,12 @@ def test_byte_max_inclusive003_1689_byte_max_inclusive003_1689_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_max_inclusive002_1688_byte_max_inclusive002_1688_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -2634,11 +2799,12 @@ def test_byte_max_inclusive002_1688_byte_max_inclusive002_1688_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_max_inclusive001_1687_byte_max_inclusive001_1687_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -2650,11 +2816,12 @@ def test_byte_max_inclusive001_1687_byte_max_inclusive001_1687_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_enumeration004_1686_byte_enumeration004_1686_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -2666,11 +2833,12 @@ def test_byte_enumeration004_1686_byte_enumeration004_1686_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_enumeration003_1685_byte_enumeration003_1685_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -2682,11 +2850,12 @@ def test_byte_enumeration003_1685_byte_enumeration003_1685_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_enumeration002_1684_byte_enumeration002_1684_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -2698,11 +2867,12 @@ def test_byte_enumeration002_1684_byte_enumeration002_1684_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_enumeration001_1683_byte_enumeration001_1683_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -2714,11 +2884,12 @@ def test_byte_enumeration001_1683_byte_enumeration001_1683_i(save_xml):
         instance="msData/datatypes/Facets/byte/byte_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_byte_pattern001_1682_byte_pattern001_1682_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -2730,11 +2901,12 @@ def test_byte_pattern001_1682_byte_pattern001_1682_v(save_xml):
         instance="msData/datatypes/Facets/byte/byte_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_total_digits003_1681_short_total_digits003_1681_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -2746,11 +2918,12 @@ def test_short_total_digits003_1681_short_total_digits003_1681_v(save_xml):
         instance="msData/datatypes/Facets/short/short_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_total_digits002_1680_short_total_digits002_1680_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -2762,11 +2935,12 @@ def test_short_total_digits002_1680_short_total_digits002_1680_v(save_xml):
         instance="msData/datatypes/Facets/short/short_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_total_digits001_1679_short_total_digits001_1679_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -2778,11 +2952,12 @@ def test_short_total_digits001_1679_short_total_digits001_1679_i(save_xml):
         instance="msData/datatypes/Facets/short/short_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_exclusive005_1678_short_min_exclusive005_1678_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -2794,11 +2969,12 @@ def test_short_min_exclusive005_1678_short_min_exclusive005_1678_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_exclusive004_1677_short_min_exclusive004_1677_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -2810,11 +2986,12 @@ def test_short_min_exclusive004_1677_short_min_exclusive004_1677_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_exclusive003_1676_short_min_exclusive003_1676_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -2826,11 +3003,12 @@ def test_short_min_exclusive003_1676_short_min_exclusive003_1676_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_exclusive002_1675_short_min_exclusive002_1675_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -2842,11 +3020,12 @@ def test_short_min_exclusive002_1675_short_min_exclusive002_1675_i(save_xml):
         instance="msData/datatypes/Facets/short/short_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_exclusive001_1674_short_min_exclusive001_1674_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -2858,11 +3037,12 @@ def test_short_min_exclusive001_1674_short_min_exclusive001_1674_i(save_xml):
         instance="msData/datatypes/Facets/short/short_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_inclusive005_1673_short_min_inclusive005_1673_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -2874,11 +3054,12 @@ def test_short_min_inclusive005_1673_short_min_inclusive005_1673_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_inclusive004_1672_short_min_inclusive004_1672_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -2890,11 +3071,12 @@ def test_short_min_inclusive004_1672_short_min_inclusive004_1672_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_inclusive003_1671_short_min_inclusive003_1671_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -2906,11 +3088,12 @@ def test_short_min_inclusive003_1671_short_min_inclusive003_1671_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_inclusive002_1670_short_min_inclusive002_1670_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -2922,11 +3105,12 @@ def test_short_min_inclusive002_1670_short_min_inclusive002_1670_i(save_xml):
         instance="msData/datatypes/Facets/short/short_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_min_inclusive001_1669_short_min_inclusive001_1669_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -2938,11 +3122,12 @@ def test_short_min_inclusive001_1669_short_min_inclusive001_1669_v(save_xml):
         instance="msData/datatypes/Facets/short/short_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_max_exclusive003_1668_short_max_exclusive003_1668_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -2954,11 +3139,12 @@ def test_short_max_exclusive003_1668_short_max_exclusive003_1668_v(save_xml):
         instance="msData/datatypes/Facets/short/short_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_max_exclusive002_1667_short_max_exclusive002_1667_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -2970,11 +3156,12 @@ def test_short_max_exclusive002_1667_short_max_exclusive002_1667_i(save_xml):
         instance="msData/datatypes/Facets/short/short_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_max_exclusive001_1666_short_max_exclusive001_1666_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -2986,11 +3173,12 @@ def test_short_max_exclusive001_1666_short_max_exclusive001_1666_i(save_xml):
         instance="msData/datatypes/Facets/short/short_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_max_inclusive003_1665_short_max_inclusive003_1665_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -3002,11 +3190,12 @@ def test_short_max_inclusive003_1665_short_max_inclusive003_1665_v(save_xml):
         instance="msData/datatypes/Facets/short/short_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_max_inclusive002_1664_short_max_inclusive002_1664_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -3018,11 +3207,12 @@ def test_short_max_inclusive002_1664_short_max_inclusive002_1664_i(save_xml):
         instance="msData/datatypes/Facets/short/short_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_max_inclusive001_1663_short_max_inclusive001_1663_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -3034,11 +3224,12 @@ def test_short_max_inclusive001_1663_short_max_inclusive001_1663_v(save_xml):
         instance="msData/datatypes/Facets/short/short_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_enumeration004_1662_short_enumeration004_1662_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -3050,11 +3241,12 @@ def test_short_enumeration004_1662_short_enumeration004_1662_v(save_xml):
         instance="msData/datatypes/Facets/short/short_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_enumeration003_1661_short_enumeration003_1661_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -3066,11 +3258,12 @@ def test_short_enumeration003_1661_short_enumeration003_1661_i(save_xml):
         instance="msData/datatypes/Facets/short/short_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_enumeration002_1660_short_enumeration002_1660_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -3082,11 +3275,12 @@ def test_short_enumeration002_1660_short_enumeration002_1660_v(save_xml):
         instance="msData/datatypes/Facets/short/short_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_enumeration001_1659_short_enumeration001_1659_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -3098,11 +3292,12 @@ def test_short_enumeration001_1659_short_enumeration001_1659_i(save_xml):
         instance="msData/datatypes/Facets/short/short_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_short_pattern001_1658_short_pattern001_1658_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -3114,11 +3309,12 @@ def test_short_pattern001_1658_short_pattern001_1658_v(save_xml):
         instance="msData/datatypes/Facets/short/short_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test111092_1657_test111092_1657_i(save_xml):
     """
     TEST :Facet Schemas for string : test derived maxExclusive to be equal
@@ -3130,11 +3326,12 @@ def test_test111092_1657_test111092_1657_i(save_xml):
         instance="msData/datatypes/Facets/int/test111092.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_total_digits003_1656_int_total_digits003_1656_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -3146,11 +3343,12 @@ def test_int_total_digits003_1656_int_total_digits003_1656_v(save_xml):
         instance="msData/datatypes/Facets/int/int_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_total_digits002_1655_int_total_digits002_1655_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -3162,11 +3360,12 @@ def test_int_total_digits002_1655_int_total_digits002_1655_v(save_xml):
         instance="msData/datatypes/Facets/int/int_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_total_digits001_1654_int_total_digits001_1654_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -3178,11 +3377,12 @@ def test_int_total_digits001_1654_int_total_digits001_1654_i(save_xml):
         instance="msData/datatypes/Facets/int/int_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_exclusive005_1653_int_min_exclusive005_1653_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -3194,11 +3394,12 @@ def test_int_min_exclusive005_1653_int_min_exclusive005_1653_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_exclusive004_1652_int_min_exclusive004_1652_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -3210,11 +3411,12 @@ def test_int_min_exclusive004_1652_int_min_exclusive004_1652_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_exclusive003_1651_int_min_exclusive003_1651_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -3226,11 +3428,12 @@ def test_int_min_exclusive003_1651_int_min_exclusive003_1651_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_exclusive002_1650_int_min_exclusive002_1650_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -3242,11 +3445,12 @@ def test_int_min_exclusive002_1650_int_min_exclusive002_1650_i(save_xml):
         instance="msData/datatypes/Facets/int/int_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_exclusive001_1649_int_min_exclusive001_1649_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -3258,11 +3462,12 @@ def test_int_min_exclusive001_1649_int_min_exclusive001_1649_i(save_xml):
         instance="msData/datatypes/Facets/int/int_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_inclusive005_1648_int_min_inclusive005_1648_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -3274,11 +3479,12 @@ def test_int_min_inclusive005_1648_int_min_inclusive005_1648_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_inclusive004_1647_int_min_inclusive004_1647_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -3290,11 +3496,12 @@ def test_int_min_inclusive004_1647_int_min_inclusive004_1647_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_inclusive003_1646_int_min_inclusive003_1646_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -3306,11 +3513,12 @@ def test_int_min_inclusive003_1646_int_min_inclusive003_1646_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_inclusive002_1645_int_min_inclusive002_1645_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -3322,11 +3530,12 @@ def test_int_min_inclusive002_1645_int_min_inclusive002_1645_i(save_xml):
         instance="msData/datatypes/Facets/int/int_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_min_inclusive001_1644_int_min_inclusive001_1644_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -3338,11 +3547,12 @@ def test_int_min_inclusive001_1644_int_min_inclusive001_1644_v(save_xml):
         instance="msData/datatypes/Facets/int/int_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_max_exclusive003_1643_int_max_exclusive003_1643_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -3354,11 +3564,12 @@ def test_int_max_exclusive003_1643_int_max_exclusive003_1643_v(save_xml):
         instance="msData/datatypes/Facets/int/int_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_max_exclusive002_1642_int_max_exclusive002_1642_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -3370,11 +3581,12 @@ def test_int_max_exclusive002_1642_int_max_exclusive002_1642_i(save_xml):
         instance="msData/datatypes/Facets/int/int_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_max_exclusive001_1641_int_max_exclusive001_1641_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -3386,11 +3598,12 @@ def test_int_max_exclusive001_1641_int_max_exclusive001_1641_i(save_xml):
         instance="msData/datatypes/Facets/int/int_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_max_inclusive003_1640_int_max_inclusive003_1640_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -3402,11 +3615,12 @@ def test_int_max_inclusive003_1640_int_max_inclusive003_1640_v(save_xml):
         instance="msData/datatypes/Facets/int/int_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_max_inclusive002_1639_int_max_inclusive002_1639_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -3418,11 +3632,12 @@ def test_int_max_inclusive002_1639_int_max_inclusive002_1639_i(save_xml):
         instance="msData/datatypes/Facets/int/int_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_max_inclusive001_1638_int_max_inclusive001_1638_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -3434,11 +3649,12 @@ def test_int_max_inclusive001_1638_int_max_inclusive001_1638_v(save_xml):
         instance="msData/datatypes/Facets/int/int_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_enumeration004_1637_int_enumeration004_1637_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -3450,11 +3666,12 @@ def test_int_enumeration004_1637_int_enumeration004_1637_v(save_xml):
         instance="msData/datatypes/Facets/int/int_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_enumeration003_1636_int_enumeration003_1636_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -3466,11 +3683,12 @@ def test_int_enumeration003_1636_int_enumeration003_1636_i(save_xml):
         instance="msData/datatypes/Facets/int/int_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_enumeration002_1635_int_enumeration002_1635_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -3482,11 +3700,12 @@ def test_int_enumeration002_1635_int_enumeration002_1635_v(save_xml):
         instance="msData/datatypes/Facets/int/int_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_enumeration001_1634_int_enumeration001_1634_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -3498,11 +3717,12 @@ def test_int_enumeration001_1634_int_enumeration001_1634_i(save_xml):
         instance="msData/datatypes/Facets/int/int_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_int_pattern001_1633_int_pattern001_1633_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -3514,11 +3734,12 @@ def test_int_pattern001_1633_int_pattern001_1633_v(save_xml):
         instance="msData/datatypes/Facets/int/int_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_total_digits003_1632_long_total_digits003_1632_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -3530,11 +3751,12 @@ def test_long_total_digits003_1632_long_total_digits003_1632_v(save_xml):
         instance="msData/datatypes/Facets/long/long_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_total_digits002_1631_long_total_digits002_1631_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -3546,11 +3768,12 @@ def test_long_total_digits002_1631_long_total_digits002_1631_v(save_xml):
         instance="msData/datatypes/Facets/long/long_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_total_digits001_1630_long_total_digits001_1630_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -3562,11 +3785,12 @@ def test_long_total_digits001_1630_long_total_digits001_1630_i(save_xml):
         instance="msData/datatypes/Facets/long/long_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_exclusive005_1629_long_min_exclusive005_1629_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -3578,11 +3802,12 @@ def test_long_min_exclusive005_1629_long_min_exclusive005_1629_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_exclusive004_1628_long_min_exclusive004_1628_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -3594,11 +3819,12 @@ def test_long_min_exclusive004_1628_long_min_exclusive004_1628_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_exclusive003_1627_long_min_exclusive003_1627_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -3610,11 +3836,12 @@ def test_long_min_exclusive003_1627_long_min_exclusive003_1627_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_exclusive002_1626_long_min_exclusive002_1626_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -3626,11 +3853,12 @@ def test_long_min_exclusive002_1626_long_min_exclusive002_1626_i(save_xml):
         instance="msData/datatypes/Facets/long/long_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_exclusive001_1625_long_min_exclusive001_1625_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -3642,11 +3870,12 @@ def test_long_min_exclusive001_1625_long_min_exclusive001_1625_i(save_xml):
         instance="msData/datatypes/Facets/long/long_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_inclusive005_1624_long_min_inclusive005_1624_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -3658,11 +3887,12 @@ def test_long_min_inclusive005_1624_long_min_inclusive005_1624_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_inclusive004_1623_long_min_inclusive004_1623_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -3674,11 +3904,12 @@ def test_long_min_inclusive004_1623_long_min_inclusive004_1623_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_inclusive003_1622_long_min_inclusive003_1622_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -3690,11 +3921,12 @@ def test_long_min_inclusive003_1622_long_min_inclusive003_1622_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_inclusive002_1621_long_min_inclusive002_1621_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -3706,11 +3938,12 @@ def test_long_min_inclusive002_1621_long_min_inclusive002_1621_i(save_xml):
         instance="msData/datatypes/Facets/long/long_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_min_inclusive001_1620_long_min_inclusive001_1620_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -3722,11 +3955,12 @@ def test_long_min_inclusive001_1620_long_min_inclusive001_1620_v(save_xml):
         instance="msData/datatypes/Facets/long/long_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_max_exclusive003_1619_long_max_exclusive003_1619_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -3738,11 +3972,12 @@ def test_long_max_exclusive003_1619_long_max_exclusive003_1619_v(save_xml):
         instance="msData/datatypes/Facets/long/long_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_max_exclusive002_1618_long_max_exclusive002_1618_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -3754,11 +3989,12 @@ def test_long_max_exclusive002_1618_long_max_exclusive002_1618_i(save_xml):
         instance="msData/datatypes/Facets/long/long_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_max_exclusive001_1617_long_max_exclusive001_1617_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -3770,11 +4006,12 @@ def test_long_max_exclusive001_1617_long_max_exclusive001_1617_i(save_xml):
         instance="msData/datatypes/Facets/long/long_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_max_inclusive003_1616_long_max_inclusive003_1616_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -3786,11 +4023,12 @@ def test_long_max_inclusive003_1616_long_max_inclusive003_1616_v(save_xml):
         instance="msData/datatypes/Facets/long/long_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_max_inclusive002_1615_long_max_inclusive002_1615_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -3802,11 +4040,12 @@ def test_long_max_inclusive002_1615_long_max_inclusive002_1615_i(save_xml):
         instance="msData/datatypes/Facets/long/long_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_max_inclusive001_1614_long_max_inclusive001_1614_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -3818,11 +4057,12 @@ def test_long_max_inclusive001_1614_long_max_inclusive001_1614_v(save_xml):
         instance="msData/datatypes/Facets/long/long_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_enumeration004_1613_long_enumeration004_1613_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -3834,11 +4074,12 @@ def test_long_enumeration004_1613_long_enumeration004_1613_v(save_xml):
         instance="msData/datatypes/Facets/long/long_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_enumeration003_1612_long_enumeration003_1612_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-1 0 1
@@ -3850,11 +4091,12 @@ def test_long_enumeration003_1612_long_enumeration003_1612_i(save_xml):
         instance="msData/datatypes/Facets/long/long_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_enumeration002_1611_long_enumeration002_1611_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -3866,11 +4108,12 @@ def test_long_enumeration002_1611_long_enumeration002_1611_v(save_xml):
         instance="msData/datatypes/Facets/long/long_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_enumeration001_1610_long_enumeration001_1610_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=0 and
@@ -3882,11 +4125,12 @@ def test_long_enumeration001_1610_long_enumeration001_1610_i(save_xml):
         instance="msData/datatypes/Facets/long/long_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_long_pattern001_1609_long_pattern001_1609_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -3898,11 +4142,12 @@ def test_long_pattern001_1609_long_pattern001_1609_v(save_xml):
         instance="msData/datatypes/Facets/long/long_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_total_digits003_1608_negative_integer_total_digits003_1608_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -3914,11 +4159,12 @@ def test_negative_integer_total_digits003_1608_negative_integer_total_digits003_
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_total_digits002_1607_negative_integer_total_digits002_1607_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -3930,11 +4176,12 @@ def test_negative_integer_total_digits002_1607_negative_integer_total_digits002_
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_total_digits001_1606_negative_integer_total_digits001_1606_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -3946,11 +4193,12 @@ def test_negative_integer_total_digits001_1606_negative_integer_total_digits001_
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_exclusive005_1605_negative_integer_min_exclusive005_1605_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=-7 and
@@ -3962,11 +4210,12 @@ def test_negative_integer_min_exclusive005_1605_negative_integer_min_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_exclusive004_1604_negative_integer_min_exclusive004_1604_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=-7 and
@@ -3978,11 +4227,12 @@ def test_negative_integer_min_exclusive004_1604_negative_integer_min_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_exclusive003_1603_negative_integer_min_exclusive003_1603_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=-7 and
@@ -3994,11 +4244,12 @@ def test_negative_integer_min_exclusive003_1603_negative_integer_min_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_exclusive002_1602_negative_integer_min_exclusive002_1602_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=-5 and
@@ -4010,11 +4261,12 @@ def test_negative_integer_min_exclusive002_1602_negative_integer_min_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_exclusive001_1601_negative_integer_min_exclusive001_1601_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=-7 and
@@ -4026,11 +4278,12 @@ def test_negative_integer_min_exclusive001_1601_negative_integer_min_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_inclusive005_1600_negative_integer_min_inclusive005_1600_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=-7 and
@@ -4042,11 +4295,12 @@ def test_negative_integer_min_inclusive005_1600_negative_integer_min_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_inclusive004_1599_negative_integer_min_inclusive004_1599_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=-7 and
@@ -4058,11 +4312,12 @@ def test_negative_integer_min_inclusive004_1599_negative_integer_min_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_inclusive003_1598_negative_integer_min_inclusive003_1598_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=-7 and
@@ -4074,11 +4329,12 @@ def test_negative_integer_min_inclusive003_1598_negative_integer_min_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_inclusive002_1597_negative_integer_min_inclusive002_1597_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=-5 and
@@ -4090,11 +4346,12 @@ def test_negative_integer_min_inclusive002_1597_negative_integer_min_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_min_inclusive001_1596_negative_integer_min_inclusive001_1596_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=-7 and
@@ -4106,11 +4363,12 @@ def test_negative_integer_min_inclusive001_1596_negative_integer_min_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_max_exclusive003_1595_negative_integer_max_exclusive003_1595_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=-1 and
@@ -4122,11 +4380,12 @@ def test_negative_integer_max_exclusive003_1595_negative_integer_max_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_max_exclusive002_1594_negative_integer_max_exclusive002_1594_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=-7 and
@@ -4138,11 +4397,12 @@ def test_negative_integer_max_exclusive002_1594_negative_integer_max_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_max_exclusive001_1593_negative_integer_max_exclusive001_1593_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=-7 and
@@ -4154,11 +4414,12 @@ def test_negative_integer_max_exclusive001_1593_negative_integer_max_exclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_max_inclusive003_1592_negative_integer_max_inclusive003_1592_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=-1 and
@@ -4170,11 +4431,12 @@ def test_negative_integer_max_inclusive003_1592_negative_integer_max_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_max_inclusive002_1591_negative_integer_max_inclusive002_1591_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=-7 and
@@ -4186,11 +4448,12 @@ def test_negative_integer_max_inclusive002_1591_negative_integer_max_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_max_inclusive001_1590_negative_integer_max_inclusive001_1590_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=-7 and
@@ -4202,11 +4465,12 @@ def test_negative_integer_max_inclusive001_1590_negative_integer_max_inclusive00
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_enumeration004_1589_negative_integer_enumeration004_1589_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 -789
@@ -4218,11 +4482,12 @@ def test_negative_integer_enumeration004_1589_negative_integer_enumeration004_15
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_enumeration003_1588_negative_integer_enumeration003_1588_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 -789
@@ -4234,11 +4499,12 @@ def test_negative_integer_enumeration003_1588_negative_integer_enumeration003_15
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_enumeration002_1587_negative_integer_enumeration002_1587_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 and
@@ -4250,11 +4516,12 @@ def test_negative_integer_enumeration002_1587_negative_integer_enumeration002_15
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_enumeration001_1586_negative_integer_enumeration001_1586_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 and
@@ -4266,11 +4533,12 @@ def test_negative_integer_enumeration001_1586_negative_integer_enumeration001_15
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_negative_integer_pattern001_1585_negative_integer_pattern001_1585_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=-\p{Nd}{1,3}
@@ -4282,11 +4550,12 @@ def test_negative_integer_pattern001_1585_negative_integer_pattern001_1585_v(sav
         instance="msData/datatypes/Facets/negativeInteger/negativeInteger_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_total_digits003_1584_non_positive_integer_total_digits003_1584_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -4298,11 +4567,12 @@ def test_non_positive_integer_total_digits003_1584_non_positive_integer_total_di
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_total_digits002_1583_non_positive_integer_total_digits002_1583_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -4314,11 +4584,12 @@ def test_non_positive_integer_total_digits002_1583_non_positive_integer_total_di
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_total_digits001_1582_non_positive_integer_total_digits001_1582_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -4330,11 +4601,12 @@ def test_non_positive_integer_total_digits001_1582_non_positive_integer_total_di
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_exclusive005_1581_non_positive_integer_min_exclusive005_1581_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=-7 and
@@ -4346,11 +4618,12 @@ def test_non_positive_integer_min_exclusive005_1581_non_positive_integer_min_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_exclusive004_1580_non_positive_integer_min_exclusive004_1580_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=-7 and
@@ -4362,11 +4635,12 @@ def test_non_positive_integer_min_exclusive004_1580_non_positive_integer_min_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_exclusive003_1579_non_positive_integer_min_exclusive003_1579_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=-7 and
@@ -4378,11 +4652,12 @@ def test_non_positive_integer_min_exclusive003_1579_non_positive_integer_min_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_exclusive002_1578_non_positive_integer_min_exclusive002_1578_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=-5 and
@@ -4394,11 +4669,12 @@ def test_non_positive_integer_min_exclusive002_1578_non_positive_integer_min_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_exclusive001_1577_non_positive_integer_min_exclusive001_1577_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=-7 and
@@ -4410,11 +4686,12 @@ def test_non_positive_integer_min_exclusive001_1577_non_positive_integer_min_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_inclusive005_1576_non_positive_integer_min_inclusive005_1576_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=-7 and
@@ -4426,11 +4703,12 @@ def test_non_positive_integer_min_inclusive005_1576_non_positive_integer_min_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_inclusive004_1575_non_positive_integer_min_inclusive004_1575_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=-7 and
@@ -4442,11 +4720,12 @@ def test_non_positive_integer_min_inclusive004_1575_non_positive_integer_min_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_inclusive003_1574_non_positive_integer_min_inclusive003_1574_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=-7 and
@@ -4458,11 +4737,12 @@ def test_non_positive_integer_min_inclusive003_1574_non_positive_integer_min_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_inclusive002_1573_non_positive_integer_min_inclusive002_1573_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=-5 and
@@ -4474,11 +4754,12 @@ def test_non_positive_integer_min_inclusive002_1573_non_positive_integer_min_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_min_inclusive001_1572_non_positive_integer_min_inclusive001_1572_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=-7 and
@@ -4490,11 +4771,12 @@ def test_non_positive_integer_min_inclusive001_1572_non_positive_integer_min_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_max_exclusive003_1571_non_positive_integer_max_exclusive003_1571_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=-1 and
@@ -4506,11 +4788,12 @@ def test_non_positive_integer_max_exclusive003_1571_non_positive_integer_max_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_max_exclusive002_1570_non_positive_integer_max_exclusive002_1570_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=-7 and
@@ -4522,11 +4805,12 @@ def test_non_positive_integer_max_exclusive002_1570_non_positive_integer_max_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_max_exclusive001_1569_non_positive_integer_max_exclusive001_1569_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=-7 and
@@ -4538,11 +4822,12 @@ def test_non_positive_integer_max_exclusive001_1569_non_positive_integer_max_exc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_max_inclusive003_1568_non_positive_integer_max_inclusive003_1568_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=-1 and
@@ -4554,11 +4839,12 @@ def test_non_positive_integer_max_inclusive003_1568_non_positive_integer_max_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_max_inclusive002_1567_non_positive_integer_max_inclusive002_1567_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=-7 and
@@ -4570,11 +4856,12 @@ def test_non_positive_integer_max_inclusive002_1567_non_positive_integer_max_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_max_inclusive001_1566_non_positive_integer_max_inclusive001_1566_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=-7 and
@@ -4586,11 +4873,12 @@ def test_non_positive_integer_max_inclusive001_1566_non_positive_integer_max_inc
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_enumeration004_1565_non_positive_integer_enumeration004_1565_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 -789
@@ -4602,11 +4890,12 @@ def test_non_positive_integer_enumeration004_1565_non_positive_integer_enumerati
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_enumeration003_1564_non_positive_integer_enumeration003_1564_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 -789
@@ -4618,11 +4907,12 @@ def test_non_positive_integer_enumeration003_1564_non_positive_integer_enumerati
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_enumeration002_1563_non_positive_integer_enumeration002_1563_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 and
@@ -4634,11 +4924,12 @@ def test_non_positive_integer_enumeration002_1563_non_positive_integer_enumerati
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_enumeration001_1562_non_positive_integer_enumeration001_1562_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=-456 and
@@ -4650,11 +4941,12 @@ def test_non_positive_integer_enumeration001_1562_non_positive_integer_enumerati
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_non_positive_integer_pattern001_1561_non_positive_integer_pattern001_1561_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=-\p{Nd}{1,3}
@@ -4666,11 +4958,12 @@ def test_non_positive_integer_pattern001_1561_non_positive_integer_pattern001_15
         instance="msData/datatypes/Facets/nonPositiveInteger/nonPositiveInteger_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_total_digits003_1560_integer_total_digits003_1560_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -4682,11 +4975,12 @@ def test_integer_total_digits003_1560_integer_total_digits003_1560_v(save_xml):
         instance="msData/datatypes/Facets/integer/integer_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_total_digits002_1559_integer_total_digits002_1559_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -4698,11 +4992,12 @@ def test_integer_total_digits002_1559_integer_total_digits002_1559_v(save_xml):
         instance="msData/datatypes/Facets/integer/integer_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_total_digits001_1558_integer_total_digits001_1558_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -4714,11 +5009,12 @@ def test_integer_total_digits001_1558_integer_total_digits001_1558_i(save_xml):
         instance="msData/datatypes/Facets/integer/integer_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_exclusive005_1557_integer_min_exclusive005_1557_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -4730,11 +5026,12 @@ def test_integer_min_exclusive005_1557_integer_min_exclusive005_1557_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_exclusive004_1556_integer_min_exclusive004_1556_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1 and
@@ -4746,11 +5043,12 @@ def test_integer_min_exclusive004_1556_integer_min_exclusive004_1556_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_exclusive003_1555_integer_min_exclusive003_1555_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -4762,11 +5060,12 @@ def test_integer_min_exclusive003_1555_integer_min_exclusive003_1555_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_exclusive002_1554_integer_min_exclusive002_1554_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5 and
@@ -4778,11 +5077,12 @@ def test_integer_min_exclusive002_1554_integer_min_exclusive002_1554_i(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_exclusive001_1553_integer_min_exclusive001_1553_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1 and
@@ -4794,11 +5094,12 @@ def test_integer_min_exclusive001_1553_integer_min_exclusive001_1553_i(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_inclusive005_1552_integer_min_inclusive005_1552_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -4810,11 +5111,12 @@ def test_integer_min_inclusive005_1552_integer_min_inclusive005_1552_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_inclusive004_1551_integer_min_inclusive004_1551_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1 and
@@ -4826,11 +5128,12 @@ def test_integer_min_inclusive004_1551_integer_min_inclusive004_1551_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_inclusive003_1550_integer_min_inclusive003_1550_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -4842,11 +5145,12 @@ def test_integer_min_inclusive003_1550_integer_min_inclusive003_1550_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_inclusive002_1549_integer_min_inclusive002_1549_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5 and
@@ -4858,11 +5162,12 @@ def test_integer_min_inclusive002_1549_integer_min_inclusive002_1549_i(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_min_inclusive001_1548_integer_min_inclusive001_1548_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1 and
@@ -4874,11 +5179,12 @@ def test_integer_min_inclusive001_1548_integer_min_inclusive001_1548_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_max_exclusive003_1547_integer_max_exclusive003_1547_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7 and
@@ -4890,11 +5196,12 @@ def test_integer_max_exclusive003_1547_integer_max_exclusive003_1547_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_max_exclusive002_1546_integer_max_exclusive002_1546_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -4906,11 +5213,12 @@ def test_integer_max_exclusive002_1546_integer_max_exclusive002_1546_i(save_xml)
         instance="msData/datatypes/Facets/integer/integer_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_max_exclusive001_1545_integer_max_exclusive001_1545_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1 and
@@ -4922,11 +5230,12 @@ def test_integer_max_exclusive001_1545_integer_max_exclusive001_1545_i(save_xml)
         instance="msData/datatypes/Facets/integer/integer_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_max_inclusive003_1544_integer_max_inclusive003_1544_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7 and
@@ -4938,11 +5247,12 @@ def test_integer_max_inclusive003_1544_integer_max_inclusive003_1544_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_max_inclusive002_1543_integer_max_inclusive002_1543_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -4954,11 +5264,12 @@ def test_integer_max_inclusive002_1543_integer_max_inclusive002_1543_i(save_xml)
         instance="msData/datatypes/Facets/integer/integer_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_max_inclusive001_1542_integer_max_inclusive001_1542_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1 and
@@ -4970,11 +5281,12 @@ def test_integer_max_inclusive001_1542_integer_max_inclusive001_1542_v(save_xml)
         instance="msData/datatypes/Facets/integer/integer_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_enumeration004_1541_integer_enumeration004_1541_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=123 456
@@ -4986,11 +5298,12 @@ def test_integer_enumeration004_1541_integer_enumeration004_1541_v(save_xml):
         instance="msData/datatypes/Facets/integer/integer_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_enumeration003_1540_integer_enumeration003_1540_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=123 456
@@ -5002,11 +5315,12 @@ def test_integer_enumeration003_1540_integer_enumeration003_1540_i(save_xml):
         instance="msData/datatypes/Facets/integer/integer_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_enumeration002_1539_integer_enumeration002_1539_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=123 and
@@ -5018,11 +5332,12 @@ def test_integer_enumeration002_1539_integer_enumeration002_1539_v(save_xml):
         instance="msData/datatypes/Facets/integer/integer_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_enumeration001_1538_integer_enumeration001_1538_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=123 and
@@ -5034,11 +5349,12 @@ def test_integer_enumeration001_1538_integer_enumeration001_1538_i(save_xml):
         instance="msData/datatypes/Facets/integer/integer_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_integer_pattern001_1537_integer_pattern001_1537_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and value=\p{Nd}{1,3}
@@ -5050,11 +5366,12 @@ def test_integer_pattern001_1537_integer_pattern001_1537_v(save_xml):
         instance="msData/datatypes/Facets/integer/integer_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_enumeration004_1536_idref_enumeration004_1536_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5066,11 +5383,12 @@ def test_idref_enumeration004_1536_idref_enumeration004_1536_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_enumeration003_1535_idref_enumeration003_1535_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5082,11 +5400,12 @@ def test_idref_enumeration003_1535_idref_enumeration003_1535_i(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_enumeration002_1534_idref_enumeration002_1534_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5098,11 +5417,12 @@ def test_idref_enumeration002_1534_idref_enumeration002_1534_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_enumeration001_1533_idref_enumeration001_1533_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5114,11 +5434,12 @@ def test_idref_enumeration001_1533_idref_enumeration001_1533_i(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_pattern001_1532_idref_pattern001_1532_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -5130,11 +5451,12 @@ def test_idref_pattern001_1532_idref_pattern001_1532_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_max_length003_1531_idref_max_length003_1531_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -5146,11 +5468,12 @@ def test_idref_max_length003_1531_idref_max_length003_1531_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_max_length002_1530_idref_max_length002_1530_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -5162,11 +5485,12 @@ def test_idref_max_length002_1530_idref_max_length002_1530_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_max_length001_1529_idref_max_length001_1529_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -5178,11 +5502,12 @@ def test_idref_max_length001_1529_idref_max_length001_1529_i(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_min_length004_1528_idref_min_length004_1528_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -5194,11 +5519,12 @@ def test_idref_min_length004_1528_idref_min_length004_1528_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_min_length003_1527_idref_min_length003_1527_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -5210,11 +5536,12 @@ def test_idref_min_length003_1527_idref_min_length003_1527_i(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_min_length002_1526_idref_min_length002_1526_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -5226,11 +5553,12 @@ def test_idref_min_length002_1526_idref_min_length002_1526_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_min_length001_1525_idref_min_length001_1525_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -5242,11 +5570,12 @@ def test_idref_min_length001_1525_idref_min_length001_1525_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_length003_1524_idref_length003_1524_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -5258,11 +5587,12 @@ def test_idref_length003_1524_idref_length003_1524_i(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_length002_1523_idref_length002_1523_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -5274,11 +5604,12 @@ def test_idref_length002_1523_idref_length002_1523_v(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idref_length001_1522_idref_length001_1522_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -5290,11 +5621,12 @@ def test_idref_length001_1522_idref_length001_1522_i(save_xml):
         instance="msData/datatypes/Facets/IDREF/IDREF_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_enumeration004_1521_id_enumeration004_1521_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5306,11 +5638,12 @@ def test_id_enumeration004_1521_id_enumeration004_1521_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_enumeration003_1520_id_enumeration003_1520_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5322,11 +5655,12 @@ def test_id_enumeration003_1520_id_enumeration003_1520_i(save_xml):
         instance="msData/datatypes/Facets/ID/ID_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_enumeration002_1519_id_enumeration002_1519_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5338,11 +5672,12 @@ def test_id_enumeration002_1519_id_enumeration002_1519_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_enumeration001_1518_id_enumeration001_1518_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5354,11 +5689,12 @@ def test_id_enumeration001_1518_id_enumeration001_1518_i(save_xml):
         instance="msData/datatypes/Facets/ID/ID_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_pattern001_1517_id_pattern001_1517_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -5370,11 +5706,12 @@ def test_id_pattern001_1517_id_pattern001_1517_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_max_length003_1516_id_max_length003_1516_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -5386,11 +5723,12 @@ def test_id_max_length003_1516_id_max_length003_1516_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_max_length002_1515_id_max_length002_1515_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -5402,11 +5740,12 @@ def test_id_max_length002_1515_id_max_length002_1515_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_max_length001_1514_id_max_length001_1514_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -5418,11 +5757,12 @@ def test_id_max_length001_1514_id_max_length001_1514_i(save_xml):
         instance="msData/datatypes/Facets/ID/ID_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_min_length004_1513_id_min_length004_1513_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -5434,11 +5774,12 @@ def test_id_min_length004_1513_id_min_length004_1513_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_min_length003_1512_id_min_length003_1512_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -5450,11 +5791,12 @@ def test_id_min_length003_1512_id_min_length003_1512_i(save_xml):
         instance="msData/datatypes/Facets/ID/ID_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_min_length002_1511_id_min_length002_1511_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -5466,11 +5808,12 @@ def test_id_min_length002_1511_id_min_length002_1511_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_min_length001_1510_id_min_length001_1510_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -5482,11 +5825,12 @@ def test_id_min_length001_1510_id_min_length001_1510_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_length003_1509_id_length003_1509_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -5498,11 +5842,12 @@ def test_id_length003_1509_id_length003_1509_i(save_xml):
         instance="msData/datatypes/Facets/ID/ID_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_length002_1508_id_length002_1508_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -5514,11 +5859,12 @@ def test_id_length002_1508_id_length002_1508_v(save_xml):
         instance="msData/datatypes/Facets/ID/ID_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_length001_1507_id_length001_1507_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -5530,11 +5876,12 @@ def test_id_length001_1507_id_length001_1507_i(save_xml):
         instance="msData/datatypes/Facets/ID/ID_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_enumeration004_1506_ncname_enumeration004_1506_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5546,11 +5893,12 @@ def test_ncname_enumeration004_1506_ncname_enumeration004_1506_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_enumeration003_1505_ncname_enumeration003_1505_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5562,11 +5910,12 @@ def test_ncname_enumeration003_1505_ncname_enumeration003_1505_i(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_enumeration002_1504_ncname_enumeration002_1504_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5578,11 +5927,12 @@ def test_ncname_enumeration002_1504_ncname_enumeration002_1504_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_enumeration001_1503_ncname_enumeration001_1503_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5594,11 +5944,12 @@ def test_ncname_enumeration001_1503_ncname_enumeration001_1503_i(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_pattern001_1502_ncname_pattern001_1502_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -5610,11 +5961,12 @@ def test_ncname_pattern001_1502_ncname_pattern001_1502_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_max_length003_1501_ncname_max_length003_1501_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -5626,11 +5978,12 @@ def test_ncname_max_length003_1501_ncname_max_length003_1501_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_max_length002_1500_ncname_max_length002_1500_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -5642,11 +5995,12 @@ def test_ncname_max_length002_1500_ncname_max_length002_1500_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_max_length001_1499_ncname_max_length001_1499_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -5658,11 +6012,12 @@ def test_ncname_max_length001_1499_ncname_max_length001_1499_i(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_min_length004_1498_ncname_min_length004_1498_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -5674,11 +6029,12 @@ def test_ncname_min_length004_1498_ncname_min_length004_1498_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_min_length003_1497_ncname_min_length003_1497_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -5690,11 +6046,12 @@ def test_ncname_min_length003_1497_ncname_min_length003_1497_i(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_min_length002_1496_ncname_min_length002_1496_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -5706,11 +6063,12 @@ def test_ncname_min_length002_1496_ncname_min_length002_1496_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_min_length001_1495_ncname_min_length001_1495_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -5722,11 +6080,12 @@ def test_ncname_min_length001_1495_ncname_min_length001_1495_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_length003_1494_ncname_length003_1494_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -5738,11 +6097,12 @@ def test_ncname_length003_1494_ncname_length003_1494_i(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_length002_1493_ncname_length002_1493_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -5754,11 +6114,12 @@ def test_ncname_length002_1493_ncname_length002_1493_v(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ncname_length001_1492_ncname_length001_1492_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -5770,11 +6131,12 @@ def test_ncname_length001_1492_ncname_length001_1492_i(save_xml):
         instance="msData/datatypes/Facets/NCName/NCName_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_enumeration004_1491_name_enumeration004_1491_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5786,11 +6148,12 @@ def test_name_enumeration004_1491_name_enumeration004_1491_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_enumeration003_1490_name_enumeration003_1490_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -5802,11 +6165,12 @@ def test_name_enumeration003_1490_name_enumeration003_1490_i(save_xml):
         instance="msData/datatypes/Facets/Name/Name_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_enumeration002_1489_name_enumeration002_1489_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5818,11 +6182,12 @@ def test_name_enumeration002_1489_name_enumeration002_1489_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_enumeration001_1488_name_enumeration001_1488_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -5834,11 +6199,12 @@ def test_name_enumeration001_1488_name_enumeration001_1488_i(save_xml):
         instance="msData/datatypes/Facets/Name/Name_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_pattern001_1487_name_pattern001_1487_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -5850,11 +6216,12 @@ def test_name_pattern001_1487_name_pattern001_1487_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_max_length003_1486_name_max_length003_1486_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -5866,11 +6233,12 @@ def test_name_max_length003_1486_name_max_length003_1486_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_max_length002_1485_name_max_length002_1485_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -5882,11 +6250,12 @@ def test_name_max_length002_1485_name_max_length002_1485_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_max_length001_1484_name_max_length001_1484_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -5898,11 +6267,12 @@ def test_name_max_length001_1484_name_max_length001_1484_i(save_xml):
         instance="msData/datatypes/Facets/Name/Name_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_min_length004_1483_name_min_length004_1483_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -5914,11 +6284,12 @@ def test_name_min_length004_1483_name_min_length004_1483_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_min_length003_1482_name_min_length003_1482_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -5930,11 +6301,12 @@ def test_name_min_length003_1482_name_min_length003_1482_i(save_xml):
         instance="msData/datatypes/Facets/Name/Name_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_min_length002_1481_name_min_length002_1481_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -5946,11 +6318,12 @@ def test_name_min_length002_1481_name_min_length002_1481_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_min_length001_1480_name_min_length001_1480_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -5962,11 +6335,12 @@ def test_name_min_length001_1480_name_min_length001_1480_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_length003_1479_name_length003_1479_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -5978,11 +6352,12 @@ def test_name_length003_1479_name_length003_1479_i(save_xml):
         instance="msData/datatypes/Facets/Name/Name_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_length002_1478_name_length002_1478_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -5994,11 +6369,12 @@ def test_name_length002_1478_name_length002_1478_v(save_xml):
         instance="msData/datatypes/Facets/Name/Name_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name_length001_1477_name_length001_1477_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -6010,11 +6386,12 @@ def test_name_length001_1477_name_length001_1477_i(save_xml):
         instance="msData/datatypes/Facets/Name/Name_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_pattern002_1476_nmtokens_pattern002_1476_i(save_xml):
     """
     TEST :Facet Schemas for string : XSD: NMTOKENS, IDREFS, and ENTITIES
@@ -6026,11 +6403,12 @@ def test_nmtokens_pattern002_1476_nmtokens_pattern002_1476_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_pattern002.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_pattern001_1475_nmtokens_pattern001_1475_v(save_xml):
     """
     TEST :Facet Schemas for string : XSD: NMTOKENS, IDREFS, and ENTITIES
@@ -6042,11 +6420,12 @@ def test_nmtokens_pattern001_1475_nmtokens_pattern001_1475_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_pattern001.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_enumeration004_1474_nmtokens_enumeration004_1474_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6058,11 +6437,12 @@ def test_nmtokens_enumeration004_1474_nmtokens_enumeration004_1474_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_enumeration003_1473_nmtokens_enumeration003_1473_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6074,11 +6454,12 @@ def test_nmtokens_enumeration003_1473_nmtokens_enumeration003_1473_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_enumeration002_1472_nmtokens_enumeration002_1472_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6090,11 +6471,12 @@ def test_nmtokens_enumeration002_1472_nmtokens_enumeration002_1472_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_enumeration001_1471_nmtokens_enumeration001_1471_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6106,11 +6488,12 @@ def test_nmtokens_enumeration001_1471_nmtokens_enumeration001_1471_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_max_length003_1470_nmtokens_max_length003_1470_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -6122,11 +6505,12 @@ def test_nmtokens_max_length003_1470_nmtokens_max_length003_1470_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_max_length002_1469_nmtokens_max_length002_1469_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -6138,11 +6522,12 @@ def test_nmtokens_max_length002_1469_nmtokens_max_length002_1469_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_min_length003_1466_nmtokens_min_length003_1466_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -6154,11 +6539,12 @@ def test_nmtokens_min_length003_1466_nmtokens_min_length003_1466_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_min_length002_1465_nmtokens_min_length002_1465_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -6170,11 +6556,12 @@ def test_nmtokens_min_length002_1465_nmtokens_min_length002_1465_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_length003_1463_nmtokens_length003_1463_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -6186,11 +6573,12 @@ def test_nmtokens_length003_1463_nmtokens_length003_1463_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_length002_1462_nmtokens_length002_1462_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -6202,11 +6590,12 @@ def test_nmtokens_length002_1462_nmtokens_length002_1462_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtokens_length001_1461_nmtokens_length001_1461_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -6218,11 +6607,12 @@ def test_nmtokens_length001_1461_nmtokens_length001_1461_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKENS/NMTOKENS_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_enumeration004_1460_nmtoken_enumeration004_1460_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6234,11 +6624,12 @@ def test_nmtoken_enumeration004_1460_nmtoken_enumeration004_1460_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_enumeration003_1459_nmtoken_enumeration003_1459_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6250,11 +6641,12 @@ def test_nmtoken_enumeration003_1459_nmtoken_enumeration003_1459_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_enumeration002_1458_nmtoken_enumeration002_1458_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6266,11 +6658,12 @@ def test_nmtoken_enumeration002_1458_nmtoken_enumeration002_1458_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_enumeration001_1457_nmtoken_enumeration001_1457_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6282,11 +6675,12 @@ def test_nmtoken_enumeration001_1457_nmtoken_enumeration001_1457_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_pattern001_1456_nmtoken_pattern001_1456_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -6298,11 +6692,12 @@ def test_nmtoken_pattern001_1456_nmtoken_pattern001_1456_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_max_length003_1455_nmtoken_max_length003_1455_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -6314,11 +6709,12 @@ def test_nmtoken_max_length003_1455_nmtoken_max_length003_1455_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_max_length002_1454_nmtoken_max_length002_1454_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -6330,11 +6726,12 @@ def test_nmtoken_max_length002_1454_nmtoken_max_length002_1454_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_max_length001_1453_nmtoken_max_length001_1453_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -6346,11 +6743,12 @@ def test_nmtoken_max_length001_1453_nmtoken_max_length001_1453_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_min_length004_1452_nmtoken_min_length004_1452_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -6362,11 +6760,12 @@ def test_nmtoken_min_length004_1452_nmtoken_min_length004_1452_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_min_length003_1451_nmtoken_min_length003_1451_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -6378,11 +6777,12 @@ def test_nmtoken_min_length003_1451_nmtoken_min_length003_1451_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_min_length002_1450_nmtoken_min_length002_1450_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -6394,11 +6794,12 @@ def test_nmtoken_min_length002_1450_nmtoken_min_length002_1450_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_min_length001_1449_nmtoken_min_length001_1449_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -6410,11 +6811,12 @@ def test_nmtoken_min_length001_1449_nmtoken_min_length001_1449_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_length003_1448_nmtoken_length003_1448_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -6426,11 +6828,12 @@ def test_nmtoken_length003_1448_nmtoken_length003_1448_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_length002_1447_nmtoken_length002_1447_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -6442,11 +6845,12 @@ def test_nmtoken_length002_1447_nmtoken_length002_1447_v(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nmtoken_length001_1446_nmtoken_length001_1446_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -6458,11 +6862,12 @@ def test_nmtoken_length001_1446_nmtoken_length001_1446_i(save_xml):
         instance="msData/datatypes/Facets/NMTOKEN/NMTOKEN_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_enumeration004_1445_idrefs_enumeration004_1445_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6474,11 +6879,12 @@ def test_idrefs_enumeration004_1445_idrefs_enumeration004_1445_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_enumeration003_1444_idrefs_enumeration003_1444_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6490,11 +6896,12 @@ def test_idrefs_enumeration003_1444_idrefs_enumeration003_1444_i(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_enumeration002_1443_idrefs_enumeration002_1443_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6506,11 +6913,12 @@ def test_idrefs_enumeration002_1443_idrefs_enumeration002_1443_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_enumeration001_1442_idrefs_enumeration001_1442_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6522,11 +6930,12 @@ def test_idrefs_enumeration001_1442_idrefs_enumeration001_1442_i(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_max_length003_1441_idrefs_max_length003_1441_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=2 and
@@ -6538,11 +6947,12 @@ def test_idrefs_max_length003_1441_idrefs_max_length003_1441_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_max_length002_1440_idrefs_max_length002_1440_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=1 and
@@ -6554,11 +6964,12 @@ def test_idrefs_max_length002_1440_idrefs_max_length002_1440_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_max_length001_1439_idrefs_max_length001_1439_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=2 and
@@ -6570,11 +6981,12 @@ def test_idrefs_max_length001_1439_idrefs_max_length001_1439_i(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_min_length004_1438_idrefs_min_length004_1438_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -6586,11 +6998,12 @@ def test_idrefs_min_length004_1438_idrefs_min_length004_1438_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_min_length003_1437_idrefs_min_length003_1437_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=3 and
@@ -6602,11 +7015,12 @@ def test_idrefs_min_length003_1437_idrefs_min_length003_1437_i(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_min_length002_1436_idrefs_min_length002_1436_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=2 and
@@ -6618,11 +7032,12 @@ def test_idrefs_min_length002_1436_idrefs_min_length002_1436_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_min_length001_1435_idrefs_min_length001_1435_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=1 and
@@ -6634,11 +7049,12 @@ def test_idrefs_min_length001_1435_idrefs_min_length001_1435_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_length003_1434_idrefs_length003_1434_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=1 and document
@@ -6650,11 +7066,12 @@ def test_idrefs_length003_1434_idrefs_length003_1434_i(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_length002_1433_idrefs_length002_1433_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=2 and document
@@ -6666,11 +7083,12 @@ def test_idrefs_length002_1433_idrefs_length002_1433_v(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idrefs_length001_1432_idrefs_length001_1432_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -6682,11 +7100,12 @@ def test_idrefs_length001_1432_idrefs_length001_1432_i(save_xml):
         instance="msData/datatypes/Facets/IDREFS/IDREFS_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_enumeration004_1431_language_enumeration004_1431_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=en fr de
@@ -6698,11 +7117,12 @@ def test_language_enumeration004_1431_language_enumeration004_1431_v(save_xml):
         instance="msData/datatypes/Facets/language/language_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_enumeration003_1430_language_enumeration003_1430_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=en fr de
@@ -6714,11 +7134,12 @@ def test_language_enumeration003_1430_language_enumeration003_1430_i(save_xml):
         instance="msData/datatypes/Facets/language/language_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_enumeration002_1429_language_enumeration002_1429_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=en and
@@ -6730,11 +7151,12 @@ def test_language_enumeration002_1429_language_enumeration002_1429_v(save_xml):
         instance="msData/datatypes/Facets/language/language_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_enumeration001_1428_language_enumeration001_1428_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=en and
@@ -6746,11 +7168,12 @@ def test_language_enumeration001_1428_language_enumeration001_1428_i(save_xml):
         instance="msData/datatypes/Facets/language/language_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_pattern001_1427_language_pattern001_1427_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=en-[a-z]{2}
@@ -6762,11 +7185,12 @@ def test_language_pattern001_1427_language_pattern001_1427_v(save_xml):
         instance="msData/datatypes/Facets/language/language_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_max_length003_1426_language_max_length003_1426_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -6778,11 +7202,12 @@ def test_language_max_length003_1426_language_max_length003_1426_v(save_xml):
         instance="msData/datatypes/Facets/language/language_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_max_length002_1425_language_max_length002_1425_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -6794,11 +7219,12 @@ def test_language_max_length002_1425_language_max_length002_1425_v(save_xml):
         instance="msData/datatypes/Facets/language/language_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_max_length001_1424_language_max_length001_1424_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -6810,11 +7236,12 @@ def test_language_max_length001_1424_language_max_length001_1424_i(save_xml):
         instance="msData/datatypes/Facets/language/language_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_min_length004_1423_language_min_length004_1423_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -6826,11 +7253,12 @@ def test_language_min_length004_1423_language_min_length004_1423_v(save_xml):
         instance="msData/datatypes/Facets/language/language_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_min_length003_1422_language_min_length003_1422_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -6842,11 +7270,12 @@ def test_language_min_length003_1422_language_min_length003_1422_i(save_xml):
         instance="msData/datatypes/Facets/language/language_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_min_length002_1421_language_min_length002_1421_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -6858,11 +7287,12 @@ def test_language_min_length002_1421_language_min_length002_1421_v(save_xml):
         instance="msData/datatypes/Facets/language/language_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_min_length001_1420_language_min_length001_1420_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -6874,11 +7304,12 @@ def test_language_min_length001_1420_language_min_length001_1420_v(save_xml):
         instance="msData/datatypes/Facets/language/language_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_length003_1419_language_length003_1419_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -6890,11 +7321,12 @@ def test_language_length003_1419_language_length003_1419_i(save_xml):
         instance="msData/datatypes/Facets/language/language_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_length002_1418_language_length002_1418_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -6906,11 +7338,12 @@ def test_language_length002_1418_language_length002_1418_v(save_xml):
         instance="msData/datatypes/Facets/language/language_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_language_length001_1417_language_length001_1417_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -6922,11 +7355,12 @@ def test_language_length001_1417_language_length001_1417_i(save_xml):
         instance="msData/datatypes/Facets/language/language_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_enumeration004_1416_token_enumeration004_1416_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6938,11 +7372,12 @@ def test_token_enumeration004_1416_token_enumeration004_1416_v(save_xml):
         instance="msData/datatypes/Facets/token/token_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_enumeration003_1415_token_enumeration003_1415_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -6954,11 +7389,12 @@ def test_token_enumeration003_1415_token_enumeration003_1415_i(save_xml):
         instance="msData/datatypes/Facets/token/token_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_enumeration002_1414_token_enumeration002_1414_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6970,11 +7406,12 @@ def test_token_enumeration002_1414_token_enumeration002_1414_v(save_xml):
         instance="msData/datatypes/Facets/token/token_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_enumeration001_1413_token_enumeration001_1413_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -6986,11 +7423,12 @@ def test_token_enumeration001_1413_token_enumeration001_1413_i(save_xml):
         instance="msData/datatypes/Facets/token/token_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_pattern001_1412_token_pattern001_1412_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -7002,11 +7440,12 @@ def test_token_pattern001_1412_token_pattern001_1412_v(save_xml):
         instance="msData/datatypes/Facets/token/token_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_max_length003_1411_token_max_length003_1411_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -7018,11 +7457,12 @@ def test_token_max_length003_1411_token_max_length003_1411_v(save_xml):
         instance="msData/datatypes/Facets/token/token_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_max_length002_1410_token_max_length002_1410_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -7034,11 +7474,12 @@ def test_token_max_length002_1410_token_max_length002_1410_v(save_xml):
         instance="msData/datatypes/Facets/token/token_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_max_length001_1409_token_max_length001_1409_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -7050,11 +7491,12 @@ def test_token_max_length001_1409_token_max_length001_1409_i(save_xml):
         instance="msData/datatypes/Facets/token/token_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_min_length004_1408_token_min_length004_1408_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -7066,11 +7508,12 @@ def test_token_min_length004_1408_token_min_length004_1408_v(save_xml):
         instance="msData/datatypes/Facets/token/token_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_min_length003_1407_token_min_length003_1407_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -7082,11 +7525,12 @@ def test_token_min_length003_1407_token_min_length003_1407_i(save_xml):
         instance="msData/datatypes/Facets/token/token_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_min_length002_1406_token_min_length002_1406_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -7098,11 +7542,12 @@ def test_token_min_length002_1406_token_min_length002_1406_v(save_xml):
         instance="msData/datatypes/Facets/token/token_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_min_length001_1405_token_min_length001_1405_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -7114,11 +7559,12 @@ def test_token_min_length001_1405_token_min_length001_1405_v(save_xml):
         instance="msData/datatypes/Facets/token/token_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_length003_1404_token_length003_1404_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -7130,11 +7576,12 @@ def test_token_length003_1404_token_length003_1404_i(save_xml):
         instance="msData/datatypes/Facets/token/token_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_length002_1403_token_length002_1403_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -7146,11 +7593,12 @@ def test_token_length002_1403_token_length002_1403_v(save_xml):
         instance="msData/datatypes/Facets/token/token_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_token_length001_1402_token_length001_1402_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -7162,11 +7610,12 @@ def test_token_length001_1402_token_length001_1402_i(save_xml):
         instance="msData/datatypes/Facets/token/token_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_enumeration004_1401_normalized_string_enumeration004_1401_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -7178,11 +7627,12 @@ def test_normalized_string_enumeration004_1401_normalized_string_enumeration004_
         instance="msData/datatypes/Facets/normalizedString/normalizedString_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_enumeration003_1400_normalized_string_enumeration003_1400_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -7194,11 +7644,12 @@ def test_normalized_string_enumeration003_1400_normalized_string_enumeration003_
         instance="msData/datatypes/Facets/normalizedString/normalizedString_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_enumeration002_1399_normalized_string_enumeration002_1399_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -7210,11 +7661,12 @@ def test_normalized_string_enumeration002_1399_normalized_string_enumeration002_
         instance="msData/datatypes/Facets/normalizedString/normalizedString_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_enumeration001_1398_normalized_string_enumeration001_1398_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -7226,11 +7678,12 @@ def test_normalized_string_enumeration001_1398_normalized_string_enumeration001_
         instance="msData/datatypes/Facets/normalizedString/normalizedString_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_pattern001_1397_normalized_string_pattern001_1397_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -7242,11 +7695,12 @@ def test_normalized_string_pattern001_1397_normalized_string_pattern001_1397_v(s
         instance="msData/datatypes/Facets/normalizedString/normalizedString_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_max_length003_1396_normalized_string_max_length003_1396_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -7258,11 +7712,12 @@ def test_normalized_string_max_length003_1396_normalized_string_max_length003_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_max_length002_1395_normalized_string_max_length002_1395_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -7274,11 +7729,12 @@ def test_normalized_string_max_length002_1395_normalized_string_max_length002_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_max_length001_1394_normalized_string_max_length001_1394_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -7290,11 +7746,12 @@ def test_normalized_string_max_length001_1394_normalized_string_max_length001_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_min_length004_1393_normalized_string_min_length004_1393_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -7306,11 +7763,12 @@ def test_normalized_string_min_length004_1393_normalized_string_min_length004_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_min_length003_1392_normalized_string_min_length003_1392_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -7322,11 +7780,12 @@ def test_normalized_string_min_length003_1392_normalized_string_min_length003_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_min_length002_1391_normalized_string_min_length002_1391_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -7338,11 +7797,12 @@ def test_normalized_string_min_length002_1391_normalized_string_min_length002_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_min_length001_1390_normalized_string_min_length001_1390_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -7354,11 +7814,12 @@ def test_normalized_string_min_length001_1390_normalized_string_min_length001_13
         instance="msData/datatypes/Facets/normalizedString/normalizedString_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_length003_1389_normalized_string_length003_1389_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -7370,11 +7831,12 @@ def test_normalized_string_length003_1389_normalized_string_length003_1389_i(sav
         instance="msData/datatypes/Facets/normalizedString/normalizedString_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_length002_1388_normalized_string_length002_1388_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -7386,11 +7848,12 @@ def test_normalized_string_length002_1388_normalized_string_length002_1388_v(sav
         instance="msData/datatypes/Facets/normalizedString/normalizedString_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_normalized_string_length001_1387_normalized_string_length001_1387_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -7402,11 +7865,12 @@ def test_normalized_string_length001_1387_normalized_string_length001_1387_i(sav
         instance="msData/datatypes/Facets/normalizedString/normalizedString_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_enumeration004_1386_notation_enumeration004_1386_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -7418,11 +7882,12 @@ def test_notation_enumeration004_1386_notation_enumeration004_1386_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_enumeration003_1385_notation_enumeration003_1385_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -7434,11 +7899,12 @@ def test_notation_enumeration003_1385_notation_enumeration003_1385_i(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_enumeration002_1384_notation_enumeration002_1384_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -7450,11 +7916,12 @@ def test_notation_enumeration002_1384_notation_enumeration002_1384_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_enumeration001_1383_notation_enumeration001_1383_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -7466,11 +7933,12 @@ def test_notation_enumeration001_1383_notation_enumeration001_1383_i(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_pattern001_1382_notation_pattern001_1382_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -7482,11 +7950,12 @@ def test_notation_pattern001_1382_notation_pattern001_1382_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_max_length003_1381_notation_max_length003_1381_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -7498,11 +7967,12 @@ def test_notation_max_length003_1381_notation_max_length003_1381_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_max_length002_1380_notation_max_length002_1380_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -7514,11 +7984,12 @@ def test_notation_max_length002_1380_notation_max_length002_1380_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_max_length001_1379_notation_max_length001_1379_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -7531,11 +8002,12 @@ def test_notation_max_length001_1379_notation_max_length001_1379_i(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_maxLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_min_length004_1378_notation_min_length004_1378_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -7547,11 +8019,12 @@ def test_notation_min_length004_1378_notation_min_length004_1378_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_min_length003_1377_notation_min_length003_1377_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -7564,11 +8037,12 @@ def test_notation_min_length003_1377_notation_min_length003_1377_i(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_minLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_min_length002_1376_notation_min_length002_1376_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -7580,11 +8054,12 @@ def test_notation_min_length002_1376_notation_min_length002_1376_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_min_length001_1375_notation_min_length001_1375_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -7596,11 +8071,12 @@ def test_notation_min_length001_1375_notation_min_length001_1375_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_length003_1374_notation_length003_1374_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -7613,11 +8089,12 @@ def test_notation_length003_1374_notation_length003_1374_i(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_length003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_length002_1373_notation_length002_1373_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -7629,11 +8106,12 @@ def test_notation_length002_1373_notation_length002_1373_v(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notation_length001_1372_notation_length001_1372_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -7646,11 +8124,12 @@ def test_notation_length001_1372_notation_length001_1372_i(save_xml):
         instance="msData/datatypes/Facets/NOTATION/NOTATION_length001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_enumeration004_1371_qname_enumeration004_1371_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo:fo
@@ -7662,11 +8141,12 @@ def test_qname_enumeration004_1371_qname_enumeration004_1371_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_enumeration003_1370_qname_enumeration003_1370_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo:fo
@@ -7678,11 +8158,12 @@ def test_qname_enumeration003_1370_qname_enumeration003_1370_i(save_xml):
         instance="msData/datatypes/Facets/QName/QName_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_enumeration002_1369_qname_enumeration002_1369_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo:fo
@@ -7694,11 +8175,12 @@ def test_qname_enumeration002_1369_qname_enumeration002_1369_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_enumeration001_1368_qname_enumeration001_1368_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo:fo
@@ -7710,11 +8192,12 @@ def test_qname_enumeration001_1368_qname_enumeration001_1368_i(save_xml):
         instance="msData/datatypes/Facets/QName/QName_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_pattern001_1367_qname_pattern001_1367_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -7726,11 +8209,12 @@ def test_qname_pattern001_1367_qname_pattern001_1367_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_max_length003_1366_qname_max_length003_1366_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -7742,11 +8226,12 @@ def test_qname_max_length003_1366_qname_max_length003_1366_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_max_length002_1365_qname_max_length002_1365_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -7758,11 +8243,12 @@ def test_qname_max_length002_1365_qname_max_length002_1365_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_max_length001_1364_qname_max_length001_1364_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -7775,11 +8261,12 @@ def test_qname_max_length001_1364_qname_max_length001_1364_i(save_xml):
         instance="msData/datatypes/Facets/QName/QName_maxLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_min_length004_1363_qname_min_length004_1363_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -7791,11 +8278,12 @@ def test_qname_min_length004_1363_qname_min_length004_1363_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_min_length003_1362_qname_min_length003_1362_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -7808,11 +8296,12 @@ def test_qname_min_length003_1362_qname_min_length003_1362_i(save_xml):
         instance="msData/datatypes/Facets/QName/QName_minLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_min_length002_1361_qname_min_length002_1361_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -7824,11 +8313,12 @@ def test_qname_min_length002_1361_qname_min_length002_1361_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_min_length001_1360_qname_min_length001_1360_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -7840,11 +8330,12 @@ def test_qname_min_length001_1360_qname_min_length001_1360_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_length003_1359_qname_length003_1359_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -7857,11 +8348,12 @@ def test_qname_length003_1359_qname_length003_1359_i(save_xml):
         instance="msData/datatypes/Facets/QName/QName_length003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_length002_1358_qname_length002_1358_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -7873,11 +8365,12 @@ def test_qname_length002_1358_qname_length002_1358_v(save_xml):
         instance="msData/datatypes/Facets/QName/QName_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qname_length001_1357_qname_length001_1357_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -7890,7 +8383,7 @@ def test_qname_length001_1357_qname_length001_1357_i(save_xml):
         instance="msData/datatypes/Facets/QName/QName_length001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -7916,6 +8409,7 @@ def test_any_uri_b006_1356_any_uri_b006_1356_i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_b005_1355_any_uri_b005_1355_i(save_xml):
     """
     TEST :Facet Schemas for string : 2 spaces should not match one %20,
@@ -7927,7 +8421,7 @@ def test_any_uri_b005_1355_any_uri_b005_1355_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_b005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -7953,6 +8447,7 @@ def test_any_uri_b004_1354_any_uri_b004_1354_v(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_b002_1353_any_uri_b002_1353_v(save_xml):
     """
     TEST :Facet Schemas for string : enum of anyURI: with dbcs char, and
@@ -7964,11 +8459,12 @@ def test_any_uri_b002_1353_any_uri_b002_1353_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_b002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_b001_1352_any_uri_b001_1352_i(save_xml):
     """
     TEST :Facet Schemas for string : enum of anyURI: c, and instance has
@@ -7980,11 +8476,12 @@ def test_any_uri_b001_1352_any_uri_b001_1352_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_b001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_a004_1339_any_uri_a004_1339_i(save_xml):
     """
     TEST :Facet Schemas for string : test that uri with ftp:// gofer://
@@ -7998,11 +8495,12 @@ def test_any_uri_a004_1339_any_uri_a004_1339_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_a004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_a002_1337_any_uri_a002_1337_v(save_xml):
     """
     TEST :Facet Schemas for string : test that dbcs charanters are allowed
@@ -8015,7 +8513,7 @@ def test_any_uri_a002_1337_any_uri_a002_1337_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_a002.xml",
         instance_is_valid=True,
         class_name="Bar",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -8039,6 +8537,7 @@ def test_any_uri_a001_1336_any_uri_a001_1336_v(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_enumeration004_1335_any_uri_enumeration004_1335_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -8051,11 +8550,12 @@ def test_any_uri_enumeration004_1335_any_uri_enumeration004_1335_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_enumeration003_1334_any_uri_enumeration003_1334_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo
@@ -8068,11 +8568,12 @@ def test_any_uri_enumeration003_1334_any_uri_enumeration003_1334_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_enumeration002_1333_any_uri_enumeration002_1333_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -8084,11 +8585,12 @@ def test_any_uri_enumeration002_1333_any_uri_enumeration002_1333_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_enumeration001_1332_any_uri_enumeration001_1332_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -8100,11 +8602,12 @@ def test_any_uri_enumeration001_1332_any_uri_enumeration001_1332_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_max_length003_1331_any_uri_max_length003_1331_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -8116,11 +8619,12 @@ def test_any_uri_max_length003_1331_any_uri_max_length003_1331_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_max_length002_1330_any_uri_max_length002_1330_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -8132,11 +8636,12 @@ def test_any_uri_max_length002_1330_any_uri_max_length002_1330_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_max_length001_1329_any_uri_max_length001_1329_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -8148,11 +8653,12 @@ def test_any_uri_max_length001_1329_any_uri_max_length001_1329_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_min_length004_1328_any_uri_min_length004_1328_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -8164,11 +8670,12 @@ def test_any_uri_min_length004_1328_any_uri_min_length004_1328_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_min_length003_1327_any_uri_min_length003_1327_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -8180,11 +8687,12 @@ def test_any_uri_min_length003_1327_any_uri_min_length003_1327_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_min_length002_1326_any_uri_min_length002_1326_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -8196,11 +8704,12 @@ def test_any_uri_min_length002_1326_any_uri_min_length002_1326_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_min_length001_1325_any_uri_min_length001_1325_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -8212,11 +8721,12 @@ def test_any_uri_min_length001_1325_any_uri_min_length001_1325_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_length003_1324_any_uri_length003_1324_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -8228,11 +8738,12 @@ def test_any_uri_length003_1324_any_uri_length003_1324_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_length002_1323_any_uri_length002_1323_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -8244,11 +8755,12 @@ def test_any_uri_length002_1323_any_uri_length002_1323_v(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_any_uri_length001_1322_any_uri_length001_1322_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -8260,11 +8772,12 @@ def test_any_uri_length001_1322_any_uri_length001_1322_i(save_xml):
         instance="msData/datatypes/Facets/anyURI/anyURI_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_enumeration002_1320_base64_binary_enumeration002_1320_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=MS0yLTM=
@@ -8276,11 +8789,12 @@ def test_base64_binary_enumeration002_1320_base64_binary_enumeration002_1320_v(s
         instance="msData/datatypes/Facets/base64Binary/base64Binary_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_enumeration001_1319_base64_binary_enumeration001_1319_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=MS0yLTM=
@@ -8292,11 +8806,12 @@ def test_base64_binary_enumeration001_1319_base64_binary_enumeration001_1319_i(s
         instance="msData/datatypes/Facets/base64Binary/base64Binary_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_max_length003_1318_base64_binary_max_length003_1318_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -8308,11 +8823,12 @@ def test_base64_binary_max_length003_1318_base64_binary_max_length003_1318_i(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_maxLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_max_length002_1317_base64_binary_max_length002_1317_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -8324,11 +8840,12 @@ def test_base64_binary_max_length002_1317_base64_binary_max_length002_1317_i(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_maxLength002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_max_length001_1316_base64_binary_max_length001_1316_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -8340,11 +8857,12 @@ def test_base64_binary_max_length001_1316_base64_binary_max_length001_1316_i(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_min_length004_1315_base64_binary_min_length004_1315_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -8356,11 +8874,12 @@ def test_base64_binary_min_length004_1315_base64_binary_min_length004_1315_v(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_min_length003_1314_base64_binary_min_length003_1314_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -8372,11 +8891,12 @@ def test_base64_binary_min_length003_1314_base64_binary_min_length003_1314_i(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_min_length002_1313_base64_binary_min_length002_1313_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -8388,11 +8908,12 @@ def test_base64_binary_min_length002_1313_base64_binary_min_length002_1313_v(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_min_length001_1312_base64_binary_min_length001_1312_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -8404,11 +8925,12 @@ def test_base64_binary_min_length001_1312_base64_binary_min_length001_1312_v(sav
         instance="msData/datatypes/Facets/base64Binary/base64Binary_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_length003_1311_base64_binary_length003_1311_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -8420,11 +8942,12 @@ def test_base64_binary_length003_1311_base64_binary_length003_1311_i(save_xml):
         instance="msData/datatypes/Facets/base64Binary/base64Binary_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_length002_1310_base64_binary_length002_1310_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -8436,11 +8959,12 @@ def test_base64_binary_length002_1310_base64_binary_length002_1310_v(save_xml):
         instance="msData/datatypes/Facets/base64Binary/base64Binary_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_base64_binary_length001_1309_base64_binary_length001_1309_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -8452,11 +8976,12 @@ def test_base64_binary_length001_1309_base64_binary_length001_1309_i(save_xml):
         instance="msData/datatypes/Facets/base64Binary/base64Binary_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_enumeration004_1308_hex_binary_enumeration004_1308_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=adf789
@@ -8468,11 +8993,12 @@ def test_hex_binary_enumeration004_1308_hex_binary_enumeration004_1308_v(save_xm
         instance="msData/datatypes/Facets/hexBinary/hexBinary_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_enumeration003_1307_hex_binary_enumeration003_1307_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=adf789
@@ -8484,11 +9010,12 @@ def test_hex_binary_enumeration003_1307_hex_binary_enumeration003_1307_i(save_xm
         instance="msData/datatypes/Facets/hexBinary/hexBinary_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_enumeration002_1306_hex_binary_enumeration002_1306_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=adf789
@@ -8500,11 +9027,12 @@ def test_hex_binary_enumeration002_1306_hex_binary_enumeration002_1306_v(save_xm
         instance="msData/datatypes/Facets/hexBinary/hexBinary_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_enumeration001_1305_hex_binary_enumeration001_1305_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=adf789
@@ -8516,11 +9044,12 @@ def test_hex_binary_enumeration001_1305_hex_binary_enumeration001_1305_i(save_xm
         instance="msData/datatypes/Facets/hexBinary/hexBinary_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_max_length003_1304_hex_binary_max_length003_1304_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -8532,11 +9061,12 @@ def test_hex_binary_max_length003_1304_hex_binary_max_length003_1304_v(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_max_length002_1303_hex_binary_max_length002_1303_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -8548,11 +9078,12 @@ def test_hex_binary_max_length002_1303_hex_binary_max_length002_1303_v(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_max_length001_1302_hex_binary_max_length001_1302_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -8564,11 +9095,12 @@ def test_hex_binary_max_length001_1302_hex_binary_max_length001_1302_v(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_maxLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_min_length004_1301_hex_binary_min_length004_1301_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -8581,11 +9113,12 @@ def test_hex_binary_min_length004_1301_hex_binary_min_length004_1301_v(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_min_length003_1300_hex_binary_min_length003_1300_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -8597,11 +9130,12 @@ def test_hex_binary_min_length003_1300_hex_binary_min_length003_1300_i(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_min_length002_1299_hex_binary_min_length002_1299_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -8613,11 +9147,12 @@ def test_hex_binary_min_length002_1299_hex_binary_min_length002_1299_v(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_min_length001_1298_hex_binary_min_length001_1298_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -8629,11 +9164,12 @@ def test_hex_binary_min_length001_1298_hex_binary_min_length001_1298_v(save_xml)
         instance="msData/datatypes/Facets/hexBinary/hexBinary_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_length003_1297_hex_binary_length003_1297_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -8645,11 +9181,12 @@ def test_hex_binary_length003_1297_hex_binary_length003_1297_i(save_xml):
         instance="msData/datatypes/Facets/hexBinary/hexBinary_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_length002_1296_hex_binary_length002_1296_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -8661,11 +9198,12 @@ def test_hex_binary_length002_1296_hex_binary_length002_1296_v(save_xml):
         instance="msData/datatypes/Facets/hexBinary/hexBinary_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hex_binary_length001_1295_hex_binary_length001_1295_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -8677,11 +9215,12 @@ def test_hex_binary_length001_1295_hex_binary_length001_1295_i(save_xml):
         instance="msData/datatypes/Facets/hexBinary/hexBinary_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_pattern001_1274_g_month_pattern001_1274_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=- -[0-9]{2}-
@@ -8693,11 +9232,12 @@ def test_g_month_pattern001_1274_g_month_pattern001_1274_v(save_xml):
         instance="msData/datatypes/Facets/gMonth/gMonth_pattern001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_exclusive005_1273_g_day_min_exclusive005_1273_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=- - -01
@@ -8709,11 +9249,12 @@ def test_g_day_min_exclusive005_1273_g_day_min_exclusive005_1273_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_exclusive004_1272_g_day_min_exclusive004_1272_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=- - -01
@@ -8725,11 +9266,12 @@ def test_g_day_min_exclusive004_1272_g_day_min_exclusive004_1272_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_exclusive003_1271_g_day_min_exclusive003_1271_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=- - -01
@@ -8741,11 +9283,12 @@ def test_g_day_min_exclusive003_1271_g_day_min_exclusive003_1271_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_exclusive002_1270_g_day_min_exclusive002_1270_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=- - -15
@@ -8757,11 +9300,12 @@ def test_g_day_min_exclusive002_1270_g_day_min_exclusive002_1270_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_exclusive001_1269_g_day_min_exclusive001_1269_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=- - -01
@@ -8773,11 +9317,12 @@ def test_g_day_min_exclusive001_1269_g_day_min_exclusive001_1269_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_inclusive005_1268_g_day_min_inclusive005_1268_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=- - -01
@@ -8789,11 +9334,12 @@ def test_g_day_min_inclusive005_1268_g_day_min_inclusive005_1268_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_inclusive004_1267_g_day_min_inclusive004_1267_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=- - -01
@@ -8805,11 +9351,12 @@ def test_g_day_min_inclusive004_1267_g_day_min_inclusive004_1267_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_inclusive003_1266_g_day_min_inclusive003_1266_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=- - -01
@@ -8821,11 +9368,12 @@ def test_g_day_min_inclusive003_1266_g_day_min_inclusive003_1266_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_inclusive002_1265_g_day_min_inclusive002_1265_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=- - -15
@@ -8837,11 +9385,12 @@ def test_g_day_min_inclusive002_1265_g_day_min_inclusive002_1265_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_min_inclusive001_1264_g_day_min_inclusive001_1264_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=- - -01
@@ -8853,11 +9402,12 @@ def test_g_day_min_inclusive001_1264_g_day_min_inclusive001_1264_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_max_exclusive003_1263_g_day_max_exclusive003_1263_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=- - -30
@@ -8869,11 +9419,12 @@ def test_g_day_max_exclusive003_1263_g_day_max_exclusive003_1263_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_max_exclusive002_1262_g_day_max_exclusive002_1262_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=- - -01
@@ -8885,11 +9436,12 @@ def test_g_day_max_exclusive002_1262_g_day_max_exclusive002_1262_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_max_exclusive001_1261_g_day_max_exclusive001_1261_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=- - -01
@@ -8901,11 +9453,12 @@ def test_g_day_max_exclusive001_1261_g_day_max_exclusive001_1261_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_max_inclusive003_1260_g_day_max_inclusive003_1260_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=- - -30
@@ -8917,11 +9470,12 @@ def test_g_day_max_inclusive003_1260_g_day_max_inclusive003_1260_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_max_inclusive002_1259_g_day_max_inclusive002_1259_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=- - -01
@@ -8933,11 +9487,12 @@ def test_g_day_max_inclusive002_1259_g_day_max_inclusive002_1259_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_max_inclusive001_1258_g_day_max_inclusive001_1258_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=- - -01
@@ -8949,11 +9504,12 @@ def test_g_day_max_inclusive001_1258_g_day_max_inclusive001_1258_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_enumeration004_1257_g_day_enumeration004_1257_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- - -15 -
@@ -8965,11 +9521,12 @@ def test_g_day_enumeration004_1257_g_day_enumeration004_1257_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_enumeration003_1256_g_day_enumeration003_1256_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- - -15 -
@@ -8981,11 +9538,12 @@ def test_g_day_enumeration003_1256_g_day_enumeration003_1256_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_enumeration002_1255_g_day_enumeration002_1255_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- - -15
@@ -8997,11 +9555,12 @@ def test_g_day_enumeration002_1255_g_day_enumeration002_1255_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_enumeration001_1254_g_day_enumeration001_1254_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- - -15
@@ -9013,11 +9572,12 @@ def test_g_day_enumeration001_1254_g_day_enumeration001_1254_i(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_day_pattern001_1253_g_day_pattern001_1253_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=- - -[0-9]{2}
@@ -9029,11 +9589,12 @@ def test_g_day_pattern001_1253_g_day_pattern001_1253_v(save_xml):
         instance="msData/datatypes/Facets/gDay/gDay_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_exclusive005_1252_g_month_day_min_exclusive005_1252_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=-
@@ -9046,11 +9607,12 @@ def test_g_month_day_min_exclusive005_1252_g_month_day_min_exclusive005_1252_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_exclusive004_1251_g_month_day_min_exclusive004_1251_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=-
@@ -9063,11 +9625,12 @@ def test_g_month_day_min_exclusive004_1251_g_month_day_min_exclusive004_1251_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_exclusive003_1250_g_month_day_min_exclusive003_1250_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=- -01-01
@@ -9079,11 +9642,12 @@ def test_g_month_day_min_exclusive003_1250_g_month_day_min_exclusive003_1250_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_exclusive002_1249_g_month_day_min_exclusive002_1249_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=- -03-15
@@ -9095,11 +9659,12 @@ def test_g_month_day_min_exclusive002_1249_g_month_day_min_exclusive002_1249_i(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_exclusive001_1248_g_month_day_min_exclusive001_1248_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=- -01-01
@@ -9111,11 +9676,12 @@ def test_g_month_day_min_exclusive001_1248_g_month_day_min_exclusive001_1248_i(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_inclusive005_1247_g_month_day_min_inclusive005_1247_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=-
@@ -9128,11 +9694,12 @@ def test_g_month_day_min_inclusive005_1247_g_month_day_min_inclusive005_1247_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_inclusive004_1246_g_month_day_min_inclusive004_1246_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=-
@@ -9145,11 +9712,12 @@ def test_g_month_day_min_inclusive004_1246_g_month_day_min_inclusive004_1246_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_inclusive003_1245_g_month_day_min_inclusive003_1245_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=- -01-01
@@ -9161,11 +9729,12 @@ def test_g_month_day_min_inclusive003_1245_g_month_day_min_inclusive003_1245_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_inclusive002_1244_g_month_day_min_inclusive002_1244_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=- -03-15
@@ -9177,11 +9746,12 @@ def test_g_month_day_min_inclusive002_1244_g_month_day_min_inclusive002_1244_i(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_min_inclusive001_1243_g_month_day_min_inclusive001_1243_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=- -01-01
@@ -9193,11 +9763,12 @@ def test_g_month_day_min_inclusive001_1243_g_month_day_min_inclusive001_1243_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_max_exclusive003_1242_g_month_day_max_exclusive003_1242_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=- -10-01
@@ -9209,11 +9780,12 @@ def test_g_month_day_max_exclusive003_1242_g_month_day_max_exclusive003_1242_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_max_exclusive002_1241_g_month_day_max_exclusive002_1241_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=- -01-01
@@ -9225,11 +9797,12 @@ def test_g_month_day_max_exclusive002_1241_g_month_day_max_exclusive002_1241_i(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_max_exclusive001_1240_g_month_day_max_exclusive001_1240_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=- -01-01
@@ -9241,11 +9814,12 @@ def test_g_month_day_max_exclusive001_1240_g_month_day_max_exclusive001_1240_i(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_max_inclusive003_1239_g_month_day_max_inclusive003_1239_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=- -10-01
@@ -9257,11 +9831,12 @@ def test_g_month_day_max_inclusive003_1239_g_month_day_max_inclusive003_1239_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_max_inclusive002_1238_g_month_day_max_inclusive002_1238_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=- -01-01
@@ -9273,11 +9848,12 @@ def test_g_month_day_max_inclusive002_1238_g_month_day_max_inclusive002_1238_i(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_max_inclusive001_1237_g_month_day_max_inclusive001_1237_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=- -01-01
@@ -9289,11 +9865,12 @@ def test_g_month_day_max_inclusive001_1237_g_month_day_max_inclusive001_1237_v(s
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_enumeration004_1236_g_month_day_enumeration004_1236_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- -03-15
@@ -9305,11 +9882,12 @@ def test_g_month_day_enumeration004_1236_g_month_day_enumeration004_1236_v(save_
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_enumeration003_1235_g_month_day_enumeration003_1235_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- -03-15
@@ -9321,11 +9899,12 @@ def test_g_month_day_enumeration003_1235_g_month_day_enumeration003_1235_i(save_
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_enumeration002_1234_g_month_day_enumeration002_1234_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- -03-15
@@ -9337,11 +9916,12 @@ def test_g_month_day_enumeration002_1234_g_month_day_enumeration002_1234_v(save_
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_enumeration001_1233_g_month_day_enumeration001_1233_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=- -03-15
@@ -9353,11 +9933,12 @@ def test_g_month_day_enumeration001_1233_g_month_day_enumeration001_1233_i(save_
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_month_day_pattern001_1232_g_month_day_pattern001_1232_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=-
@@ -9369,11 +9950,12 @@ def test_g_month_day_pattern001_1232_g_month_day_pattern001_1232_v(save_xml):
         instance="msData/datatypes/Facets/gMonthDay/gMonthDay_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_exclusive005_1231_g_year_min_exclusive005_1231_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1998
@@ -9385,11 +9967,12 @@ def test_g_year_min_exclusive005_1231_g_year_min_exclusive005_1231_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_exclusive004_1230_g_year_min_exclusive004_1230_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1998
@@ -9401,11 +9984,12 @@ def test_g_year_min_exclusive004_1230_g_year_min_exclusive004_1230_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_exclusive003_1229_g_year_min_exclusive003_1229_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1998 and
@@ -9417,11 +10001,12 @@ def test_g_year_min_exclusive003_1229_g_year_min_exclusive003_1229_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_exclusive002_1228_g_year_min_exclusive002_1228_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=2000 and
@@ -9433,11 +10018,12 @@ def test_g_year_min_exclusive002_1228_g_year_min_exclusive002_1228_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_exclusive001_1227_g_year_min_exclusive001_1227_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1998 and
@@ -9449,11 +10035,12 @@ def test_g_year_min_exclusive001_1227_g_year_min_exclusive001_1227_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_inclusive005_1226_g_year_min_inclusive005_1226_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1998
@@ -9465,11 +10052,12 @@ def test_g_year_min_inclusive005_1226_g_year_min_inclusive005_1226_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_inclusive004_1225_g_year_min_inclusive004_1225_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1998
@@ -9481,11 +10069,12 @@ def test_g_year_min_inclusive004_1225_g_year_min_inclusive004_1225_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_inclusive003_1224_g_year_min_inclusive003_1224_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1998 and
@@ -9497,11 +10086,12 @@ def test_g_year_min_inclusive003_1224_g_year_min_inclusive003_1224_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_inclusive002_1223_g_year_min_inclusive002_1223_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=2000 and
@@ -9513,11 +10103,12 @@ def test_g_year_min_inclusive002_1223_g_year_min_inclusive002_1223_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_min_inclusive001_1222_g_year_min_inclusive001_1222_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1998 and
@@ -9529,11 +10120,12 @@ def test_g_year_min_inclusive001_1222_g_year_min_inclusive001_1222_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_max_exclusive003_1221_g_year_max_exclusive003_1221_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=2002 and
@@ -9545,11 +10137,12 @@ def test_g_year_max_exclusive003_1221_g_year_max_exclusive003_1221_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_max_exclusive002_1220_g_year_max_exclusive002_1220_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1998 and
@@ -9561,11 +10154,12 @@ def test_g_year_max_exclusive002_1220_g_year_max_exclusive002_1220_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_max_exclusive001_1219_g_year_max_exclusive001_1219_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1998 and
@@ -9577,11 +10171,12 @@ def test_g_year_max_exclusive001_1219_g_year_max_exclusive001_1219_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_max_inclusive003_1218_g_year_max_inclusive003_1218_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=2002 and
@@ -9593,11 +10188,12 @@ def test_g_year_max_inclusive003_1218_g_year_max_inclusive003_1218_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_max_inclusive002_1217_g_year_max_inclusive002_1217_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1998 and
@@ -9609,11 +10205,12 @@ def test_g_year_max_inclusive002_1217_g_year_max_inclusive002_1217_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_max_inclusive001_1216_g_year_max_inclusive001_1216_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1998 and
@@ -9625,11 +10222,12 @@ def test_g_year_max_inclusive001_1216_g_year_max_inclusive001_1216_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_enumeration004_1215_g_year_enumeration004_1215_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2000 1999
@@ -9641,11 +10239,12 @@ def test_g_year_enumeration004_1215_g_year_enumeration004_1215_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_enumeration003_1214_g_year_enumeration003_1214_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2000 1999
@@ -9657,11 +10256,12 @@ def test_g_year_enumeration003_1214_g_year_enumeration003_1214_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_enumeration002_1213_g_year_enumeration002_1213_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2000 and
@@ -9673,11 +10273,12 @@ def test_g_year_enumeration002_1213_g_year_enumeration002_1213_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_enumeration001_1212_g_year_enumeration001_1212_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2000 and
@@ -9689,11 +10290,12 @@ def test_g_year_enumeration001_1212_g_year_enumeration001_1212_i(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_pattern001_1211_g_year_pattern001_1211_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[0-9]{4} and
@@ -9705,11 +10307,12 @@ def test_g_year_pattern001_1211_g_year_pattern001_1211_v(save_xml):
         instance="msData/datatypes/Facets/gYear/gYear_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_exclusive005_1210_g_year_month_min_exclusive005_1210_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=2000-12
@@ -9721,11 +10324,12 @@ def test_g_year_month_min_exclusive005_1210_g_year_month_min_exclusive005_1210_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_exclusive004_1209_g_year_month_min_exclusive004_1209_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=2000-12
@@ -9737,11 +10341,12 @@ def test_g_year_month_min_exclusive004_1209_g_year_month_min_exclusive004_1209_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_exclusive003_1208_g_year_month_min_exclusive003_1208_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=2000-12
@@ -9753,11 +10358,12 @@ def test_g_year_month_min_exclusive003_1208_g_year_month_min_exclusive003_1208_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_exclusive002_1207_g_year_month_min_exclusive002_1207_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=2001-03
@@ -9769,11 +10375,12 @@ def test_g_year_month_min_exclusive002_1207_g_year_month_min_exclusive002_1207_i
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_exclusive001_1206_g_year_month_min_exclusive001_1206_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=2000-12
@@ -9785,11 +10392,12 @@ def test_g_year_month_min_exclusive001_1206_g_year_month_min_exclusive001_1206_i
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_inclusive005_1205_g_year_month_min_inclusive005_1205_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=2000-12
@@ -9801,11 +10409,12 @@ def test_g_year_month_min_inclusive005_1205_g_year_month_min_inclusive005_1205_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_inclusive004_1204_g_year_month_min_inclusive004_1204_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=2000-12
@@ -9817,11 +10426,12 @@ def test_g_year_month_min_inclusive004_1204_g_year_month_min_inclusive004_1204_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_inclusive003_1203_g_year_month_min_inclusive003_1203_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=2000-12
@@ -9833,11 +10443,12 @@ def test_g_year_month_min_inclusive003_1203_g_year_month_min_inclusive003_1203_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_inclusive002_1202_g_year_month_min_inclusive002_1202_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=2001-03
@@ -9849,11 +10460,12 @@ def test_g_year_month_min_inclusive002_1202_g_year_month_min_inclusive002_1202_i
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_min_inclusive001_1201_g_year_month_min_inclusive001_1201_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=2000-12
@@ -9865,11 +10477,12 @@ def test_g_year_month_min_inclusive001_1201_g_year_month_min_inclusive001_1201_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_max_exclusive003_1200_g_year_month_max_exclusive003_1200_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=2001-12
@@ -9881,11 +10494,12 @@ def test_g_year_month_max_exclusive003_1200_g_year_month_max_exclusive003_1200_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_max_exclusive002_1199_g_year_month_max_exclusive002_1199_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=2000-12
@@ -9897,11 +10511,12 @@ def test_g_year_month_max_exclusive002_1199_g_year_month_max_exclusive002_1199_i
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_max_exclusive001_1198_g_year_month_max_exclusive001_1198_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=2000-12
@@ -9913,11 +10528,12 @@ def test_g_year_month_max_exclusive001_1198_g_year_month_max_exclusive001_1198_i
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_max_inclusive003_1197_g_year_month_max_inclusive003_1197_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=2001-12
@@ -9929,11 +10545,12 @@ def test_g_year_month_max_inclusive003_1197_g_year_month_max_inclusive003_1197_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_max_inclusive002_1196_g_year_month_max_inclusive002_1196_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=2000-12
@@ -9945,11 +10562,12 @@ def test_g_year_month_max_inclusive002_1196_g_year_month_max_inclusive002_1196_i
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_max_inclusive001_1195_g_year_month_max_inclusive001_1195_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=2000-12
@@ -9961,11 +10579,12 @@ def test_g_year_month_max_inclusive001_1195_g_year_month_max_inclusive001_1195_v
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_enumeration004_1194_g_year_month_enumeration004_1194_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2001-03
@@ -9977,11 +10596,12 @@ def test_g_year_month_enumeration004_1194_g_year_month_enumeration004_1194_v(sav
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_enumeration003_1193_g_year_month_enumeration003_1193_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2001-03
@@ -9993,11 +10613,12 @@ def test_g_year_month_enumeration003_1193_g_year_month_enumeration003_1193_i(sav
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_enumeration002_1192_g_year_month_enumeration002_1192_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2001-03
@@ -10009,11 +10630,12 @@ def test_g_year_month_enumeration002_1192_g_year_month_enumeration002_1192_v(sav
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_enumeration001_1191_g_year_month_enumeration001_1191_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=2001-03
@@ -10025,11 +10647,12 @@ def test_g_year_month_enumeration001_1191_g_year_month_enumeration001_1191_i(sav
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_g_year_month_pattern001_1190_g_year_month_pattern001_1190_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -10041,11 +10664,12 @@ def test_g_year_month_pattern001_1190_g_year_month_pattern001_1190_v(save_xml):
         instance="msData/datatypes/Facets/gYearMonth/gYearMonth_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_exclusive005_1189_date_min_exclusive005_1189_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -10058,11 +10682,12 @@ def test_date_min_exclusive005_1189_date_min_exclusive005_1189_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_exclusive004_1188_date_min_exclusive004_1188_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -10075,11 +10700,12 @@ def test_date_min_exclusive004_1188_date_min_exclusive004_1188_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_exclusive003_1187_date_min_exclusive003_1187_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10091,11 +10717,12 @@ def test_date_min_exclusive003_1187_date_min_exclusive003_1187_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_exclusive002_1186_date_min_exclusive002_1186_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10107,11 +10734,12 @@ def test_date_min_exclusive002_1186_date_min_exclusive002_1186_i(save_xml):
         instance="msData/datatypes/Facets/date/date_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_exclusive001_1185_date_min_exclusive001_1185_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10123,11 +10751,12 @@ def test_date_min_exclusive001_1185_date_min_exclusive001_1185_i(save_xml):
         instance="msData/datatypes/Facets/date/date_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_inclusive005_1184_date_min_inclusive005_1184_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -10140,11 +10769,12 @@ def test_date_min_inclusive005_1184_date_min_inclusive005_1184_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_inclusive004_1183_date_min_inclusive004_1183_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -10157,11 +10787,12 @@ def test_date_min_inclusive004_1183_date_min_inclusive004_1183_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_inclusive003_1182_date_min_inclusive003_1182_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10173,11 +10804,12 @@ def test_date_min_inclusive003_1182_date_min_inclusive003_1182_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_inclusive002_1181_date_min_inclusive002_1181_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10189,11 +10821,12 @@ def test_date_min_inclusive002_1181_date_min_inclusive002_1181_i(save_xml):
         instance="msData/datatypes/Facets/date/date_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_min_inclusive001_1180_date_min_inclusive001_1180_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10205,11 +10838,12 @@ def test_date_min_inclusive001_1180_date_min_inclusive001_1180_v(save_xml):
         instance="msData/datatypes/Facets/date/date_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_max_exclusive003_1179_date_max_exclusive003_1179_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10221,11 +10855,12 @@ def test_date_max_exclusive003_1179_date_max_exclusive003_1179_v(save_xml):
         instance="msData/datatypes/Facets/date/date_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_max_exclusive002_1178_date_max_exclusive002_1178_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10237,11 +10872,12 @@ def test_date_max_exclusive002_1178_date_max_exclusive002_1178_i(save_xml):
         instance="msData/datatypes/Facets/date/date_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_max_exclusive001_1177_date_max_exclusive001_1177_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10253,11 +10889,12 @@ def test_date_max_exclusive001_1177_date_max_exclusive001_1177_i(save_xml):
         instance="msData/datatypes/Facets/date/date_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_max_inclusive003_1176_date_max_inclusive003_1176_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10269,11 +10906,12 @@ def test_date_max_inclusive003_1176_date_max_inclusive003_1176_v(save_xml):
         instance="msData/datatypes/Facets/date/date_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_max_inclusive002_1175_date_max_inclusive002_1175_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10285,11 +10923,12 @@ def test_date_max_inclusive002_1175_date_max_inclusive002_1175_i(save_xml):
         instance="msData/datatypes/Facets/date/date_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_max_inclusive001_1174_date_max_inclusive001_1174_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10301,11 +10940,12 @@ def test_date_max_inclusive001_1174_date_max_inclusive001_1174_v(save_xml):
         instance="msData/datatypes/Facets/date/date_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_enumeration004_1173_date_enumeration004_1173_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10317,11 +10957,12 @@ def test_date_enumeration004_1173_date_enumeration004_1173_v(save_xml):
         instance="msData/datatypes/Facets/date/date_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_enumeration003_1172_date_enumeration003_1172_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10333,11 +10974,12 @@ def test_date_enumeration003_1172_date_enumeration003_1172_i(save_xml):
         instance="msData/datatypes/Facets/date/date_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_enumeration002_1171_date_enumeration002_1171_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10349,11 +10991,12 @@ def test_date_enumeration002_1171_date_enumeration002_1171_v(save_xml):
         instance="msData/datatypes/Facets/date/date_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_enumeration001_1170_date_enumeration001_1170_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10365,11 +11008,12 @@ def test_date_enumeration001_1170_date_enumeration001_1170_i(save_xml):
         instance="msData/datatypes/Facets/date/date_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_pattern001_1169_date_pattern001_1169_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -10381,11 +11025,12 @@ def test_date_pattern001_1169_date_pattern001_1169_v(save_xml):
         instance="msData/datatypes/Facets/date/date_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_exclusive005_1168_time_min_exclusive005_1168_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -10398,11 +11043,12 @@ def test_time_min_exclusive005_1168_time_min_exclusive005_1168_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_exclusive004_1167_time_min_exclusive004_1167_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -10415,11 +11061,12 @@ def test_time_min_exclusive004_1167_time_min_exclusive004_1167_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_exclusive003_1166_time_min_exclusive003_1166_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10431,11 +11078,12 @@ def test_time_min_exclusive003_1166_time_min_exclusive003_1166_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_exclusive002_1165_time_min_exclusive002_1165_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10447,11 +11095,12 @@ def test_time_min_exclusive002_1165_time_min_exclusive002_1165_i(save_xml):
         instance="msData/datatypes/Facets/time/time_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_exclusive001_1164_time_min_exclusive001_1164_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10463,11 +11112,12 @@ def test_time_min_exclusive001_1164_time_min_exclusive001_1164_i(save_xml):
         instance="msData/datatypes/Facets/time/time_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_inclusive006_1163_time_min_inclusive006_1163_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10480,11 +11130,12 @@ def test_time_min_inclusive006_1163_time_min_inclusive006_1163_i(save_xml):
         instance="msData/datatypes/Facets/time/time_minInclusive006.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_inclusive005_1162_time_min_inclusive005_1162_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -10497,11 +11148,12 @@ def test_time_min_inclusive005_1162_time_min_inclusive005_1162_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_inclusive004_1161_time_min_inclusive004_1161_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -10514,11 +11166,12 @@ def test_time_min_inclusive004_1161_time_min_inclusive004_1161_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_inclusive003_1160_time_min_inclusive003_1160_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10530,11 +11183,12 @@ def test_time_min_inclusive003_1160_time_min_inclusive003_1160_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_inclusive002_1159_time_min_inclusive002_1159_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10546,11 +11200,12 @@ def test_time_min_inclusive002_1159_time_min_inclusive002_1159_i(save_xml):
         instance="msData/datatypes/Facets/time/time_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_min_inclusive001_1158_time_min_inclusive001_1158_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10562,11 +11217,12 @@ def test_time_min_inclusive001_1158_time_min_inclusive001_1158_v(save_xml):
         instance="msData/datatypes/Facets/time/time_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_max_exclusive003_1157_time_max_exclusive003_1157_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10578,11 +11234,12 @@ def test_time_max_exclusive003_1157_time_max_exclusive003_1157_v(save_xml):
         instance="msData/datatypes/Facets/time/time_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_max_exclusive002_1156_time_max_exclusive002_1156_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10594,11 +11251,12 @@ def test_time_max_exclusive002_1156_time_max_exclusive002_1156_i(save_xml):
         instance="msData/datatypes/Facets/time/time_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_max_exclusive001_1155_time_max_exclusive001_1155_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10610,11 +11268,12 @@ def test_time_max_exclusive001_1155_time_max_exclusive001_1155_i(save_xml):
         instance="msData/datatypes/Facets/time/time_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_max_inclusive003_1154_time_max_inclusive003_1154_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10626,11 +11285,12 @@ def test_time_max_inclusive003_1154_time_max_inclusive003_1154_v(save_xml):
         instance="msData/datatypes/Facets/time/time_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_max_inclusive002_1153_time_max_inclusive002_1153_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10642,11 +11302,12 @@ def test_time_max_inclusive002_1153_time_max_inclusive002_1153_i(save_xml):
         instance="msData/datatypes/Facets/time/time_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_max_inclusive001_1152_time_max_inclusive001_1152_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10658,11 +11319,12 @@ def test_time_max_inclusive001_1152_time_max_inclusive001_1152_v(save_xml):
         instance="msData/datatypes/Facets/time/time_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_enumeration004_1151_time_enumeration004_1151_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10675,11 +11337,12 @@ def test_time_enumeration004_1151_time_enumeration004_1151_v(save_xml):
         instance="msData/datatypes/Facets/time/time_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_enumeration003_1150_time_enumeration003_1150_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10691,11 +11354,12 @@ def test_time_enumeration003_1150_time_enumeration003_1150_i(save_xml):
         instance="msData/datatypes/Facets/time/time_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_enumeration002_1149_time_enumeration002_1149_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10707,11 +11371,12 @@ def test_time_enumeration002_1149_time_enumeration002_1149_v(save_xml):
         instance="msData/datatypes/Facets/time/time_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_enumeration001_1148_time_enumeration001_1148_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -10723,11 +11388,12 @@ def test_time_enumeration001_1148_time_enumeration001_1148_i(save_xml):
         instance="msData/datatypes/Facets/time/time_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_time_pattern001_1147_time_pattern001_1147_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -10740,11 +11406,12 @@ def test_time_pattern001_1147_time_pattern001_1147_v(save_xml):
         instance="msData/datatypes/Facets/time/time_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_exclusive005_1146_date_time_min_exclusive005_1146_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -10757,11 +11424,12 @@ def test_date_time_min_exclusive005_1146_date_time_min_exclusive005_1146_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_exclusive004_1145_date_time_min_exclusive004_1145_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -10774,11 +11442,12 @@ def test_date_time_min_exclusive004_1145_date_time_min_exclusive004_1145_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_exclusive003_1144_date_time_min_exclusive003_1144_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10790,11 +11459,12 @@ def test_date_time_min_exclusive003_1144_date_time_min_exclusive003_1144_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_exclusive002_1143_date_time_min_exclusive002_1143_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10806,11 +11476,12 @@ def test_date_time_min_exclusive002_1143_date_time_min_exclusive002_1143_i(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_exclusive001_1142_date_time_min_exclusive001_1142_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and
@@ -10822,11 +11493,12 @@ def test_date_time_min_exclusive001_1142_date_time_min_exclusive001_1142_i(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_inclusive005_1141_date_time_min_inclusive005_1141_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -10839,11 +11511,12 @@ def test_date_time_min_inclusive005_1141_date_time_min_inclusive005_1141_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_inclusive004_1140_date_time_min_inclusive004_1140_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -10856,11 +11529,12 @@ def test_date_time_min_inclusive004_1140_date_time_min_inclusive004_1140_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_inclusive003_1139_date_time_min_inclusive003_1139_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10872,11 +11546,12 @@ def test_date_time_min_inclusive003_1139_date_time_min_inclusive003_1139_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_inclusive002_1138_date_time_min_inclusive002_1138_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10888,11 +11563,12 @@ def test_date_time_min_inclusive002_1138_date_time_min_inclusive002_1138_i(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_min_inclusive001_1137_date_time_min_inclusive001_1137_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and
@@ -10904,11 +11580,12 @@ def test_date_time_min_inclusive001_1137_date_time_min_inclusive001_1137_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_max_exclusive003_1136_date_time_max_exclusive003_1136_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10920,11 +11597,12 @@ def test_date_time_max_exclusive003_1136_date_time_max_exclusive003_1136_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_max_exclusive002_1135_date_time_max_exclusive002_1135_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10936,11 +11614,12 @@ def test_date_time_max_exclusive002_1135_date_time_max_exclusive002_1135_i(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_max_exclusive001_1134_date_time_max_exclusive001_1134_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and
@@ -10952,11 +11631,12 @@ def test_date_time_max_exclusive001_1134_date_time_max_exclusive001_1134_i(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_max_inclusive003_1133_date_time_max_inclusive003_1133_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10968,11 +11648,12 @@ def test_date_time_max_inclusive003_1133_date_time_max_inclusive003_1133_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_max_inclusive002_1132_date_time_max_inclusive002_1132_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -10984,11 +11665,12 @@ def test_date_time_max_inclusive002_1132_date_time_max_inclusive002_1132_i(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_max_inclusive001_1131_date_time_max_inclusive001_1131_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and
@@ -11000,11 +11682,12 @@ def test_date_time_max_inclusive001_1131_date_time_max_inclusive001_1131_v(save_
         instance="msData/datatypes/Facets/dateTime/dateTime_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_enumeration005b_1130_date_time_enumeration005b_1130_v(save_xml):
     """
     TEST :Facet Schemas for string : XSD: XsdDateTime comparison of
@@ -11016,11 +11699,12 @@ def test_date_time_enumeration005b_1130_date_time_enumeration005b_1130_v(save_xm
         instance="msData/datatypes/Facets/dateTime/dateTime_enumeration005b.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_enumeration005a_1129_date_time_enumeration005a_1129_v(save_xml):
     """
     TEST :Facet Schemas for string : XSD: XsdDateTime comparison of
@@ -11032,11 +11716,12 @@ def test_date_time_enumeration005a_1129_date_time_enumeration005a_1129_v(save_xm
         instance="msData/datatypes/Facets/dateTime/dateTime_enumeration005a.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_enumeration004_1128_date_time_enumeration004_1128_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -11049,11 +11734,12 @@ def test_date_time_enumeration004_1128_date_time_enumeration004_1128_v(save_xml)
         instance="msData/datatypes/Facets/dateTime/dateTime_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_enumeration003_1127_date_time_enumeration003_1127_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -11066,11 +11752,12 @@ def test_date_time_enumeration003_1127_date_time_enumeration003_1127_i(save_xml)
         instance="msData/datatypes/Facets/dateTime/dateTime_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_enumeration002_1126_date_time_enumeration002_1126_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -11082,11 +11769,12 @@ def test_date_time_enumeration002_1126_date_time_enumeration002_1126_v(save_xml)
         instance="msData/datatypes/Facets/dateTime/dateTime_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_enumeration001_1125_date_time_enumeration001_1125_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and
@@ -11098,11 +11786,12 @@ def test_date_time_enumeration001_1125_date_time_enumeration001_1125_i(save_xml)
         instance="msData/datatypes/Facets/dateTime/dateTime_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_date_time_pattern001_1124_date_time_pattern001_1124_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -11115,11 +11804,12 @@ def test_date_time_pattern001_1124_date_time_pattern001_1124_v(save_xml):
         instance="msData/datatypes/Facets/dateTime/dateTime_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_exclusive005_1123_duration_min_exclusive005_1123_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -11132,11 +11822,12 @@ def test_duration_min_exclusive005_1123_duration_min_exclusive005_1123_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_exclusive004_1122_duration_min_exclusive004_1122_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and
@@ -11149,11 +11840,12 @@ def test_duration_min_exclusive004_1122_duration_min_exclusive004_1122_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_exclusive003_1121_duration_min_exclusive003_1121_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=P1Y1MT1H
@@ -11165,11 +11857,12 @@ def test_duration_min_exclusive003_1121_duration_min_exclusive003_1121_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_exclusive002_1120_duration_min_exclusive002_1120_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=P1Y2MT2H
@@ -11181,11 +11874,12 @@ def test_duration_min_exclusive002_1120_duration_min_exclusive002_1120_i(save_xm
         instance="msData/datatypes/Facets/duration/duration_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_exclusive001_1119_duration_min_exclusive001_1119_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=P1Y1MT1H
@@ -11197,11 +11891,12 @@ def test_duration_min_exclusive001_1119_duration_min_exclusive001_1119_i(save_xm
         instance="msData/datatypes/Facets/duration/duration_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_inclusive005_1118_duration_min_inclusive005_1118_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -11214,11 +11909,12 @@ def test_duration_min_inclusive005_1118_duration_min_inclusive005_1118_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_inclusive004_1117_duration_min_inclusive004_1117_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and
@@ -11231,11 +11927,12 @@ def test_duration_min_inclusive004_1117_duration_min_inclusive004_1117_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_inclusive003_1116_duration_min_inclusive003_1116_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=P1Y1MT1H
@@ -11247,11 +11944,12 @@ def test_duration_min_inclusive003_1116_duration_min_inclusive003_1116_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_inclusive002_1115_duration_min_inclusive002_1115_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=P1Y2MT2H
@@ -11263,11 +11961,12 @@ def test_duration_min_inclusive002_1115_duration_min_inclusive002_1115_i(save_xm
         instance="msData/datatypes/Facets/duration/duration_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_min_inclusive001_1114_duration_min_inclusive001_1114_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=P1Y1MT1H
@@ -11279,11 +11978,12 @@ def test_duration_min_inclusive001_1114_duration_min_inclusive001_1114_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_max_exclusive003_1113_duration_max_exclusive003_1113_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=P2Y3MT2H
@@ -11295,11 +11995,12 @@ def test_duration_max_exclusive003_1113_duration_max_exclusive003_1113_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_max_exclusive002_1112_duration_max_exclusive002_1112_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=P1Y1MT1H
@@ -11311,11 +12012,12 @@ def test_duration_max_exclusive002_1112_duration_max_exclusive002_1112_i(save_xm
         instance="msData/datatypes/Facets/duration/duration_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_max_exclusive001_1111_duration_max_exclusive001_1111_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=P1Y1MT1H
@@ -11327,11 +12029,12 @@ def test_duration_max_exclusive001_1111_duration_max_exclusive001_1111_i(save_xm
         instance="msData/datatypes/Facets/duration/duration_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_max_inclusive003_1110_duration_max_inclusive003_1110_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=P2Y3MT2H
@@ -11343,11 +12046,12 @@ def test_duration_max_inclusive003_1110_duration_max_inclusive003_1110_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_max_inclusive002_1109_duration_max_inclusive002_1109_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=P1Y1MT1H
@@ -11359,11 +12063,12 @@ def test_duration_max_inclusive002_1109_duration_max_inclusive002_1109_i(save_xm
         instance="msData/datatypes/Facets/duration/duration_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_max_inclusive001_1108_duration_max_inclusive001_1108_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=P1Y1MT1H
@@ -11375,11 +12080,12 @@ def test_duration_max_inclusive001_1108_duration_max_inclusive001_1108_v(save_xm
         instance="msData/datatypes/Facets/duration/duration_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_enumeration004_1107_duration_enumeration004_1107_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=P1347Y
@@ -11391,11 +12097,12 @@ def test_duration_enumeration004_1107_duration_enumeration004_1107_v(save_xml):
         instance="msData/datatypes/Facets/duration/duration_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_enumeration003_1106_duration_enumeration003_1106_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=P1347Y
@@ -11407,11 +12114,12 @@ def test_duration_enumeration003_1106_duration_enumeration003_1106_i(save_xml):
         instance="msData/datatypes/Facets/duration/duration_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_enumeration002_1105_duration_enumeration002_1105_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=P1347Y
@@ -11423,11 +12131,12 @@ def test_duration_enumeration002_1105_duration_enumeration002_1105_v(save_xml):
         instance="msData/datatypes/Facets/duration/duration_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_enumeration001_1104_duration_enumeration001_1104_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=P1347Y
@@ -11439,11 +12148,12 @@ def test_duration_enumeration001_1104_duration_enumeration001_1104_i(save_xml):
         instance="msData/datatypes/Facets/duration/duration_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_duration_pattern001_1103_duration_pattern001_1103_v(save_xml):
     r"""
     TEST :Facet Schemas for string : facet=pattern and
@@ -11456,11 +12166,12 @@ def test_duration_pattern001_1103_duration_pattern001_1103_v(save_xml):
         instance="msData/datatypes/Facets/duration/duration_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_exclusive005_1102_double_min_exclusive005_1102_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1.1 and
@@ -11472,11 +12183,12 @@ def test_double_min_exclusive005_1102_double_min_exclusive005_1102_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_exclusive004_1101_double_min_exclusive004_1101_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1.1 and
@@ -11488,11 +12200,12 @@ def test_double_min_exclusive004_1101_double_min_exclusive004_1101_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_exclusive003_1100_double_min_exclusive003_1100_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1.1 and
@@ -11504,11 +12217,12 @@ def test_double_min_exclusive003_1100_double_min_exclusive003_1100_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_exclusive002_1099_double_min_exclusive002_1099_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5.55 and
@@ -11520,11 +12234,12 @@ def test_double_min_exclusive002_1099_double_min_exclusive002_1099_i(save_xml):
         instance="msData/datatypes/Facets/double/double_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_exclusive001_1098_double_min_exclusive001_1098_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1.1 and
@@ -11536,11 +12251,12 @@ def test_double_min_exclusive001_1098_double_min_exclusive001_1098_i(save_xml):
         instance="msData/datatypes/Facets/double/double_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_inclusive005_1097_double_min_inclusive005_1097_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1.1 and
@@ -11552,11 +12268,12 @@ def test_double_min_inclusive005_1097_double_min_inclusive005_1097_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_inclusive004_1096_double_min_inclusive004_1096_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1.1 and
@@ -11568,11 +12285,12 @@ def test_double_min_inclusive004_1096_double_min_inclusive004_1096_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_inclusive003_1095_double_min_inclusive003_1095_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1.1 and
@@ -11584,11 +12302,12 @@ def test_double_min_inclusive003_1095_double_min_inclusive003_1095_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_inclusive002_1094_double_min_inclusive002_1094_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5.55 and
@@ -11600,11 +12319,12 @@ def test_double_min_inclusive002_1094_double_min_inclusive002_1094_i(save_xml):
         instance="msData/datatypes/Facets/double/double_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_min_inclusive001_1093_double_min_inclusive001_1093_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1.1 and
@@ -11616,11 +12336,12 @@ def test_double_min_inclusive001_1093_double_min_inclusive001_1093_v(save_xml):
         instance="msData/datatypes/Facets/double/double_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_max_exclusive003_1092_double_max_exclusive003_1092_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7.7 and
@@ -11632,11 +12353,12 @@ def test_double_max_exclusive003_1092_double_max_exclusive003_1092_v(save_xml):
         instance="msData/datatypes/Facets/double/double_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_max_exclusive002_1091_double_max_exclusive002_1091_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1.1 and
@@ -11648,11 +12370,12 @@ def test_double_max_exclusive002_1091_double_max_exclusive002_1091_i(save_xml):
         instance="msData/datatypes/Facets/double/double_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_max_exclusive001_1090_double_max_exclusive001_1090_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1.1 and
@@ -11664,11 +12387,12 @@ def test_double_max_exclusive001_1090_double_max_exclusive001_1090_i(save_xml):
         instance="msData/datatypes/Facets/double/double_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_max_inclusive003_1089_double_max_inclusive003_1089_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7.7 and
@@ -11680,11 +12404,12 @@ def test_double_max_inclusive003_1089_double_max_inclusive003_1089_v(save_xml):
         instance="msData/datatypes/Facets/double/double_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_max_inclusive002_1088_double_max_inclusive002_1088_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1.1 and
@@ -11696,11 +12421,12 @@ def test_double_max_inclusive002_1088_double_max_inclusive002_1088_i(save_xml):
         instance="msData/datatypes/Facets/double/double_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_max_inclusive001_1087_double_max_inclusive001_1087_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1.1 and
@@ -11712,11 +12438,12 @@ def test_double_max_inclusive001_1087_double_max_inclusive001_1087_v(save_xml):
         instance="msData/datatypes/Facets/double/double_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_enumeration004_1086_double_enumeration004_1086_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 3.14
@@ -11728,11 +12455,12 @@ def test_double_enumeration004_1086_double_enumeration004_1086_v(save_xml):
         instance="msData/datatypes/Facets/double/double_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_enumeration003_1085_double_enumeration003_1085_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 3.14
@@ -11744,11 +12472,12 @@ def test_double_enumeration003_1085_double_enumeration003_1085_i(save_xml):
         instance="msData/datatypes/Facets/double/double_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_enumeration002_1084_double_enumeration002_1084_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 and
@@ -11760,11 +12489,12 @@ def test_double_enumeration002_1084_double_enumeration002_1084_v(save_xml):
         instance="msData/datatypes/Facets/double/double_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_enumeration001_1083_double_enumeration001_1083_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 and
@@ -11776,11 +12506,12 @@ def test_double_enumeration001_1083_double_enumeration001_1083_i(save_xml):
         instance="msData/datatypes/Facets/double/double_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_double_pattern001_1082_double_pattern001_1082_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -11792,11 +12523,12 @@ def test_double_pattern001_1082_double_pattern001_1082_v(save_xml):
         instance="msData/datatypes/Facets/double/double_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_exclusive005_1081_float_min_exclusive005_1081_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1.1 and
@@ -11808,11 +12540,12 @@ def test_float_min_exclusive005_1081_float_min_exclusive005_1081_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_exclusive004_1080_float_min_exclusive004_1080_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1.1 and
@@ -11824,11 +12557,12 @@ def test_float_min_exclusive004_1080_float_min_exclusive004_1080_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_exclusive003_1079_float_min_exclusive003_1079_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1.1 and
@@ -11840,11 +12574,12 @@ def test_float_min_exclusive003_1079_float_min_exclusive003_1079_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_exclusive002_1078_float_min_exclusive002_1078_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5.55 and
@@ -11856,11 +12591,12 @@ def test_float_min_exclusive002_1078_float_min_exclusive002_1078_i(save_xml):
         instance="msData/datatypes/Facets/float/float_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_exclusive001_1077_float_min_exclusive001_1077_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1.1 and
@@ -11872,11 +12608,12 @@ def test_float_min_exclusive001_1077_float_min_exclusive001_1077_i(save_xml):
         instance="msData/datatypes/Facets/float/float_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_inclusive005_1076_float_min_inclusive005_1076_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1.1 and
@@ -11888,11 +12625,12 @@ def test_float_min_inclusive005_1076_float_min_inclusive005_1076_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_inclusive004_1075_float_min_inclusive004_1075_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1.1 and
@@ -11904,11 +12642,12 @@ def test_float_min_inclusive004_1075_float_min_inclusive004_1075_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_inclusive003_1074_float_min_inclusive003_1074_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1.1 and
@@ -11920,11 +12659,12 @@ def test_float_min_inclusive003_1074_float_min_inclusive003_1074_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_inclusive002_1073_float_min_inclusive002_1073_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5.55 and
@@ -11936,11 +12676,12 @@ def test_float_min_inclusive002_1073_float_min_inclusive002_1073_i(save_xml):
         instance="msData/datatypes/Facets/float/float_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_min_inclusive001_1072_float_min_inclusive001_1072_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1.1 and
@@ -11952,11 +12693,12 @@ def test_float_min_inclusive001_1072_float_min_inclusive001_1072_v(save_xml):
         instance="msData/datatypes/Facets/float/float_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_max_exclusive003_1071_float_max_exclusive003_1071_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7.7 and
@@ -11968,11 +12710,12 @@ def test_float_max_exclusive003_1071_float_max_exclusive003_1071_v(save_xml):
         instance="msData/datatypes/Facets/float/float_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_max_exclusive002_1070_float_max_exclusive002_1070_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1.1 and
@@ -11984,11 +12727,12 @@ def test_float_max_exclusive002_1070_float_max_exclusive002_1070_i(save_xml):
         instance="msData/datatypes/Facets/float/float_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_max_exclusive001_1069_float_max_exclusive001_1069_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1.1 and
@@ -12000,11 +12744,12 @@ def test_float_max_exclusive001_1069_float_max_exclusive001_1069_i(save_xml):
         instance="msData/datatypes/Facets/float/float_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_max_inclusive003_1068_float_max_inclusive003_1068_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7.7 and
@@ -12016,11 +12761,12 @@ def test_float_max_inclusive003_1068_float_max_inclusive003_1068_v(save_xml):
         instance="msData/datatypes/Facets/float/float_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_max_inclusive002_1067_float_max_inclusive002_1067_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1.1 and
@@ -12032,11 +12778,12 @@ def test_float_max_inclusive002_1067_float_max_inclusive002_1067_i(save_xml):
         instance="msData/datatypes/Facets/float/float_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_max_inclusive001_1066_float_max_inclusive001_1066_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1.1 and
@@ -12048,11 +12795,12 @@ def test_float_max_inclusive001_1066_float_max_inclusive001_1066_v(save_xml):
         instance="msData/datatypes/Facets/float/float_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_enumeration004_1065_float_enumeration004_1065_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 3.14
@@ -12064,11 +12812,12 @@ def test_float_enumeration004_1065_float_enumeration004_1065_v(save_xml):
         instance="msData/datatypes/Facets/float/float_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_enumeration003_1064_float_enumeration003_1064_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 3.14
@@ -12080,11 +12829,12 @@ def test_float_enumeration003_1064_float_enumeration003_1064_i(save_xml):
         instance="msData/datatypes/Facets/float/float_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_enumeration002_1063_float_enumeration002_1063_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 and
@@ -12096,11 +12846,12 @@ def test_float_enumeration002_1063_float_enumeration002_1063_v(save_xml):
         instance="msData/datatypes/Facets/float/float_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_enumeration001_1062_float_enumeration001_1062_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 and
@@ -12112,11 +12863,12 @@ def test_float_enumeration001_1062_float_enumeration001_1062_i(save_xml):
         instance="msData/datatypes/Facets/float/float_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_float_pattern001_1061_float_pattern001_1061_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -12128,11 +12880,12 @@ def test_float_pattern001_1061_float_pattern001_1061_v(save_xml):
         instance="msData/datatypes/Facets/float/float_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_total_digits004_1060_decimal_total_digits004_1060_v(save_xml):
     """
     TEST :Facet Schemas for string : XSD: totalDigits calculartion for
@@ -12144,11 +12897,12 @@ def test_decimal_total_digits004_1060_decimal_total_digits004_1060_v(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_totalDigits004.xml",
         instance_is_valid=True,
         class_name="T1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_total_digits003_1059_decimal_total_digits003_1059_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=4 and
@@ -12160,11 +12914,12 @@ def test_decimal_total_digits003_1059_decimal_total_digits003_1059_v(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_totalDigits003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_total_digits002_1058_decimal_total_digits002_1058_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=3 and
@@ -12176,11 +12931,12 @@ def test_decimal_total_digits002_1058_decimal_total_digits002_1058_v(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_totalDigits002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_total_digits001_1057_decimal_total_digits001_1057_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=totalDigits and value=2 and
@@ -12192,11 +12948,12 @@ def test_decimal_total_digits001_1057_decimal_total_digits001_1057_i(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_totalDigits001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_exclusive005_1056_decimal_min_exclusive005_1056_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1.1 and
@@ -12208,11 +12965,12 @@ def test_decimal_min_exclusive005_1056_decimal_min_exclusive005_1056_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minExclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_exclusive004_1055_decimal_min_exclusive004_1055_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minExclusive and value=1.1 and
@@ -12224,11 +12982,12 @@ def test_decimal_min_exclusive004_1055_decimal_min_exclusive004_1055_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minExclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_exclusive003_1054_decimal_min_exclusive003_1054_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1.1 and
@@ -12240,11 +12999,12 @@ def test_decimal_min_exclusive003_1054_decimal_min_exclusive003_1054_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_exclusive002_1053_decimal_min_exclusive002_1053_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=5.55 and
@@ -12256,11 +13016,12 @@ def test_decimal_min_exclusive002_1053_decimal_min_exclusive002_1053_i(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_exclusive001_1052_decimal_min_exclusive001_1052_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minExclusive and value=1.1 and
@@ -12272,11 +13033,12 @@ def test_decimal_min_exclusive001_1052_decimal_min_exclusive001_1052_i(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_inclusive005_1051_decimal_min_inclusive005_1051_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1.1 and
@@ -12288,11 +13050,12 @@ def test_decimal_min_inclusive005_1051_decimal_min_inclusive005_1051_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minInclusive005.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_inclusive004_1050_decimal_min_inclusive004_1050_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minInclusive and value=1.1 and
@@ -12304,11 +13067,12 @@ def test_decimal_min_inclusive004_1050_decimal_min_inclusive004_1050_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minInclusive004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_inclusive003_1049_decimal_min_inclusive003_1049_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1.1 and
@@ -12320,11 +13084,12 @@ def test_decimal_min_inclusive003_1049_decimal_min_inclusive003_1049_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_inclusive002_1048_decimal_min_inclusive002_1048_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=5.55 and
@@ -12336,11 +13101,12 @@ def test_decimal_min_inclusive002_1048_decimal_min_inclusive002_1048_i(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_min_inclusive001_1047_decimal_min_inclusive001_1047_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minInclusive and value=1.1 and
@@ -12352,11 +13118,12 @@ def test_decimal_min_inclusive001_1047_decimal_min_inclusive001_1047_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_minInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_max_exclusive003_1046_decimal_max_exclusive003_1046_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=7.7 and
@@ -12368,11 +13135,12 @@ def test_decimal_max_exclusive003_1046_decimal_max_exclusive003_1046_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_maxExclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_max_exclusive002_1045_decimal_max_exclusive002_1045_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1.1 and
@@ -12384,11 +13152,12 @@ def test_decimal_max_exclusive002_1045_decimal_max_exclusive002_1045_i(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_maxExclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_max_exclusive001_1044_decimal_max_exclusive001_1044_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxExclusive and value=1.1 and
@@ -12400,11 +13169,12 @@ def test_decimal_max_exclusive001_1044_decimal_max_exclusive001_1044_i(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_maxExclusive001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_max_inclusive003_1043_decimal_max_inclusive003_1043_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=7.7 and
@@ -12416,11 +13186,12 @@ def test_decimal_max_inclusive003_1043_decimal_max_inclusive003_1043_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_maxInclusive003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_max_inclusive002_1042_decimal_max_inclusive002_1042_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1.1 and
@@ -12432,11 +13203,12 @@ def test_decimal_max_inclusive002_1042_decimal_max_inclusive002_1042_i(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_maxInclusive002.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_max_inclusive001_1041_decimal_max_inclusive001_1041_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxInclusive and value=1.1 and
@@ -12448,11 +13220,12 @@ def test_decimal_max_inclusive001_1041_decimal_max_inclusive001_1041_v(save_xml)
         instance="msData/datatypes/Facets/decimal/decimal_maxInclusive001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_enumeration004_1040_decimal_enumeration004_1040_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 3.14
@@ -12464,11 +13237,12 @@ def test_decimal_enumeration004_1040_decimal_enumeration004_1040_v(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_enumeration003_1039_decimal_enumeration003_1039_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 3.14
@@ -12480,11 +13254,12 @@ def test_decimal_enumeration003_1039_decimal_enumeration003_1039_i(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_enumeration002_1038_decimal_enumeration002_1038_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 and
@@ -12496,11 +13271,12 @@ def test_decimal_enumeration002_1038_decimal_enumeration002_1038_v(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_enumeration001_1037_decimal_enumeration001_1037_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=1.1 and
@@ -12512,11 +13288,12 @@ def test_decimal_enumeration001_1037_decimal_enumeration001_1037_i(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_decimal_pattern001_1036_decimal_pattern001_1036_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and
@@ -12528,11 +13305,12 @@ def test_decimal_pattern001_1036_decimal_pattern001_1036_v(save_xml):
         instance="msData/datatypes/Facets/decimal/decimal_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_enumeration004_1035_string_enumeration004_1035_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo 123
@@ -12544,11 +13322,12 @@ def test_string_enumeration004_1035_string_enumeration004_1035_v(save_xml):
         instance="msData/datatypes/Facets/string/string_enumeration004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_enumeration003_1034_string_enumeration003_1034_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo 123
@@ -12560,11 +13339,12 @@ def test_string_enumeration003_1034_string_enumeration003_1034_i(save_xml):
         instance="msData/datatypes/Facets/string/string_enumeration003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_enumeration002_1033_string_enumeration002_1033_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -12576,11 +13356,12 @@ def test_string_enumeration002_1033_string_enumeration002_1033_v(save_xml):
         instance="msData/datatypes/Facets/string/string_enumeration002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_enumeration001_1032_string_enumeration001_1032_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=enumeration and value=foo and
@@ -12592,11 +13373,12 @@ def test_string_enumeration001_1032_string_enumeration001_1032_i(save_xml):
         instance="msData/datatypes/Facets/string/string_enumeration001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_pattern002_1031_string_pattern002_1031_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -12608,11 +13390,12 @@ def test_string_pattern002_1031_string_pattern002_1031_i(save_xml):
         instance="msData/datatypes/Facets/string/string_pattern002.xml",
         instance_is_valid=False,
         class_name="Xml",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_pattern001_1030_string_pattern001_1030_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=pattern and value=[a-z]{3} and
@@ -12624,11 +13407,12 @@ def test_string_pattern001_1030_string_pattern001_1030_v(save_xml):
         instance="msData/datatypes/Facets/string/string_pattern001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_max_length003_1029_string_max_length003_1029_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=6 and
@@ -12640,11 +13424,12 @@ def test_string_max_length003_1029_string_max_length003_1029_v(save_xml):
         instance="msData/datatypes/Facets/string/string_maxLength003.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_max_length002_1028_string_max_length002_1028_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=5 and
@@ -12656,11 +13441,12 @@ def test_string_max_length002_1028_string_max_length002_1028_v(save_xml):
         instance="msData/datatypes/Facets/string/string_maxLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_max_length001_1027_string_max_length001_1027_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=maxLength and value=4 and
@@ -12672,11 +13458,12 @@ def test_string_max_length001_1027_string_max_length001_1027_i(save_xml):
         instance="msData/datatypes/Facets/string/string_maxLength001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_min_length004_1026_string_min_length004_1026_v(save_xml):
     """
     TEST :Facet Schemas for string : (facet=minLength and value=4 and
@@ -12688,11 +13475,12 @@ def test_string_min_length004_1026_string_min_length004_1026_v(save_xml):
         instance="msData/datatypes/Facets/string/string_minLength004.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_min_length003_1025_string_min_length003_1025_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=6 and
@@ -12704,11 +13492,12 @@ def test_string_min_length003_1025_string_min_length003_1025_i(save_xml):
         instance="msData/datatypes/Facets/string/string_minLength003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_min_length002_1024_string_min_length002_1024_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=5 and
@@ -12720,11 +13509,12 @@ def test_string_min_length002_1024_string_min_length002_1024_v(save_xml):
         instance="msData/datatypes/Facets/string/string_minLength002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_min_length001_1023_string_min_length001_1023_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=minLength and value=4 and
@@ -12736,11 +13526,12 @@ def test_string_min_length001_1023_string_min_length001_1023_v(save_xml):
         instance="msData/datatypes/Facets/string/string_minLength001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_length003_1022_string_length003_1022_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=6 and document
@@ -12752,11 +13543,12 @@ def test_string_length003_1022_string_length003_1022_i(save_xml):
         instance="msData/datatypes/Facets/string/string_length003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_length002_1021_string_length002_1021_v(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=5 and document
@@ -12768,11 +13560,12 @@ def test_string_length002_1021_string_length002_1021_v(save_xml):
         instance="msData/datatypes/Facets/string/string_length002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_string_length001_1020_string_length001_1020_i(save_xml):
     """
     TEST :Facet Schemas for string : facet=length and value=4 and document
@@ -12784,11 +13577,12 @@ def test_string_length001_1020_string_length001_1020_i(save_xml):
         instance="msData/datatypes/Facets/string/string_length001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z033b_elem_z033b_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12801,11 +13595,12 @@ def test_elem_z033b_elem_z033b_v(save_xml):
         instance="msData/element/elemZ033b.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z029_elem_z029_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12818,11 +13613,12 @@ def test_elem_z029_elem_z029_v(save_xml):
         instance="msData/element/elemZ029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700g2_qfe1700g2_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12835,11 +13631,12 @@ def test_qfe1700g2_qfe1700g2_v(save_xml):
         instance="msData/element/QFE1700g2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700g1_qfe1700g1_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12852,11 +13649,12 @@ def test_qfe1700g1_qfe1700g1_i(save_xml):
         instance="msData/element/QFE1700g1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700f3_qfe1700f3_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12869,11 +13667,12 @@ def test_qfe1700f3_qfe1700f3_i(save_xml):
         instance="msData/element/QFE1700f3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700f2_qfe1700f2_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12886,11 +13685,12 @@ def test_qfe1700f2_qfe1700f2_v(save_xml):
         instance="msData/element/QFE1700f2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700f1_qfe1700f1_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12903,11 +13703,12 @@ def test_qfe1700f1_qfe1700f1_v(save_xml):
         instance="msData/element/QFE1700f1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700e3_qfe1700e3_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12920,11 +13721,12 @@ def test_qfe1700e3_qfe1700e3_i(save_xml):
         instance="msData/element/QFE1700e3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700e2_qfe1700e2_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12937,11 +13739,12 @@ def test_qfe1700e2_qfe1700e2_v(save_xml):
         instance="msData/element/QFE1700e2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700e1_qfe1700e1_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12954,11 +13757,12 @@ def test_qfe1700e1_qfe1700e1_v(save_xml):
         instance="msData/element/QFE1700e1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700d1_qfe1700d1_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -12971,11 +13775,12 @@ def test_qfe1700d1_qfe1700d1_i(save_xml):
         instance="msData/element/QFE1700d1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_qfe1700c2_qfe1700c2_v(save_xml):
     """
@@ -12989,11 +13794,12 @@ def test_qfe1700c2_qfe1700c2_v(save_xml):
         instance="msData/element/QFE1700c2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700c1_qfe1700c1_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13006,11 +13812,12 @@ def test_qfe1700c1_qfe1700c1_i(save_xml):
         instance="msData/element/QFE1700c1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700b2_qfe1700b2_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13023,11 +13830,12 @@ def test_qfe1700b2_qfe1700b2_v(save_xml):
         instance="msData/element/QFE1700b2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700b1_qfe1700b1_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13040,11 +13848,12 @@ def test_qfe1700b1_qfe1700b1_v(save_xml):
         instance="msData/element/QFE1700b1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700a3_qfe1700a3_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13057,11 +13866,12 @@ def test_qfe1700a3_qfe1700a3_v(save_xml):
         instance="msData/element/QFE1700a3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700a2_qfe1700a2_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13074,11 +13884,12 @@ def test_qfe1700a2_qfe1700a2_v(save_xml):
         instance="msData/element/QFE1700a2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_qfe1700a1_qfe1700a1_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13091,11 +13902,12 @@ def test_qfe1700a1_qfe1700a1_v(save_xml):
         instance="msData/element/QFE1700a1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z023_elem_z023_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13108,11 +13920,12 @@ def test_elem_z023_elem_z023_i(save_xml):
         instance="msData/element/elemZ023.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z022b_elem_z022b_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13125,11 +13938,12 @@ def test_elem_z022b_elem_z022b_v(save_xml):
         instance="msData/element/test115478_b.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z022a_elem_z022a_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13142,11 +13956,12 @@ def test_elem_z022a_elem_z022a_i(save_xml):
         instance="msData/element/test115478.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021g_elem_z021g_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13159,11 +13974,12 @@ def test_elem_z021g_elem_z021g_i(save_xml):
         instance="msData/element/test115044_c.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021f_elem_z021f_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13176,11 +13992,12 @@ def test_elem_z021f_elem_z021f_i(save_xml):
         instance="msData/element/test115044_b.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021e_elem_z021e_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13193,11 +14010,12 @@ def test_elem_z021e_elem_z021e_v(save_xml):
         instance="msData/element/test115044_a.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021d_elem_z021d_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13210,11 +14028,12 @@ def test_elem_z021d_elem_z021d_v(save_xml):
         instance="msData/element/test115044_b.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021c_elem_z021c_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13227,11 +14046,12 @@ def test_elem_z021c_elem_z021c_v(save_xml):
         instance="msData/element/test115044_a.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021b_elem_z021b_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13244,11 +14064,12 @@ def test_elem_z021b_elem_z021b_i(save_xml):
         instance="msData/element/test115044_b.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z021a_elem_z021a_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13261,11 +14082,12 @@ def test_elem_z021a_elem_z021a_v(save_xml):
         instance="msData/element/test115044_a.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z020_elem_z020_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13278,11 +14100,12 @@ def test_elem_z020_elem_z020_v(save_xml):
         instance="msData/element/elemZ020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z019_elem_z019_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13295,11 +14118,12 @@ def test_elem_z019_elem_z019_v(save_xml):
         instance="msData/element/elemZ019.xml",
         instance_is_valid=True,
         class_name="Series",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z018_elem_z018_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13311,11 +14135,12 @@ def test_elem_z018_elem_z018_v(save_xml):
         instance="msData/element/elemZ018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z017_elem_z017_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13327,11 +14152,12 @@ def test_elem_z017_elem_z017_v(save_xml):
         instance="msData/element/elemZ017.xml",
         instance_is_valid=True,
         class_name="AccessPermission",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z016_elem_z016_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13345,11 +14171,12 @@ def test_elem_z016_elem_z016_i(save_xml):
         instance="msData/element/elemZ016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z015_elem_z015_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13362,11 +14189,12 @@ def test_elem_z015_elem_z015_i(save_xml):
         instance="msData/element/elemZ015.xml",
         instance_is_valid=False,
         class_name="XTask",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z014_elem_z014_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13379,11 +14207,12 @@ def test_elem_z014_elem_z014_v(save_xml):
         instance="msData/element/elemZ014.xml",
         instance_is_valid=True,
         class_name="RootElem",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z010_elem_z010_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13400,11 +14229,12 @@ def test_elem_z010_elem_z010_v(save_xml):
         instance="msData/element/elemZ010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z009_elem_z009_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13421,11 +14251,12 @@ def test_elem_z009_elem_z009_v(save_xml):
         instance="msData/element/elemZ009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z003_elem_z003_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13437,11 +14268,12 @@ def test_elem_z003_elem_z003_v(save_xml):
         instance="msData/element/elemZ003.xml",
         instance_is_valid=True,
         class_name="Container",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z002_elem_z002_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13454,11 +14286,12 @@ def test_elem_z002_elem_z002_v(save_xml):
         instance="msData/element/elemZ002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_z001_elem_z001_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13471,11 +14304,12 @@ def test_elem_z001_elem_z001_v(save_xml):
         instance="msData/element/elemZ001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u025_elem_u025_i(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13487,11 +14321,12 @@ def test_elem_u025_elem_u025_i(save_xml):
         instance="msData/element/elemU025.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u024_elem_u024_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13503,11 +14338,12 @@ def test_elem_u024_elem_u024_v(save_xml):
         instance="msData/element/elemU024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u023_elem_u023_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13519,11 +14355,12 @@ def test_elem_u023_elem_u023_v(save_xml):
         instance="msData/element/elemU023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u022_elem_u022_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13535,11 +14372,12 @@ def test_elem_u022_elem_u022_v(save_xml):
         instance="msData/element/elemU022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u021_elem_u021_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13551,11 +14389,12 @@ def test_elem_u021_elem_u021_v(save_xml):
         instance="msData/element/elemU021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u020_elem_u020_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13567,11 +14406,12 @@ def test_elem_u020_elem_u020_v(save_xml):
         instance="msData/element/elemU020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u019_elem_u019_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13583,11 +14423,12 @@ def test_elem_u019_elem_u019_v(save_xml):
         instance="msData/element/elemU019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u018_elem_u018_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13599,11 +14440,12 @@ def test_elem_u018_elem_u018_v(save_xml):
         instance="msData/element/elemU018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u017_elem_u017_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13615,11 +14457,12 @@ def test_elem_u017_elem_u017_v(save_xml):
         instance="msData/element/elemU017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u015_elem_u015_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13631,11 +14474,12 @@ def test_elem_u015_elem_u015_v(save_xml):
         instance="msData/element/elemU015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u014_elem_u014_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13647,11 +14491,12 @@ def test_elem_u014_elem_u014_v(save_xml):
         instance="msData/element/elemU014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u013_elem_u013_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13663,11 +14508,12 @@ def test_elem_u013_elem_u013_v(save_xml):
         instance="msData/element/elemU013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u012_elem_u012_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13679,11 +14525,12 @@ def test_elem_u012_elem_u012_v(save_xml):
         instance="msData/element/elemU012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u011_elem_u011_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13695,11 +14542,12 @@ def test_elem_u011_elem_u011_v(save_xml):
         instance="msData/element/elemU011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u010_elem_u010_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13711,11 +14559,12 @@ def test_elem_u010_elem_u010_v(save_xml):
         instance="msData/element/elemU010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u009_elem_u009_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13727,11 +14576,12 @@ def test_elem_u009_elem_u009_v(save_xml):
         instance="msData/element/elemU009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u008_elem_u008_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13743,11 +14593,12 @@ def test_elem_u008_elem_u008_v(save_xml):
         instance="msData/element/elemU008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u007_elem_u007_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13759,11 +14610,12 @@ def test_elem_u007_elem_u007_v(save_xml):
         instance="msData/element/elemU007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u006_elem_u006_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13775,11 +14627,12 @@ def test_elem_u006_elem_u006_v(save_xml):
         instance="msData/element/elemU006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u005_elem_u005_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13791,11 +14644,12 @@ def test_elem_u005_elem_u005_v(save_xml):
         instance="msData/element/elemU005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u004_elem_u004_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13808,11 +14662,12 @@ def test_elem_u004_elem_u004_v(save_xml):
         instance="msData/element/elemU004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u003_elem_u003_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13824,11 +14679,12 @@ def test_elem_u003_elem_u003_v(save_xml):
         instance="msData/element/elemU003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u002_elem_u002_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13840,11 +14696,12 @@ def test_elem_u002_elem_u002_v(save_xml):
         instance="msData/element/elemU002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_u001_elem_u001_v(save_xml):
     r"""
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13856,11 +14713,12 @@ def test_elem_u001_elem_u001_v(save_xml):
         instance="msData/element/elemU001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t074_elem_t074_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13873,11 +14731,12 @@ def test_elem_t074_elem_t074_i(save_xml):
         instance="msData/element/elemT074.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t073_elem_t073_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13890,11 +14749,12 @@ def test_elem_t073_elem_t073_v(save_xml):
         instance="msData/element/elemT073.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t072_elem_t072_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13907,11 +14767,12 @@ def test_elem_t072_elem_t072_v(save_xml):
         instance="msData/element/elemT072.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t071_elem_t071_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13924,11 +14785,12 @@ def test_elem_t071_elem_t071_v(save_xml):
         instance="msData/element/elemT071.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t070_elem_t070_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13941,11 +14803,12 @@ def test_elem_t070_elem_t070_i(save_xml):
         instance="msData/element/elemT070.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t069_elem_t069_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13958,11 +14821,12 @@ def test_elem_t069_elem_t069_i(save_xml):
         instance="msData/element/elemT069.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t068_elem_t068_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13975,11 +14839,12 @@ def test_elem_t068_elem_t068_i(save_xml):
         instance="msData/element/elemT068.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t067_elem_t067_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -13992,11 +14857,12 @@ def test_elem_t067_elem_t067_v(save_xml):
         instance="msData/element/elemT067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t066_elem_t066_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14009,11 +14875,12 @@ def test_elem_t066_elem_t066_v(save_xml):
         instance="msData/element/elemT066.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t065_elem_t065_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14027,11 +14894,12 @@ def test_elem_t065_elem_t065_i(save_xml):
         instance="msData/element/elemT065.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t064_elem_t064_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14044,11 +14912,12 @@ def test_elem_t064_elem_t064_v(save_xml):
         instance="msData/element/elemT064.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t063_elem_t063_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14062,11 +14931,12 @@ def test_elem_t063_elem_t063_i(save_xml):
         instance="msData/element/elemT063.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t062_elem_t062_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14079,11 +14949,12 @@ def test_elem_t062_elem_t062_v(save_xml):
         instance="msData/element/elemT062.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t061_elem_t061_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14096,11 +14967,12 @@ def test_elem_t061_elem_t061_i(save_xml):
         instance="msData/element/elemT061.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t060_elem_t060_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14113,11 +14985,12 @@ def test_elem_t060_elem_t060_i(save_xml):
         instance="msData/element/elemT060.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t059_elem_t059_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14130,11 +15003,12 @@ def test_elem_t059_elem_t059_i(save_xml):
         instance="msData/element/elemT059.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_elem_t058_elem_t058_v(save_xml):
     """
@@ -14147,11 +15021,12 @@ def test_elem_t058_elem_t058_v(save_xml):
         instance="msData/element/elemT058.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t057_elem_t057_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14167,11 +15042,12 @@ def test_elem_t057_elem_t057_v(save_xml):
         instance="msData/element/elemT057.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t056_elem_t056_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14187,11 +15063,12 @@ def test_elem_t056_elem_t056_v(save_xml):
         instance="msData/element/elemT056.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t055_elem_t055_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14207,11 +15084,12 @@ def test_elem_t055_elem_t055_v(save_xml):
         instance="msData/element/elemT055.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t054_elem_t054_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14227,11 +15105,12 @@ def test_elem_t054_elem_t054_v(save_xml):
         instance="msData/element/elemT054.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t053_elem_t053_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14244,11 +15123,12 @@ def test_elem_t053_elem_t053_i(save_xml):
         instance="msData/element/elemT053.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t052_elem_t052_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14261,11 +15141,12 @@ def test_elem_t052_elem_t052_i(save_xml):
         instance="msData/element/elemT052.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t051_elem_t051_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14278,11 +15159,12 @@ def test_elem_t051_elem_t051_i(save_xml):
         instance="msData/element/elemT051.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t050_elem_t050_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14295,11 +15177,12 @@ def test_elem_t050_elem_t050_i(save_xml):
         instance="msData/element/elemT050.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t049_elem_t049_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14312,11 +15195,12 @@ def test_elem_t049_elem_t049_i(save_xml):
         instance="msData/element/elemT049.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t048_elem_t048_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14329,11 +15213,12 @@ def test_elem_t048_elem_t048_i(save_xml):
         instance="msData/element/elemT048.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t047_elem_t047_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14346,11 +15231,12 @@ def test_elem_t047_elem_t047_i(save_xml):
         instance="msData/element/elemT047.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t046_elem_t046_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14363,11 +15249,12 @@ def test_elem_t046_elem_t046_i(save_xml):
         instance="msData/element/elemT046.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t045_elem_t045_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14380,11 +15267,12 @@ def test_elem_t045_elem_t045_i(save_xml):
         instance="msData/element/elemT045.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t044_elem_t044_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14397,11 +15285,12 @@ def test_elem_t044_elem_t044_v(save_xml):
         instance="msData/element/elemT044.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t043_elem_t043_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14414,11 +15303,12 @@ def test_elem_t043_elem_t043_v(save_xml):
         instance="msData/element/elemT043.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t042_elem_t042_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14431,11 +15321,12 @@ def test_elem_t042_elem_t042_v(save_xml):
         instance="msData/element/elemT042.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t041_elem_t041_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14448,11 +15339,12 @@ def test_elem_t041_elem_t041_v(save_xml):
         instance="msData/element/elemT041.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t040_elem_t040_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14465,11 +15357,12 @@ def test_elem_t040_elem_t040_v(save_xml):
         instance="msData/element/elemT040.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t039_elem_t039_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14482,11 +15375,12 @@ def test_elem_t039_elem_t039_i(save_xml):
         instance="msData/element/elemT039.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t038_elem_t038_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14499,11 +15393,12 @@ def test_elem_t038_elem_t038_v(save_xml):
         instance="msData/element/elemT038.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t037_elem_t037_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14516,11 +15411,12 @@ def test_elem_t037_elem_t037_i(save_xml):
         instance="msData/element/elemT037.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t036_elem_t036_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14533,11 +15429,12 @@ def test_elem_t036_elem_t036_i(save_xml):
         instance="msData/element/elemT036.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t035_elem_t035_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14550,11 +15447,12 @@ def test_elem_t035_elem_t035_i(save_xml):
         instance="msData/element/elemT035.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t034_elem_t034_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14567,11 +15465,12 @@ def test_elem_t034_elem_t034_i(save_xml):
         instance="msData/element/elemT034.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t033_elem_t033_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14584,11 +15483,12 @@ def test_elem_t033_elem_t033_i(save_xml):
         instance="msData/element/elemT033.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t032_elem_t032_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14601,11 +15501,12 @@ def test_elem_t032_elem_t032_v(save_xml):
         instance="msData/element/elemT032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t031_elem_t031_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14618,11 +15519,12 @@ def test_elem_t031_elem_t031_i(save_xml):
         instance="msData/element/elemT031.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t030_elem_t030_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14635,11 +15537,12 @@ def test_elem_t030_elem_t030_v(save_xml):
         instance="msData/element/elemT030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t029_elem_t029_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14655,11 +15558,12 @@ def test_elem_t029_elem_t029_v(save_xml):
         instance="msData/element/elemT029.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t028_elem_t028_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14675,11 +15579,12 @@ def test_elem_t028_elem_t028_v(save_xml):
         instance="msData/element/elemT028.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t027_elem_t027_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14695,11 +15600,12 @@ def test_elem_t027_elem_t027_v(save_xml):
         instance="msData/element/elemT027.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t026_elem_t026_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14715,11 +15621,12 @@ def test_elem_t026_elem_t026_v(save_xml):
         instance="msData/element/elemT026.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_elem_t025_elem_t025_v(save_xml):
     """
@@ -14733,11 +15640,12 @@ def test_elem_t025_elem_t025_v(save_xml):
         instance="msData/element/elemT025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t024_elem_t024_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14750,11 +15658,12 @@ def test_elem_t024_elem_t024_i(save_xml):
         instance="msData/element/elemT024.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t023_elem_t023_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14767,11 +15676,12 @@ def test_elem_t023_elem_t023_i(save_xml):
         instance="msData/element/elemT023.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t022_elem_t022_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14784,11 +15694,12 @@ def test_elem_t022_elem_t022_i(save_xml):
         instance="msData/element/elemT022.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t021_elem_t021_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14801,11 +15712,12 @@ def test_elem_t021_elem_t021_i(save_xml):
         instance="msData/element/elemT021.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t020_elem_t020_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14818,11 +15730,12 @@ def test_elem_t020_elem_t020_i(save_xml):
         instance="msData/element/elemT020.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t019_elem_t019_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14835,11 +15748,12 @@ def test_elem_t019_elem_t019_i(save_xml):
         instance="msData/element/elemT019.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t018_elem_t018_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14852,11 +15766,12 @@ def test_elem_t018_elem_t018_i(save_xml):
         instance="msData/element/elemT018.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t017_elem_t017_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14869,11 +15784,12 @@ def test_elem_t017_elem_t017_i(save_xml):
         instance="msData/element/elemT017.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t016_elem_t016_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14886,11 +15802,12 @@ def test_elem_t016_elem_t016_v(save_xml):
         instance="msData/element/elemT016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t015_elem_t015_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14903,11 +15820,12 @@ def test_elem_t015_elem_t015_v(save_xml):
         instance="msData/element/elemT015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t014_elem_t014_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14920,11 +15838,12 @@ def test_elem_t014_elem_t014_v(save_xml):
         instance="msData/element/elemT014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t013_elem_t013_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14937,11 +15856,12 @@ def test_elem_t013_elem_t013_i(save_xml):
         instance="msData/element/elemT013.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t012_elem_t012_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14953,11 +15873,12 @@ def test_elem_t012_elem_t012_i(save_xml):
         instance="msData/element/elemT012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t011_elem_t011_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -14970,11 +15891,12 @@ def test_elem_t011_elem_t011_i(save_xml):
         instance="msData/element/elemT011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_elem_t008_elem_t008_v(save_xml):
     """
@@ -14988,11 +15910,12 @@ def test_elem_t008_elem_t008_v(save_xml):
         instance="msData/element/elemT008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t007_elem_t007_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15005,11 +15928,12 @@ def test_elem_t007_elem_t007_v(save_xml):
         instance="msData/element/elemT007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t006_elem_t006_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15022,11 +15946,12 @@ def test_elem_t006_elem_t006_i(save_xml):
         instance="msData/element/elemT006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t005_elem_t005_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15039,11 +15964,12 @@ def test_elem_t005_elem_t005_i(save_xml):
         instance="msData/element/elemT005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t004_elem_t004_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15056,11 +15982,12 @@ def test_elem_t004_elem_t004_i(save_xml):
         instance="msData/element/elemT004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t003_elem_t003_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15073,11 +16000,12 @@ def test_elem_t003_elem_t003_v(save_xml):
         instance="msData/element/elemT003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_elem_t002_elem_t002_v(save_xml):
     """
@@ -15091,11 +16019,12 @@ def test_elem_t002_elem_t002_v(save_xml):
         instance="msData/element/elemT002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_t001_elem_t001_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15108,11 +16037,12 @@ def test_elem_t001_elem_t001_i(save_xml):
         instance="msData/element/elemT001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_s008_elem_s008_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15125,11 +16055,12 @@ def test_elem_s008_elem_s008_v(save_xml):
         instance="msData/element/elemS008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_s007_elem_s007_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15142,11 +16073,12 @@ def test_elem_s007_elem_s007_v(save_xml):
         instance="msData/element/elemS007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_s003_elem_s003_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15159,11 +16091,12 @@ def test_elem_s003_elem_s003_v(save_xml):
         instance="msData/element/elemS003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_s002_elem_s002_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15176,11 +16109,12 @@ def test_elem_s002_elem_s002_v(save_xml):
         instance="msData/element/elemS002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_r005_elem_r005_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15193,11 +16127,12 @@ def test_elem_r005_elem_r005_v(save_xml):
         instance="msData/element/elemR005.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_r004_elem_r004_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15210,11 +16145,12 @@ def test_elem_r004_elem_r004_v(save_xml):
         instance="msData/element/elemR004.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_r002_elem_r002_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15227,11 +16163,12 @@ def test_elem_r002_elem_r002_v(save_xml):
         instance="msData/element/elemR002.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_r001_elem_r001_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15244,11 +16181,12 @@ def test_elem_r001_elem_r001_v(save_xml):
         instance="msData/element/elemR001.xml",
         instance_is_valid=True,
         class_name="PurchaseOrder",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q022_elem_q022_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15260,11 +16198,12 @@ def test_elem_q022_elem_q022_v(save_xml):
         instance="msData/element/elemQ022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q021_elem_q021_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15277,11 +16216,12 @@ def test_elem_q021_elem_q021_v(save_xml):
         instance="msData/element/elemQ021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q020_elem_q020_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15293,11 +16233,12 @@ def test_elem_q020_elem_q020_v(save_xml):
         instance="msData/element/elemQ020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q019_elem_q019_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15309,11 +16250,12 @@ def test_elem_q019_elem_q019_v(save_xml):
         instance="msData/element/elemQ019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q018_elem_q018_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15326,11 +16268,12 @@ def test_elem_q018_elem_q018_i(save_xml):
         instance="msData/element/elemQ018.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q017_elem_q017_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15342,11 +16285,12 @@ def test_elem_q017_elem_q017_v(save_xml):
         instance="msData/element/elemQ017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q015_elem_q015_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15359,11 +16303,12 @@ def test_elem_q015_elem_q015_v(save_xml):
         instance="msData/element/elemQ015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q014_elem_q014_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15376,11 +16321,12 @@ def test_elem_q014_elem_q014_i(save_xml):
         instance="msData/element/elemQ014.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q013_elem_q013_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15393,11 +16339,12 @@ def test_elem_q013_elem_q013_v(save_xml):
         instance="msData/element/elemQ013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q012_elem_q012_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15409,11 +16356,12 @@ def test_elem_q012_elem_q012_i(save_xml):
         instance="msData/element/elemQ012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q011_elem_q011_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15425,11 +16373,12 @@ def test_elem_q011_elem_q011_v(save_xml):
         instance="msData/element/elemQ011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q010_elem_q010_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15441,11 +16390,12 @@ def test_elem_q010_elem_q010_i(save_xml):
         instance="msData/element/elemQ010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q009_elem_q009_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15457,11 +16407,12 @@ def test_elem_q009_elem_q009_i(save_xml):
         instance="msData/element/elemQ009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q008_elem_q008_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15473,11 +16424,12 @@ def test_elem_q008_elem_q008_v(save_xml):
         instance="msData/element/elemQ008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_q007_elem_q007_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15489,11 +16441,12 @@ def test_elem_q007_elem_q007_i(save_xml):
         instance="msData/element/elemQ007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o012_elem_o012_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15505,11 +16458,12 @@ def test_elem_o012_elem_o012_v(save_xml):
         instance="msData/element/elemO012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o011_elem_o011_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15522,11 +16476,12 @@ def test_elem_o011_elem_o011_i(save_xml):
         instance="msData/element/elemO011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o010_elem_o010_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15539,11 +16494,12 @@ def test_elem_o010_elem_o010_i(save_xml):
         instance="msData/element/elemO010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o009_elem_o009_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15555,11 +16511,12 @@ def test_elem_o009_elem_o009_v(save_xml):
         instance="msData/element/elemO009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o008_elem_o008_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15572,11 +16529,12 @@ def test_elem_o008_elem_o008_v(save_xml):
         instance="msData/element/elemO008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o007_elem_o007_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15589,11 +16547,12 @@ def test_elem_o007_elem_o007_i(save_xml):
         instance="msData/element/elemO007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o006_elem_o006_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15606,11 +16565,12 @@ def test_elem_o006_elem_o006_v(save_xml):
         instance="msData/element/elemO006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o005_elem_o005_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15623,11 +16583,12 @@ def test_elem_o005_elem_o005_v(save_xml):
         instance="msData/element/elemO005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o004_elem_o004_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15639,11 +16600,12 @@ def test_elem_o004_elem_o004_v(save_xml):
         instance="msData/element/elemO004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o003_elem_o003_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15656,11 +16618,12 @@ def test_elem_o003_elem_o003_v(save_xml):
         instance="msData/element/elemO003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o002_elem_o002_v(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15672,11 +16635,12 @@ def test_elem_o002_elem_o002_v(save_xml):
         instance="msData/element/elemO002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_elem_o001_elem_o001_i(save_xml):
     """
     TEST :3.3.2 XML Representation of Element Declaration Schema
@@ -15689,11 +16653,12 @@ def test_elem_o001_elem_o001_i(save_xml):
         instance="msData/element/elemO001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_f001_err_f001_i(save_xml):
     """
     TEST :Primer Errata : Errata E2-35: length facet is now allowed with
@@ -15706,11 +16671,12 @@ def test_err_f001_err_f001_i(save_xml):
         instance="msData/errata10/errF001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_e008_err_e008_v(save_xml):
     """
     TEST :Primer Errata : E2-17 Error: Do not allow carriage return in
@@ -15722,11 +16688,12 @@ def test_err_e008_err_e008_v(save_xml):
         instance="msData/errata10/errE008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_e006_err_e006_v(save_xml):
     """
     TEST :Primer Errata : E2-22 Clarification: test date, gYearMonth,
@@ -15739,11 +16706,12 @@ def test_err_e006_err_e006_v(save_xml):
         instance="msData/errata10/errE006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_e004_err_e004_i(save_xml):
     """
     TEST :Primer Errata : E2-24 Error: test that absent 'T' is enforced
@@ -15755,11 +16723,12 @@ def test_err_e004_err_e004_i(save_xml):
         instance="msData/errata10/errE004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_e003_err_e003_v(save_xml):
     """
     TEST :Primer Errata : E2-25 Error: test support for the new language
@@ -15771,11 +16740,12 @@ def test_err_e003_err_e003_v(save_xml):
         instance="msData/errata10/errE003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_e002_err_e002_v(save_xml):
     """
     TEST :Primer Errata : E2-27 Error: test that nonNegativeIntegers
@@ -15787,11 +16757,12 @@ def test_err_e002_err_e002_v(save_xml):
         instance="msData/errata10/errE002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_e001_err_e001_v(save_xml):
     """
     TEST :Primer Errata : E2-27 Error: test that nonPositiveIntegers
@@ -15803,11 +16774,12 @@ def test_err_e001_err_e001_v(save_xml):
         instance="msData/errata10/errE001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_c007_err_c007_v(save_xml):
     """
     TEST :Primer Errata : E1-22 Error: R-117 Process contents for ur-type
@@ -15819,11 +16791,12 @@ def test_err_c007_err_c007_v(save_xml):
         instance="msData/errata10/errC007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_c001_err_c001_v(save_xml):
     """
     TEST :Primer Errata : E1-40 Clarification: test that anySimpleType
@@ -15835,11 +16808,12 @@ def test_err_c001_err_c001_v(save_xml):
         instance="msData/errata10/errC001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_a003_err_a003_v(save_xml):
     """
     TEST :Primer Errata : E0-15 Error, E2-12 Error: test lexical
@@ -15851,11 +16825,12 @@ def test_err_a003_err_a003_v(save_xml):
         instance="msData/errata10/errA003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_a002_err_a002_i(save_xml):
     """
     TEST :Primer Errata : E0-10 Error, E1-11 Error: test that ##other
@@ -15867,11 +16842,12 @@ def test_err_a002_err_a002_i(save_xml):
         instance="msData/errata10/errA002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_err_a001_err_a001_v(save_xml):
     """
     TEST :Primer Errata : E0-23 Clarification: test that facet
@@ -15884,11 +16860,12 @@ def test_err_a001_err_a001_v(save_xml):
         instance="msData/errata10/errA001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_o009v_group_o009v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test content: (xml instant is
@@ -15900,11 +16877,12 @@ def test_group_o009v_group_o009v_i(save_xml):
         instance="msData/group/groupO009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_o008v_group_o008v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test content: annotation follow by
@@ -15916,11 +16894,12 @@ def test_group_o008v_group_o008v_v(save_xml):
         instance="msData/group/groupO008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_o007v_group_o007v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test content: (xml instant is
@@ -15932,11 +16911,12 @@ def test_group_o007v_group_o007v_i(save_xml):
         instance="msData/group/groupO007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_o006v_group_o006v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test content: annotation follow by
@@ -15948,11 +16928,12 @@ def test_group_o006v_group_o006v_v(save_xml):
         instance="msData/group/groupO006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_o005v_group_o005v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test content: (xml instant is
@@ -15964,11 +16945,12 @@ def test_group_o005v_group_o005v_i(save_xml):
         instance="msData/group/groupO005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_o004v_group_o004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test content: annotation follow by
@@ -15980,11 +16962,12 @@ def test_group_o004v_group_o004v_v(save_xml):
         instance="msData/group/groupO004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n021v_group_n021v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -15996,11 +16979,12 @@ def test_group_n021v_group_n021v_v(save_xml):
         instance="msData/group/groupN021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n019v_group_n019v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16012,11 +16996,12 @@ def test_group_n019v_group_n019v_i(save_xml):
         instance="msData/group/groupN019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n018v_group_n018v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16028,11 +17013,12 @@ def test_group_n018v_group_n018v_v(save_xml):
         instance="msData/group/groupN018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n017v_group_n017v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16044,11 +17030,12 @@ def test_group_n017v_group_n017v_v(save_xml):
         instance="msData/group/groupN017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n016v_group_n016v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16060,11 +17047,12 @@ def test_group_n016v_group_n016v_i(save_xml):
         instance="msData/group/groupN016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n015v_group_n015v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16076,11 +17064,12 @@ def test_group_n015v_group_n015v_i(save_xml):
         instance="msData/group/groupN015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n014v_group_n014v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16092,11 +17081,12 @@ def test_group_n014v_group_n014v_v(save_xml):
         instance="msData/group/groupN014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n013v_group_n013v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16108,11 +17098,12 @@ def test_group_n013v_group_n013v_i(save_xml):
         instance="msData/group/groupN013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n012v_group_n012v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16124,11 +17115,12 @@ def test_group_n012v_group_n012v_i(save_xml):
         instance="msData/group/groupN012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n011v_group_n011v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16140,11 +17132,12 @@ def test_group_n011v_group_n011v_v(save_xml):
         instance="msData/group/groupN011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n010v_group_n010v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16156,11 +17149,12 @@ def test_group_n010v_group_n010v_i(save_xml):
         instance="msData/group/groupN010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n009v_group_n009v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16172,11 +17166,12 @@ def test_group_n009v_group_n009v_v(save_xml):
         instance="msData/group/groupN009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n008v_group_n008v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16188,11 +17183,12 @@ def test_group_n008v_group_n008v_i(save_xml):
         instance="msData/group/groupN008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n007v_group_n007v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16204,11 +17200,12 @@ def test_group_n007v_group_n007v_v(save_xml):
         instance="msData/group/groupN007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n006v_group_n006v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -16220,6 +17217,6 @@ def test_group_n006v_group_n006v_i(save_xml):
         instance="msData/group/groupN006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_ms_meta_3000.py
+++ b/tests/test_ms_meta_3000.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_group_n005v_group_n005v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -14,11 +15,12 @@ def test_group_n005v_group_n005v_v(save_xml):
         instance="msData/group/groupN005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n004v_group_n004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -30,11 +32,12 @@ def test_group_n004v_group_n004v_v(save_xml):
         instance="msData/group/groupN004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n003v_group_n003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -46,11 +49,12 @@ def test_group_n003v_group_n003v_i(save_xml):
         instance="msData/group/groupN003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n002v_group_n002v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -62,11 +66,12 @@ def test_group_n002v_group_n002v_v(save_xml):
         instance="msData/group/groupN002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_n001v_group_n001v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: elements in
@@ -78,11 +83,12 @@ def test_group_n001v_group_n001v_v(save_xml):
         instance="msData/group/groupN001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_m005v_group_m005v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: check that
@@ -95,11 +101,12 @@ def test_group_m005v_group_m005v_i(save_xml):
         instance="msData/group/groupM005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_m004v_group_m004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: check that
@@ -112,11 +119,12 @@ def test_group_m004v_group_m004v_v(save_xml):
         instance="msData/group/groupM004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_m003v_group_m003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is complexType: check that
@@ -129,11 +137,12 @@ def test_group_m003v_group_m003v_i(save_xml):
         instance="msData/group/groupM003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l021v_group_l021v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -145,11 +154,12 @@ def test_group_l021v_group_l021v_v(save_xml):
         instance="msData/group/groupL021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l019v_group_l019v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -161,11 +171,12 @@ def test_group_l019v_group_l019v_i(save_xml):
         instance="msData/group/groupL019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l018v_group_l018v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -177,11 +188,12 @@ def test_group_l018v_group_l018v_v(save_xml):
         instance="msData/group/groupL018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l017v_group_l017v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -193,11 +205,12 @@ def test_group_l017v_group_l017v_v(save_xml):
         instance="msData/group/groupL017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l016v_group_l016v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -209,11 +222,12 @@ def test_group_l016v_group_l016v_i(save_xml):
         instance="msData/group/groupL016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l015v_group_l015v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -225,11 +239,12 @@ def test_group_l015v_group_l015v_i(save_xml):
         instance="msData/group/groupL015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l014v_group_l014v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -241,11 +256,12 @@ def test_group_l014v_group_l014v_v(save_xml):
         instance="msData/group/groupL014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l013v_group_l013v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -257,11 +273,12 @@ def test_group_l013v_group_l013v_i(save_xml):
         instance="msData/group/groupL013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l012v_group_l012v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -273,11 +290,12 @@ def test_group_l012v_group_l012v_i(save_xml):
         instance="msData/group/groupL012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l011v_group_l011v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -289,11 +307,12 @@ def test_group_l011v_group_l011v_v(save_xml):
         instance="msData/group/groupL011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l010v_group_l010v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -305,11 +324,12 @@ def test_group_l010v_group_l010v_i(save_xml):
         instance="msData/group/groupL010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l009v_group_l009v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -321,11 +341,12 @@ def test_group_l009v_group_l009v_v(save_xml):
         instance="msData/group/groupL009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l008v_group_l008v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -337,11 +358,12 @@ def test_group_l008v_group_l008v_i(save_xml):
         instance="msData/group/groupL008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l007_group_l007_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -353,11 +375,12 @@ def test_group_l007_group_l007_v(save_xml):
         instance="msData/group/groupL007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l006v_group_l006v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -369,11 +392,12 @@ def test_group_l006v_group_l006v_i(save_xml):
         instance="msData/group/groupL006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l005v_group_l005v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -385,11 +409,12 @@ def test_group_l005v_group_l005v_v(save_xml):
         instance="msData/group/groupL005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l004v_group_l004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -401,11 +426,12 @@ def test_group_l004v_group_l004v_v(save_xml):
         instance="msData/group/groupL004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l003v_group_l003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -417,11 +443,12 @@ def test_group_l003v_group_l003v_i(save_xml):
         instance="msData/group/groupL003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l002v_group_l002v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -433,11 +460,12 @@ def test_group_l002v_group_l002v_v(save_xml):
         instance="msData/group/groupL002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_l001v_group_l001v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: elements in
@@ -449,11 +477,12 @@ def test_group_l001v_group_l001v_v(save_xml):
         instance="msData/group/groupL001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_k005v_group_k005v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: check that
@@ -466,11 +495,12 @@ def test_group_k005v_group_k005v_i(save_xml):
         instance="msData/group/groupK005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_k004v_group_k004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: check that
@@ -483,11 +513,12 @@ def test_group_k004v_group_k004v_v(save_xml):
         instance="msData/group/groupK004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_k003v_group_k003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is choice: check that
@@ -500,11 +531,12 @@ def test_group_k003v_group_k003v_i(save_xml):
         instance="msData/group/groupK003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j021v_group_j021v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -516,11 +548,12 @@ def test_group_j021v_group_j021v_v(save_xml):
         instance="msData/group/groupJ021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j019v_group_j019v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -532,11 +565,12 @@ def test_group_j019v_group_j019v_i(save_xml):
         instance="msData/group/groupJ019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j018v_group_j018v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -548,11 +582,12 @@ def test_group_j018v_group_j018v_v(save_xml):
         instance="msData/group/groupJ018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j017v_group_j017v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -564,11 +599,12 @@ def test_group_j017v_group_j017v_v(save_xml):
         instance="msData/group/groupJ017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j016v_group_j016v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -580,11 +616,12 @@ def test_group_j016v_group_j016v_i(save_xml):
         instance="msData/group/groupJ016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j015v_group_j015v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -596,11 +633,12 @@ def test_group_j015v_group_j015v_i(save_xml):
         instance="msData/group/groupJ015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j014v_group_j014v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -612,11 +650,12 @@ def test_group_j014v_group_j014v_v(save_xml):
         instance="msData/group/groupJ014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j013v_group_j013v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -628,11 +667,12 @@ def test_group_j013v_group_j013v_i(save_xml):
         instance="msData/group/groupJ013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j012v_group_j012v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -644,11 +684,12 @@ def test_group_j012v_group_j012v_i(save_xml):
         instance="msData/group/groupJ012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j011v_group_j011v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -660,11 +701,12 @@ def test_group_j011v_group_j011v_v(save_xml):
         instance="msData/group/groupJ011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j010v_group_j010v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -676,11 +718,12 @@ def test_group_j010v_group_j010v_i(save_xml):
         instance="msData/group/groupJ010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j009v_group_j009v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -692,11 +735,12 @@ def test_group_j009v_group_j009v_v(save_xml):
         instance="msData/group/groupJ009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j008v_group_j008v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -708,11 +752,12 @@ def test_group_j008v_group_j008v_i(save_xml):
         instance="msData/group/groupJ008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j007v_group_j007v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -724,11 +769,12 @@ def test_group_j007v_group_j007v_v(save_xml):
         instance="msData/group/groupJ007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j006v_group_j006v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -740,11 +786,12 @@ def test_group_j006v_group_j006v_i(save_xml):
         instance="msData/group/groupJ006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j005v_group_j005v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -756,11 +803,12 @@ def test_group_j005v_group_j005v_v(save_xml):
         instance="msData/group/groupJ005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j004v_group_j004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -772,11 +820,12 @@ def test_group_j004v_group_j004v_v(save_xml):
         instance="msData/group/groupJ004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j003v_group_j003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -788,11 +837,12 @@ def test_group_j003v_group_j003v_i(save_xml):
         instance="msData/group/groupJ003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j002v_group_j002v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -804,11 +854,12 @@ def test_group_j002v_group_j002v_v(save_xml):
         instance="msData/group/groupJ002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_j001v_group_j001v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: elements in
@@ -820,11 +871,12 @@ def test_group_j001v_group_j001v_v(save_xml):
         instance="msData/group/groupJ001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_i005v_group_i005v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: check that
@@ -837,11 +889,12 @@ def test_group_i005v_group_i005v_i(save_xml):
         instance="msData/group/groupI005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_i004v_group_i004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: check that
@@ -854,11 +907,12 @@ def test_group_i004v_group_i004v_v(save_xml):
         instance="msData/group/groupI004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_i003v_group_i003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is sequence: check that
@@ -871,11 +925,12 @@ def test_group_i003v_group_i003v_i(save_xml):
         instance="msData/group/groupI003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h019v_group_h019v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -887,11 +942,12 @@ def test_group_h019v_group_h019v_i(save_xml):
         instance="msData/group/groupH019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h018v_group_h018v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -903,11 +959,12 @@ def test_group_h018v_group_h018v_v(save_xml):
         instance="msData/group/groupH018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h017v_group_h017v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -919,11 +976,12 @@ def test_group_h017v_group_h017v_v(save_xml):
         instance="msData/group/groupH017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h016v_group_h016v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -935,11 +993,12 @@ def test_group_h016v_group_h016v_i(save_xml):
         instance="msData/group/groupH016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h015v_group_h015v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -951,11 +1010,12 @@ def test_group_h015v_group_h015v_i(save_xml):
         instance="msData/group/groupH015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h014v_group_h014v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -967,11 +1027,12 @@ def test_group_h014v_group_h014v_v(save_xml):
         instance="msData/group/groupH014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h013v_group_h013v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -983,11 +1044,12 @@ def test_group_h013v_group_h013v_i(save_xml):
         instance="msData/group/groupH013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h012v_group_h012v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -999,11 +1061,12 @@ def test_group_h012v_group_h012v_i(save_xml):
         instance="msData/group/groupH012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h011v_group_h011v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1015,11 +1078,12 @@ def test_group_h011v_group_h011v_v(save_xml):
         instance="msData/group/groupH011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h010v_group_h010v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1031,11 +1095,12 @@ def test_group_h010v_group_h010v_i(save_xml):
         instance="msData/group/groupH010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h009v_group_h009v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1047,11 +1112,12 @@ def test_group_h009v_group_h009v_v(save_xml):
         instance="msData/group/groupH009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h008v_group_h008v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1063,11 +1129,12 @@ def test_group_h008v_group_h008v_i(save_xml):
         instance="msData/group/groupH008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h006v_group_h006v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1079,11 +1146,12 @@ def test_group_h006v_group_h006v_i(save_xml):
         instance="msData/group/groupH006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h005v_group_h005v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1095,11 +1163,12 @@ def test_group_h005v_group_h005v_v(save_xml):
         instance="msData/group/groupH005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h004v_group_h004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1111,11 +1180,12 @@ def test_group_h004v_group_h004v_v(save_xml):
         instance="msData/group/groupH004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h003v_group_h003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1127,11 +1197,12 @@ def test_group_h003v_group_h003v_i(save_xml):
         instance="msData/group/groupH003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h002v_group_h002v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1143,11 +1214,12 @@ def test_group_h002v_group_h002v_v(save_xml):
         instance="msData/group/groupH002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_h001v_group_h001v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: elements in
@@ -1159,11 +1231,12 @@ def test_group_h001v_group_h001v_v(save_xml):
         instance="msData/group/groupH001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_g005v_group_g005v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: check that
@@ -1176,11 +1249,12 @@ def test_group_g005v_group_g005v_i(save_xml):
         instance="msData/group/groupG005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_g004v_group_g004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: check that
@@ -1193,11 +1267,12 @@ def test_group_g004v_group_g004v_v(save_xml):
         instance="msData/group/groupG004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_g003v_group_g003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is restriction: check that
@@ -1210,11 +1285,12 @@ def test_group_g003v_group_g003v_i(save_xml):
         instance="msData/group/groupG003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f021v_group_f021v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1226,11 +1302,12 @@ def test_group_f021v_group_f021v_v(save_xml):
         instance="msData/group/groupF021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f019v_group_f019v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1242,11 +1319,12 @@ def test_group_f019v_group_f019v_i(save_xml):
         instance="msData/group/groupF019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f018v_group_f018v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1258,11 +1336,12 @@ def test_group_f018v_group_f018v_v(save_xml):
         instance="msData/group/groupF018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f017v_group_f017v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1274,11 +1353,12 @@ def test_group_f017v_group_f017v_v(save_xml):
         instance="msData/group/groupF017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f016v_group_f016v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1290,11 +1370,12 @@ def test_group_f016v_group_f016v_i(save_xml):
         instance="msData/group/groupF016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f015v_group_f015v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1306,11 +1387,12 @@ def test_group_f015v_group_f015v_i(save_xml):
         instance="msData/group/groupF015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f014v_group_f014v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1322,11 +1404,12 @@ def test_group_f014v_group_f014v_v(save_xml):
         instance="msData/group/groupF014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f013v_group_f013v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1338,11 +1421,12 @@ def test_group_f013v_group_f013v_i(save_xml):
         instance="msData/group/groupF013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f012v_group_f012v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1354,11 +1438,12 @@ def test_group_f012v_group_f012v_i(save_xml):
         instance="msData/group/groupF012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f011v_group_f011v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1370,11 +1455,12 @@ def test_group_f011v_group_f011v_v(save_xml):
         instance="msData/group/groupF011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f010v_group_f010v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1386,11 +1472,12 @@ def test_group_f010v_group_f010v_i(save_xml):
         instance="msData/group/groupF010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f009v_group_f009v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1402,11 +1489,12 @@ def test_group_f009v_group_f009v_v(save_xml):
         instance="msData/group/groupF009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f008v_group_f008v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1418,11 +1506,12 @@ def test_group_f008v_group_f008v_i(save_xml):
         instance="msData/group/groupF008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f007v_group_f007v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1434,11 +1523,12 @@ def test_group_f007v_group_f007v_v(save_xml):
         instance="msData/group/groupF007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f006v_group_f006v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1450,11 +1540,12 @@ def test_group_f006v_group_f006v_i(save_xml):
         instance="msData/group/groupF006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f005v_group_f005v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1466,11 +1557,12 @@ def test_group_f005v_group_f005v_v(save_xml):
         instance="msData/group/groupF005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f004v_group_f004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1482,11 +1574,12 @@ def test_group_f004v_group_f004v_v(save_xml):
         instance="msData/group/groupF004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f003v_group_f003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1498,11 +1591,12 @@ def test_group_f003v_group_f003v_i(save_xml):
         instance="msData/group/groupF003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f002v_group_f002v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1514,11 +1608,12 @@ def test_group_f002v_group_f002v_v(save_xml):
         instance="msData/group/groupF002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_f001v_group_f001v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: elements in
@@ -1530,11 +1625,12 @@ def test_group_f001v_group_f001v_v(save_xml):
         instance="msData/group/groupF001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_e005v_group_e005v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: check that
@@ -1547,11 +1643,12 @@ def test_group_e005v_group_e005v_i(save_xml):
         instance="msData/group/groupE005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_e004v_group_e004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: check that
@@ -1564,11 +1661,12 @@ def test_group_e004v_group_e004v_v(save_xml):
         instance="msData/group/groupE004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_e003v_group_e003v_i(save_xml):
     """
     TEST :Syntax Checking (id, ref) : parent is extension: check that
@@ -1581,11 +1679,12 @@ def test_group_e003v_group_e003v_i(save_xml):
         instance="msData/group/groupE003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b010v_group_b010v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is extension,
@@ -1597,11 +1696,12 @@ def test_group_b010v_group_b010v_v(save_xml):
         instance="msData/group/groupB010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b009v_group_b009v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is extension,
@@ -1613,11 +1713,12 @@ def test_group_b009v_group_b009v_v(save_xml):
         instance="msData/group/groupB009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b006v_group_b006v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is complexType,
@@ -1629,11 +1730,12 @@ def test_group_b006v_group_b006v_v(save_xml):
         instance="msData/group/groupB006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b005v_group_b005v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is choice,
@@ -1645,11 +1747,12 @@ def test_group_b005v_group_b005v_v(save_xml):
         instance="msData/group/groupB005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b004v_group_b004v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is sequence,
@@ -1661,11 +1764,12 @@ def test_group_b004v_group_b004v_v(save_xml):
         instance="msData/group/groupB004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b003v_group_b003v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is restriction,
@@ -1677,11 +1781,12 @@ def test_group_b003v_group_b003v_v(save_xml):
         instance="msData/group/groupB003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_group_b002v_group_b002v_v(save_xml):
     """
     TEST :Syntax Checking (id, ref) : Test ref:, parent is extension,
@@ -1693,11 +1798,12 @@ def test_group_b002v_group_b002v_v(save_xml):
         instance="msData/group/groupB002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z015_id_z015_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : XSD: test
@@ -1711,11 +1817,12 @@ def test_id_z015_id_z015_i(save_xml):
         instance="msData/identityConstraint/idZ015.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z012_id_z012_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : processing
@@ -1728,11 +1835,12 @@ def test_id_z012_id_z012_i(save_xml):
         instance="msData/identityConstraint/idZ012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z011_a_id_z011_a_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : xsd: multiple
@@ -1745,7 +1853,7 @@ def test_id_z011_a_id_z011_a_i(save_xml):
         instance="msData/identityConstraint/idZ011_a.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -1769,6 +1877,7 @@ def test_id_z011_id_z011_i(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_id_z010_id_z010_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : xsd idendity
@@ -1781,11 +1890,12 @@ def test_id_z010_id_z010_i(save_xml):
         instance="msData/identityConstraint/idZ010.xml",
         instance_is_valid=False,
         class_name="Root1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z008_id_z008_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : xsd: test
@@ -1797,11 +1907,12 @@ def test_id_z008_id_z008_i(save_xml):
         instance="msData/identityConstraint/idZ008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z007_id_z007_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Values of
@@ -1813,11 +1924,12 @@ def test_id_z007_id_z007_v(save_xml):
         instance="msData/identityConstraint/idZ007.xml",
         instance_is_valid=True,
         class_name="NewDataSet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z006_id_z006_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : test
@@ -1829,11 +1941,12 @@ def test_id_z006_id_z006_v(save_xml):
         instance="msData/identityConstraint/idZ006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z005_id_z005_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : test
@@ -1845,11 +1958,12 @@ def test_id_z005_id_z005_v(save_xml):
         instance="msData/identityConstraint/idZ005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z004_id_z004_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : 71477 - XSD
@@ -1862,11 +1976,12 @@ def test_id_z004_id_z004_i(save_xml):
         instance="msData/identityConstraint/idZ004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z002_id_z002_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : 70981 -
@@ -1878,11 +1993,12 @@ def test_id_z002_id_z002_i(save_xml):
         instance="msData/identityConstraint/idZ002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_z001_id_z001_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : 70955 -
@@ -1894,11 +2010,12 @@ def test_id_z001_id_z001_i(save_xml):
         instance="msData/identityConstraint/idZ001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l103_id_l103_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -1911,11 +2028,12 @@ def test_id_l103_id_l103_i(save_xml):
         instance="msData/identityConstraint/idL103.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l102_id_l102_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -1928,11 +2046,12 @@ def test_id_l102_id_l102_v(save_xml):
         instance="msData/identityConstraint/idL102.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l101_id_l101_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -1944,11 +2063,12 @@ def test_id_l101_id_l101_i(save_xml):
         instance="msData/identityConstraint/idL101.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l100_id_l100_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -1961,11 +2081,12 @@ def test_id_l100_id_l100_v(save_xml):
         instance="msData/identityConstraint/idL100.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l099_id_l099_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -1978,11 +2099,12 @@ def test_id_l099_id_l099_i(save_xml):
         instance="msData/identityConstraint/idL099.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l098_id_l098_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -1995,11 +2117,12 @@ def test_id_l098_id_l098_v(save_xml):
         instance="msData/identityConstraint/idL098.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l097_id_l097_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2012,11 +2135,12 @@ def test_id_l097_id_l097_i(save_xml):
         instance="msData/identityConstraint/idL097.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l096_id_l096_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2029,11 +2153,12 @@ def test_id_l096_id_l096_v(save_xml):
         instance="msData/identityConstraint/idL096.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l095_id_l095_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2045,11 +2170,12 @@ def test_id_l095_id_l095_i(save_xml):
         instance="msData/identityConstraint/idL095.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l094_id_l094_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2061,11 +2187,12 @@ def test_id_l094_id_l094_v(save_xml):
         instance="msData/identityConstraint/idL094.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l093_id_l093_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2078,11 +2205,12 @@ def test_id_l093_id_l093_i(save_xml):
         instance="msData/identityConstraint/idL093.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l092_id_l092_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2095,11 +2223,12 @@ def test_id_l092_id_l092_v(save_xml):
         instance="msData/identityConstraint/idL092.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l091_id_l091_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2111,11 +2240,12 @@ def test_id_l091_id_l091_i(save_xml):
         instance="msData/identityConstraint/idL091.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l090_id_l090_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test for path
@@ -2127,11 +2257,12 @@ def test_id_l090_id_l090_v(save_xml):
         instance="msData/identityConstraint/idL090.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l089_id_l089_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2143,11 +2274,12 @@ def test_id_l089_id_l089_i(save_xml):
         instance="msData/identityConstraint/idL089.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l088_id_l088_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2159,11 +2291,12 @@ def test_id_l088_id_l088_v(save_xml):
         instance="msData/identityConstraint/idL088.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l087_id_l087_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2175,11 +2308,12 @@ def test_id_l087_id_l087_i(save_xml):
         instance="msData/identityConstraint/idL087.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l086_id_l086_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2191,11 +2325,12 @@ def test_id_l086_id_l086_v(save_xml):
         instance="msData/identityConstraint/idL086.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l085_id_l085_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2207,11 +2342,12 @@ def test_id_l085_id_l085_i(save_xml):
         instance="msData/identityConstraint/idL085.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l084_id_l084_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2223,11 +2359,12 @@ def test_id_l084_id_l084_v(save_xml):
         instance="msData/identityConstraint/idL084.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l083_id_l083_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2239,11 +2376,12 @@ def test_id_l083_id_l083_i(save_xml):
         instance="msData/identityConstraint/idL083.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l082_id_l082_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2255,11 +2393,12 @@ def test_id_l082_id_l082_v(save_xml):
         instance="msData/identityConstraint/idL082.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l081_id_l081_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2271,11 +2410,12 @@ def test_id_l081_id_l081_i(save_xml):
         instance="msData/identityConstraint/idL081.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l080_id_l080_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2288,11 +2428,12 @@ def test_id_l080_id_l080_i(save_xml):
         instance="msData/identityConstraint/idL080.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l079_id_l079_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2304,11 +2445,12 @@ def test_id_l079_id_l079_i(save_xml):
         instance="msData/identityConstraint/idL079.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l078_id_l078_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2320,11 +2462,12 @@ def test_id_l078_id_l078_v(save_xml):
         instance="msData/identityConstraint/idL078.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l077a_id_l077_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2337,11 +2480,12 @@ def test_id_l077a_id_l077_v(save_xml):
         instance="msData/identityConstraint/idL077.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l077_id_l077_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2354,11 +2498,12 @@ def test_id_l077_id_l077_v(save_xml):
         instance="msData/identityConstraint/idL077.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l076a_id_l076_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2371,11 +2516,12 @@ def test_id_l076a_id_l076_v(save_xml):
         instance="msData/identityConstraint/idL076.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l076_id_l076_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test multiple
@@ -2388,11 +2534,12 @@ def test_id_l076_id_l076_v(save_xml):
         instance="msData/identityConstraint/idL076.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l075_id_l075_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2405,11 +2552,12 @@ def test_id_l075_id_l075_i(save_xml):
         instance="msData/identityConstraint/idL075.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l074_id_l074_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2422,11 +2570,12 @@ def test_id_l074_id_l074_v(save_xml):
         instance="msData/identityConstraint/idL074.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l073_id_l073_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2438,11 +2587,12 @@ def test_id_l073_id_l073_v(save_xml):
         instance="msData/identityConstraint/idL073.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l072_id_l072_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2454,11 +2604,12 @@ def test_id_l072_id_l072_i(save_xml):
         instance="msData/identityConstraint/idL072.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l071_id_l071_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2471,11 +2622,12 @@ def test_id_l071_id_l071_v(save_xml):
         instance="msData/identityConstraint/idL071.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l070_id_l070_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2487,11 +2639,12 @@ def test_id_l070_id_l070_v(save_xml):
         instance="msData/identityConstraint/idL070.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l069_id_l069_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2503,11 +2656,12 @@ def test_id_l069_id_l069_i(save_xml):
         instance="msData/identityConstraint/idL069.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l068_id_l068_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2520,11 +2674,12 @@ def test_id_l068_id_l068_v(save_xml):
         instance="msData/identityConstraint/idL068.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l067_id_l067_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2537,11 +2692,12 @@ def test_id_l067_id_l067_v(save_xml):
         instance="msData/identityConstraint/idL067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l066_id_l066_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2553,11 +2709,12 @@ def test_id_l066_id_l066_v(save_xml):
         instance="msData/identityConstraint/idL066.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l065_id_l065_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2570,11 +2727,12 @@ def test_id_l065_id_l065_i(save_xml):
         instance="msData/identityConstraint/idL065.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l064_id_l064_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2587,11 +2745,12 @@ def test_id_l064_id_l064_v(save_xml):
         instance="msData/identityConstraint/idL064.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l063_id_l063_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2603,11 +2762,12 @@ def test_id_l063_id_l063_v(save_xml):
         instance="msData/identityConstraint/idL063.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l062_id_l062_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2620,11 +2780,12 @@ def test_id_l062_id_l062_i(save_xml):
         instance="msData/identityConstraint/idL062.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l061_id_l061_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2636,11 +2797,12 @@ def test_id_l061_id_l061_i(save_xml):
         instance="msData/identityConstraint/idL061.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l060_id_l060_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2652,11 +2814,12 @@ def test_id_l060_id_l060_v(save_xml):
         instance="msData/identityConstraint/idL060.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l059_id_l059_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2668,11 +2831,12 @@ def test_id_l059_id_l059_v(save_xml):
         instance="msData/identityConstraint/idL059.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l058_id_l058_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2684,11 +2848,12 @@ def test_id_l058_id_l058_v(save_xml):
         instance="msData/identityConstraint/idL058.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l057_id_l057_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2701,11 +2866,12 @@ def test_id_l057_id_l057_i(save_xml):
         instance="msData/identityConstraint/idL057.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l056_id_l056_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2717,11 +2883,12 @@ def test_id_l056_id_l056_i(save_xml):
         instance="msData/identityConstraint/idL056.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l055_id_l055_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2734,11 +2901,12 @@ def test_id_l055_id_l055_v(save_xml):
         instance="msData/identityConstraint/idL055.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l054_id_l054_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2751,11 +2919,12 @@ def test_id_l054_id_l054_v(save_xml):
         instance="msData/identityConstraint/idL054.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l053_id_l053_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2767,11 +2936,12 @@ def test_id_l053_id_l053_v(save_xml):
         instance="msData/identityConstraint/idL053.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l052_id_l052_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2783,11 +2953,12 @@ def test_id_l052_id_l052_i(save_xml):
         instance="msData/identityConstraint/idL052.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l051_id_l051_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2799,11 +2970,12 @@ def test_id_l051_id_l051_v(save_xml):
         instance="msData/identityConstraint/idL051.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l050_id_l050_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2815,11 +2987,12 @@ def test_id_l050_id_l050_i(save_xml):
         instance="msData/identityConstraint/idL050.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l049_id_l049_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2832,11 +3005,12 @@ def test_id_l049_id_l049_v(save_xml):
         instance="msData/identityConstraint/idL049.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l048_id_l048_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2848,11 +3022,12 @@ def test_id_l048_id_l048_v(save_xml):
         instance="msData/identityConstraint/idL048.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l047_id_l047_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2864,11 +3039,12 @@ def test_id_l047_id_l047_i(save_xml):
         instance="msData/identityConstraint/idL047.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l046_id_l046_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2880,11 +3056,12 @@ def test_id_l046_id_l046_v(save_xml):
         instance="msData/identityConstraint/idL046.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l045_id_l045_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2896,11 +3073,12 @@ def test_id_l045_id_l045_v(save_xml):
         instance="msData/identityConstraint/idL045.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l044_id_l044_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2912,11 +3090,12 @@ def test_id_l044_id_l044_i(save_xml):
         instance="msData/identityConstraint/idL044.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l043_id_l043_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2929,11 +3108,12 @@ def test_id_l043_id_l043_v(save_xml):
         instance="msData/identityConstraint/idL043.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l042_id_l042_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2946,11 +3126,12 @@ def test_id_l042_id_l042_v(save_xml):
         instance="msData/identityConstraint/idL042.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l041_id_l041_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2962,11 +3143,12 @@ def test_id_l041_id_l041_v(save_xml):
         instance="msData/identityConstraint/idL041.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l040_id_l040_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -2978,11 +3160,12 @@ def test_id_l040_id_l040_i(save_xml):
         instance="msData/identityConstraint/idL040.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l039_id_l039_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -2995,11 +3178,12 @@ def test_id_l039_id_l039_v(save_xml):
         instance="msData/identityConstraint/idL039.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l038_id_l038_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3011,11 +3195,12 @@ def test_id_l038_id_l038_v(save_xml):
         instance="msData/identityConstraint/idL038.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l037_id_l037_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3027,11 +3212,12 @@ def test_id_l037_id_l037_i(save_xml):
         instance="msData/identityConstraint/idL037.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l036_id_l036_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3043,11 +3229,12 @@ def test_id_l036_id_l036_i(save_xml):
         instance="msData/identityConstraint/idL036.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l035_id_l035_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3059,11 +3246,12 @@ def test_id_l035_id_l035_v(save_xml):
         instance="msData/identityConstraint/idL035.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l034_id_l034_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3075,11 +3263,12 @@ def test_id_l034_id_l034_v(save_xml):
         instance="msData/identityConstraint/idL034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l033_id_l033_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3091,11 +3280,12 @@ def test_id_l033_id_l033_v(save_xml):
         instance="msData/identityConstraint/idL033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l032_id_l032_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3108,11 +3298,12 @@ def test_id_l032_id_l032_i(save_xml):
         instance="msData/identityConstraint/idL032.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l031_id_l031_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3124,11 +3315,12 @@ def test_id_l031_id_l031_i(save_xml):
         instance="msData/identityConstraint/idL031.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l030_id_l030_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3140,11 +3332,12 @@ def test_id_l030_id_l030_v(save_xml):
         instance="msData/identityConstraint/idL030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l029_id_l029_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3156,11 +3349,12 @@ def test_id_l029_id_l029_v(save_xml):
         instance="msData/identityConstraint/idL029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l028_id_l028_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3172,11 +3366,12 @@ def test_id_l028_id_l028_v(save_xml):
         instance="msData/identityConstraint/idL028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l027_id_l027_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3188,11 +3383,12 @@ def test_id_l027_id_l027_i(save_xml):
         instance="msData/identityConstraint/idL027.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l026_id_l026_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3204,11 +3400,12 @@ def test_id_l026_id_l026_v(save_xml):
         instance="msData/identityConstraint/idL026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l025_id_l025_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3221,11 +3418,12 @@ def test_id_l025_id_l025_i(save_xml):
         instance="msData/identityConstraint/idL025.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l024_id_l024_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3238,11 +3436,12 @@ def test_id_l024_id_l024_v(save_xml):
         instance="msData/identityConstraint/idL024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l023_id_l023_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3254,11 +3453,12 @@ def test_id_l023_id_l023_v(save_xml):
         instance="msData/identityConstraint/idL023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l022_id_l022_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3270,11 +3470,12 @@ def test_id_l022_id_l022_i(save_xml):
         instance="msData/identityConstraint/idL022.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l021_id_l021_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3287,11 +3488,12 @@ def test_id_l021_id_l021_v(save_xml):
         instance="msData/identityConstraint/idL021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l020_id_l020_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3303,11 +3505,12 @@ def test_id_l020_id_l020_v(save_xml):
         instance="msData/identityConstraint/idL020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l019_id_l019_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3319,11 +3522,12 @@ def test_id_l019_id_l019_i(save_xml):
         instance="msData/identityConstraint/idL019.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l018_id_l018_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3336,11 +3540,12 @@ def test_id_l018_id_l018_v(save_xml):
         instance="msData/identityConstraint/idL018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l017_id_l017_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3353,11 +3558,12 @@ def test_id_l017_id_l017_v(save_xml):
         instance="msData/identityConstraint/idL017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l016_id_l016_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3369,11 +3575,12 @@ def test_id_l016_id_l016_v(save_xml):
         instance="msData/identityConstraint/idL016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l015_id_l015_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3386,11 +3593,12 @@ def test_id_l015_id_l015_i(save_xml):
         instance="msData/identityConstraint/idL015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l014_id_l014_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3403,11 +3611,12 @@ def test_id_l014_id_l014_v(save_xml):
         instance="msData/identityConstraint/idL014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l013_id_l013_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3419,11 +3628,12 @@ def test_id_l013_id_l013_v(save_xml):
         instance="msData/identityConstraint/idL013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l012_id_l012_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3436,11 +3646,12 @@ def test_id_l012_id_l012_i(save_xml):
         instance="msData/identityConstraint/idL012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l011_id_l011_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3452,11 +3663,12 @@ def test_id_l011_id_l011_i(save_xml):
         instance="msData/identityConstraint/idL011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l010_id_l010_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3468,11 +3680,12 @@ def test_id_l010_id_l010_v(save_xml):
         instance="msData/identityConstraint/idL010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l009_id_l009_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3484,11 +3697,12 @@ def test_id_l009_id_l009_v(save_xml):
         instance="msData/identityConstraint/idL009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l008_id_l008_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3500,11 +3714,12 @@ def test_id_l008_id_l008_v(save_xml):
         instance="msData/identityConstraint/idL008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l007_id_l007_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3517,11 +3732,12 @@ def test_id_l007_id_l007_i(save_xml):
         instance="msData/identityConstraint/idL007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l006_id_l006_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3533,11 +3749,12 @@ def test_id_l006_id_l006_i(save_xml):
         instance="msData/identityConstraint/idL006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l005_id_l005_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3550,11 +3767,12 @@ def test_id_l005_id_l005_v(save_xml):
         instance="msData/identityConstraint/idL005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l004_id_l004_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3567,11 +3785,12 @@ def test_id_l004_id_l004_v(save_xml):
         instance="msData/identityConstraint/idL004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l003_id_l003_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3583,11 +3802,12 @@ def test_id_l003_id_l003_v(save_xml):
         instance="msData/identityConstraint/idL003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l002_id_l002_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test invalid
@@ -3599,11 +3819,12 @@ def test_id_l002_id_l002_i(save_xml):
         instance="msData/identityConstraint/idL002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_l001_id_l001_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : Test valid XML
@@ -3615,11 +3836,12 @@ def test_id_l001_id_l001_v(save_xml):
         instance="msData/identityConstraint/idL001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k017_id_k017_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref defined
@@ -3631,11 +3853,12 @@ def test_id_k017_id_k017_v(save_xml):
         instance="msData/identityConstraint/idK017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k015_id_k015_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : constraint
@@ -3647,11 +3870,12 @@ def test_id_k015_id_k015_v(save_xml):
         instance="msData/identityConstraint/idK015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k014_id_k014_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : constraint
@@ -3663,11 +3887,12 @@ def test_id_k014_id_k014_v(save_xml):
         instance="msData/identityConstraint/idK014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k013_id_k013_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : constraint
@@ -3679,11 +3904,12 @@ def test_id_k013_id_k013_v(save_xml):
         instance="msData/identityConstraint/idK013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k012_id_k012_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : constraint
@@ -3695,11 +3921,12 @@ def test_id_k012_id_k012_i(save_xml):
         instance="msData/identityConstraint/idK012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k011a_id_k011_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : constraint
@@ -3712,11 +3939,12 @@ def test_id_k011a_id_k011_v(save_xml):
         instance="msData/identityConstraint/idK011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k011_id_k011_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : constraint
@@ -3729,11 +3957,12 @@ def test_id_k011_id_k011_v(save_xml):
         instance="msData/identityConstraint/idK011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k010_id_k010_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3745,11 +3974,12 @@ def test_id_k010_id_k010_v(save_xml):
         instance="msData/identityConstraint/idK010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k009_id_k009_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3761,11 +3991,12 @@ def test_id_k009_id_k009_v(save_xml):
         instance="msData/identityConstraint/idK009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k008_id_k008_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3777,11 +4008,12 @@ def test_id_k008_id_k008_v(save_xml):
         instance="msData/identityConstraint/idK008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k007_id_k007_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3793,11 +4025,12 @@ def test_id_k007_id_k007_v(save_xml):
         instance="msData/identityConstraint/idK007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k006_id_k006_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3809,11 +4042,12 @@ def test_id_k006_id_k006_v(save_xml):
         instance="msData/identityConstraint/idK006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k005_id_k005_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3825,11 +4059,12 @@ def test_id_k005_id_k005_v(save_xml):
         instance="msData/identityConstraint/idK005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k004_id_k004_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3843,11 +4078,12 @@ def test_id_k004_id_k004_v(save_xml):
         instance="msData/identityConstraint/idK004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k003_id_k003_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3861,11 +4097,12 @@ def test_id_k003_id_k003_i(save_xml):
         instance="msData/identityConstraint/idK003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k002_id_k002_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3877,11 +4114,12 @@ def test_id_k002_id_k002_v(save_xml):
         instance="msData/identityConstraint/idK002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_k001_id_k001_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref fields
@@ -3893,11 +4131,12 @@ def test_id_k001_id_k001_v(save_xml):
         instance="msData/identityConstraint/idK001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h034_id_h034_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -3910,11 +4149,12 @@ def test_id_h034_id_h034_v(save_xml):
         instance="msData/identityConstraint/idH034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h032_id_h032_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -3926,11 +4166,12 @@ def test_id_h032_id_h032_v(save_xml):
         instance="msData/identityConstraint/idH032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h031a_id_h031_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -3943,11 +4184,12 @@ def test_id_h031a_id_h031_v(save_xml):
         instance="msData/identityConstraint/idH031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h031_id_h031_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -3960,11 +4202,12 @@ def test_id_h031_id_h031_v(save_xml):
         instance="msData/identityConstraint/idH031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h030_id_h030_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -3976,11 +4219,12 @@ def test_id_h030_id_h030_v(save_xml):
         instance="msData/identityConstraint/idH030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h029_id_h029_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -3993,11 +4237,12 @@ def test_id_h029_id_h029_v(save_xml):
         instance="msData/identityConstraint/idH029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h028_id_h028_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4009,11 +4254,12 @@ def test_id_h028_id_h028_v(save_xml):
         instance="msData/identityConstraint/idH028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h027_id_h027_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4025,11 +4271,12 @@ def test_id_h027_id_h027_v(save_xml):
         instance="msData/identityConstraint/idH027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h026_id_h026_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4042,11 +4289,12 @@ def test_id_h026_id_h026_v(save_xml):
         instance="msData/identityConstraint/idH026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h025_id_h025_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4058,11 +4306,12 @@ def test_id_h025_id_h025_v(save_xml):
         instance="msData/identityConstraint/idH025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h024_id_h024_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4075,11 +4324,12 @@ def test_id_h024_id_h024_v(save_xml):
         instance="msData/identityConstraint/idH024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h023_id_h023_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4091,11 +4341,12 @@ def test_id_h023_id_h023_v(save_xml):
         instance="msData/identityConstraint/idH023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h022_id_h022_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4107,11 +4358,12 @@ def test_id_h022_id_h022_v(save_xml):
         instance="msData/identityConstraint/idH022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h021_id_h021_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4124,11 +4376,12 @@ def test_id_h021_id_h021_v(save_xml):
         instance="msData/identityConstraint/idH021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h020_id_h020_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4140,11 +4393,12 @@ def test_id_h020_id_h020_v(save_xml):
         instance="msData/identityConstraint/idH020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h019_id_h019_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4157,11 +4411,12 @@ def test_id_h019_id_h019_v(save_xml):
         instance="msData/identityConstraint/idH019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h018_id_h018_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4174,11 +4429,12 @@ def test_id_h018_id_h018_v(save_xml):
         instance="msData/identityConstraint/idH018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h017_id_h017_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4191,11 +4447,12 @@ def test_id_h017_id_h017_v(save_xml):
         instance="msData/identityConstraint/idH017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h016_id_h016_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4208,11 +4465,12 @@ def test_id_h016_id_h016_v(save_xml):
         instance="msData/identityConstraint/idH016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h015_id_h015_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4225,11 +4483,12 @@ def test_id_h015_id_h015_v(save_xml):
         instance="msData/identityConstraint/idH015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h012_id_h012_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4242,11 +4501,12 @@ def test_id_h012_id_h012_i(save_xml):
         instance="msData/identityConstraint/idH012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h010_id_h010_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4258,11 +4518,12 @@ def test_id_h010_id_h010_i(save_xml):
         instance="msData/identityConstraint/idH010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h009_id_h009_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4274,11 +4535,12 @@ def test_id_h009_id_h009_v(save_xml):
         instance="msData/identityConstraint/idH009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h008_id_h008_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4290,11 +4552,12 @@ def test_id_h008_id_h008_v(save_xml):
         instance="msData/identityConstraint/idH008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h007_id_h007_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4307,11 +4570,12 @@ def test_id_h007_id_h007_v(save_xml):
         instance="msData/identityConstraint/idH007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h006_id_h006_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4324,11 +4588,12 @@ def test_id_h006_id_h006_i(save_xml):
         instance="msData/identityConstraint/idH006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h005_id_h005_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4341,11 +4606,12 @@ def test_id_h005_id_h005_i(save_xml):
         instance="msData/identityConstraint/idH005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h004_id_h004_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4357,11 +4623,12 @@ def test_id_h004_id_h004_v(save_xml):
         instance="msData/identityConstraint/idH004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h003_id_h003_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4373,11 +4640,12 @@ def test_id_h003_id_h003_v(save_xml):
         instance="msData/identityConstraint/idH003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_h001_id_h001_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : keyref
@@ -4389,11 +4657,12 @@ def test_id_h001_id_h001_v(save_xml):
         instance="msData/identityConstraint/idH001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g030_id_g030_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4405,11 +4674,12 @@ def test_id_g030_id_g030_v(save_xml):
         instance="msData/identityConstraint/idG030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g029_id_g029_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4422,11 +4692,12 @@ def test_id_g029_id_g029_v(save_xml):
         instance="msData/identityConstraint/idG029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g028_id_g028_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4438,11 +4709,12 @@ def test_id_g028_id_g028_v(save_xml):
         instance="msData/identityConstraint/idG028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g027_id_g027_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4454,11 +4726,12 @@ def test_id_g027_id_g027_v(save_xml):
         instance="msData/identityConstraint/idG027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g026_id_g026_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4470,11 +4743,12 @@ def test_id_g026_id_g026_v(save_xml):
         instance="msData/identityConstraint/idG026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g025_id_g025_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4486,11 +4760,12 @@ def test_id_g025_id_g025_i(save_xml):
         instance="msData/identityConstraint/idG025.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g024_id_g024_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4502,11 +4777,12 @@ def test_id_g024_id_g024_v(save_xml):
         instance="msData/identityConstraint/idG024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g023_id_g023_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4518,11 +4794,12 @@ def test_id_g023_id_g023_v(save_xml):
         instance="msData/identityConstraint/idG023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g022_id_g022_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4534,11 +4811,12 @@ def test_id_g022_id_g022_v(save_xml):
         instance="msData/identityConstraint/idG022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g021_id_g021_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4550,11 +4828,12 @@ def test_id_g021_id_g021_v(save_xml):
         instance="msData/identityConstraint/idG021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g020_id_g020_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4566,11 +4845,12 @@ def test_id_g020_id_g020_i(save_xml):
         instance="msData/identityConstraint/idG020.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g019_id_g019_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4582,11 +4862,12 @@ def test_id_g019_id_g019_v(save_xml):
         instance="msData/identityConstraint/idG019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g018_id_g018_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4598,11 +4879,12 @@ def test_id_g018_id_g018_v(save_xml):
         instance="msData/identityConstraint/idG018.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g017_id_g017_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4615,11 +4897,12 @@ def test_id_g017_id_g017_v(save_xml):
         instance="msData/identityConstraint/idG017.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g016_id_g016_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4631,11 +4914,12 @@ def test_id_g016_id_g016_v(save_xml):
         instance="msData/identityConstraint/idG016.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g015_id_g015_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4648,11 +4932,12 @@ def test_id_g015_id_g015_v(save_xml):
         instance="msData/identityConstraint/idG015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g014_id_g014_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4665,11 +4950,12 @@ def test_id_g014_id_g014_v(save_xml):
         instance="msData/identityConstraint/idG014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g013_id_g013_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4682,11 +4968,12 @@ def test_id_g013_id_g013_v(save_xml):
         instance="msData/identityConstraint/idG013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g012_id_g012_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4699,11 +4986,12 @@ def test_id_g012_id_g012_i(save_xml):
         instance="msData/identityConstraint/idG012.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g011_id_g011_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4716,11 +5004,12 @@ def test_id_g011_id_g011_i(save_xml):
         instance="msData/identityConstraint/idG011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g010_id_g010_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4732,11 +5021,12 @@ def test_id_g010_id_g010_i(save_xml):
         instance="msData/identityConstraint/idG010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g009_id_g009_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4749,11 +5039,12 @@ def test_id_g009_id_g009_i(save_xml):
         instance="msData/identityConstraint/idG009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g008_id_g008_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4765,11 +5056,12 @@ def test_id_g008_id_g008_i(save_xml):
         instance="msData/identityConstraint/idG008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g007_id_g007_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4781,11 +5073,12 @@ def test_id_g007_id_g007_v(save_xml):
         instance="msData/identityConstraint/idG007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g006_id_g006_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4798,11 +5091,12 @@ def test_id_g006_id_g006_i(save_xml):
         instance="msData/identityConstraint/idG006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g005_id_g005_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4814,11 +5108,12 @@ def test_id_g005_id_g005_i(save_xml):
         instance="msData/identityConstraint/idG005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g004_id_g004_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4830,11 +5125,12 @@ def test_id_g004_id_g004_v(save_xml):
         instance="msData/identityConstraint/idG004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g003_id_g003_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4846,11 +5142,12 @@ def test_id_g003_id_g003_i(save_xml):
         instance="msData/identityConstraint/idG003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_g001_id_g001_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : key category,
@@ -4862,11 +5159,12 @@ def test_id_g001_id_g001_v(save_xml):
         instance="msData/identityConstraint/idG001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f036_id_f036_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4879,11 +5177,12 @@ def test_id_f036_id_f036_v(save_xml):
         instance="msData/identityConstraint/idF036.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f035_id_f035_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4896,11 +5195,12 @@ def test_id_f035_id_f035_v(save_xml):
         instance="msData/identityConstraint/idF035.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f034_id_f034_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4912,11 +5212,12 @@ def test_id_f034_id_f034_v(save_xml):
         instance="msData/identityConstraint/idF034.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f033_id_f033_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4928,11 +5229,12 @@ def test_id_f033_id_f033_v(save_xml):
         instance="msData/identityConstraint/idF033.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f032_id_f032_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4944,11 +5246,12 @@ def test_id_f032_id_f032_v(save_xml):
         instance="msData/identityConstraint/idF032.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f031_id_f031_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4961,11 +5264,12 @@ def test_id_f031_id_f031_v(save_xml):
         instance="msData/identityConstraint/idF031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f030_id_f030_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4977,11 +5281,12 @@ def test_id_f030_id_f030_v(save_xml):
         instance="msData/identityConstraint/idF030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f029_id_f029_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -4993,11 +5298,12 @@ def test_id_f029_id_f029_v(save_xml):
         instance="msData/identityConstraint/idF029.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f028_id_f028_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5010,11 +5316,12 @@ def test_id_f028_id_f028_v(save_xml):
         instance="msData/identityConstraint/idF028.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f027_id_f027_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5026,11 +5333,12 @@ def test_id_f027_id_f027_v(save_xml):
         instance="msData/identityConstraint/idF027.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f026_id_f026_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5043,11 +5351,12 @@ def test_id_f026_id_f026_v(save_xml):
         instance="msData/identityConstraint/idF026.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f025_id_f025_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5059,11 +5368,12 @@ def test_id_f025_id_f025_v(save_xml):
         instance="msData/identityConstraint/idF025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f024_id_f024_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5075,11 +5385,12 @@ def test_id_f024_id_f024_v(save_xml):
         instance="msData/identityConstraint/idF024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f023_id_f023_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5092,11 +5403,12 @@ def test_id_f023_id_f023_v(save_xml):
         instance="msData/identityConstraint/idF023.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f022_id_f022_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5108,11 +5420,12 @@ def test_id_f022_id_f022_v(save_xml):
         instance="msData/identityConstraint/idF022.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f021_id_f021_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5125,11 +5438,12 @@ def test_id_f021_id_f021_v(save_xml):
         instance="msData/identityConstraint/idF021.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f020_id_f020_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5142,11 +5456,12 @@ def test_id_f020_id_f020_v(save_xml):
         instance="msData/identityConstraint/idF020.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f019_id_f019_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5159,11 +5474,12 @@ def test_id_f019_id_f019_v(save_xml):
         instance="msData/identityConstraint/idF019.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f018_id_f018_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5175,11 +5491,12 @@ def test_id_f018_id_f018_i(save_xml):
         instance="msData/identityConstraint/idF018.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f017_id_f017_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5192,11 +5509,12 @@ def test_id_f017_id_f017_i(save_xml):
         instance="msData/identityConstraint/idF017.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f016_id_f016_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5209,11 +5527,12 @@ def test_id_f016_id_f016_i(save_xml):
         instance="msData/identityConstraint/idF016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f015_id_f015_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5226,11 +5545,12 @@ def test_id_f015_id_f015_i(save_xml):
         instance="msData/identityConstraint/idF015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f014_id_f014_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5243,11 +5563,12 @@ def test_id_f014_id_f014_v(save_xml):
         instance="msData/identityConstraint/idF014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f013_id_f013_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5259,11 +5580,12 @@ def test_id_f013_id_f013_v(save_xml):
         instance="msData/identityConstraint/idF013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f012_id_f012_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5276,11 +5598,12 @@ def test_id_f012_id_f012_v(save_xml):
         instance="msData/identityConstraint/idF012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f011_id_f011_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5293,11 +5616,12 @@ def test_id_f011_id_f011_v(save_xml):
         instance="msData/identityConstraint/idF011.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f010_id_f010_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5310,11 +5634,12 @@ def test_id_f010_id_f010_i(save_xml):
         instance="msData/identityConstraint/idF010.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f009_id_f009_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5327,11 +5652,12 @@ def test_id_f009_id_f009_v(save_xml):
         instance="msData/identityConstraint/idF009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f008_id_f008_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5343,11 +5669,12 @@ def test_id_f008_id_f008_i(save_xml):
         instance="msData/identityConstraint/idF008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f007_id_f007_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5359,11 +5686,12 @@ def test_id_f007_id_f007_v(save_xml):
         instance="msData/identityConstraint/idF007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f006_id_f006_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5376,11 +5704,12 @@ def test_id_f006_id_f006_i(save_xml):
         instance="msData/identityConstraint/idF006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f005_id_f005_i(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5393,11 +5722,12 @@ def test_id_f005_id_f005_i(save_xml):
         instance="msData/identityConstraint/idF005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f004_id_f004_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5409,11 +5739,12 @@ def test_id_f004_id_f004_v(save_xml):
         instance="msData/identityConstraint/idF004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f003_id_f003_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5425,11 +5756,12 @@ def test_id_f003_id_f003_v(save_xml):
         instance="msData/identityConstraint/idF003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_id_f001_id_f001_v(save_xml):
     """
     TEST :Identity-constraint Definition Schema Component : unique
@@ -5441,11 +5773,12 @@ def test_id_f001_id_f001_v(save_xml):
         instance="msData/identityConstraint/idF001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_z004_mg_z004_v(save_xml):
     """
     TEST :model groups (ALL) : test occurence range of xs:choice
@@ -5456,11 +5789,12 @@ def test_mg_z004_mg_z004_v(save_xml):
         instance="msData/modelGroups/mgZ004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_z003_mg_z003_v(save_xml):
     """
     TEST :model groups (ALL) : test derivation by ext. with all with
@@ -5472,11 +5806,12 @@ def test_mg_z003_mg_z003_v(save_xml):
         instance="msData/modelGroups/mgZ003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_z001_mg_z001_i(save_xml):
     """
     TEST :model groups (ALL) : XSD: handling of ALL schema element when
@@ -5488,11 +5823,12 @@ def test_mg_z001_mg_z001_i(save_xml):
         instance="msData/modelGroups/mgZ001.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q020_mg_q020_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5505,11 +5841,12 @@ def test_mg_q020_mg_q020_v(save_xml):
         instance="msData/modelGroups/mgQ020.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q019_mg_q019_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5522,11 +5859,12 @@ def test_mg_q019_mg_q019_v(save_xml):
         instance="msData/modelGroups/mgQ019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q018_mg_q018_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5539,11 +5877,12 @@ def test_mg_q018_mg_q018_v(save_xml):
         instance="msData/modelGroups/mgQ018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q017_mg_q017_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5556,11 +5895,12 @@ def test_mg_q017_mg_q017_v(save_xml):
         instance="msData/modelGroups/mgQ017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q016_mg_q016_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5573,11 +5913,12 @@ def test_mg_q016_mg_q016_v(save_xml):
         instance="msData/modelGroups/mgQ016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q015_mg_q015_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5590,11 +5931,12 @@ def test_mg_q015_mg_q015_v(save_xml):
         instance="msData/modelGroups/mgQ015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q014_mg_q014_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5607,11 +5949,12 @@ def test_mg_q014_mg_q014_v(save_xml):
         instance="msData/modelGroups/mgQ014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q009_mg_q009_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5624,11 +5967,12 @@ def test_mg_q009_mg_q009_v(save_xml):
         instance="msData/modelGroups/mgQ009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q008_mg_q008_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5641,11 +5985,12 @@ def test_mg_q008_mg_q008_v(save_xml):
         instance="msData/modelGroups/mgQ008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q007_mg_q007_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5658,11 +6003,12 @@ def test_mg_q007_mg_q007_v(save_xml):
         instance="msData/modelGroups/mgQ007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q006_mg_q006_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5675,11 +6021,12 @@ def test_mg_q006_mg_q006_v(save_xml):
         instance="msData/modelGroups/mgQ006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q003_mg_q003_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5691,11 +6038,12 @@ def test_mg_q003_mg_q003_v(save_xml):
         instance="msData/modelGroups/mgQ003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_q002_mg_q002_v(save_xml):
     """
     TEST :model groups (ALL) : 2 particles with idendical element
@@ -5707,11 +6055,12 @@ def test_mg_q002_mg_q002_v(save_xml):
         instance="msData/modelGroups/mgQ002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o038_mg_o038_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'choice'
@@ -5723,11 +6072,12 @@ def test_mg_o038_mg_o038_v(save_xml):
         instance="msData/modelGroups/mgO038.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o037_mg_o037_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'sequence'
@@ -5739,11 +6089,12 @@ def test_mg_o037_mg_o037_v(save_xml):
         instance="msData/modelGroups/mgO037.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o036_mg_o036_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under
@@ -5755,11 +6106,12 @@ def test_mg_o036_mg_o036_v(save_xml):
         instance="msData/modelGroups/mgO036.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o034_mg_o034_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'redefine',
@@ -5771,11 +6123,12 @@ def test_mg_o034_mg_o034_v(save_xml):
         instance="msData/modelGroups/mgO034.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o031_mg_o031_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'choice'
@@ -5788,11 +6141,12 @@ def test_mg_o031_mg_o031_v(save_xml):
         instance="msData/modelGroups/mgO031.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o030_mg_o030_v(save_xml):
     """
     TEST :model groups (ALL) : 'all', and has minOccurs=0, maxOccurs=1
@@ -5803,11 +6157,12 @@ def test_mg_o030_mg_o030_v(save_xml):
         instance="msData/modelGroups/mgO030.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o029_mg_o029_v(save_xml):
     """
     TEST :model groups (ALL) : 'all', appear under 'restriction', which is
@@ -5819,11 +6174,12 @@ def test_mg_o029_mg_o029_v(save_xml):
         instance="msData/modelGroups/mgO029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o017_mg_o017_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'choice'
@@ -5836,11 +6192,12 @@ def test_mg_o017_mg_o017_v(save_xml):
         instance="msData/modelGroups/mgO017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o016_mg_o016_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'sequence'
@@ -5853,11 +6210,12 @@ def test_mg_o016_mg_o016_v(save_xml):
         instance="msData/modelGroups/mgO016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o015_mg_o015_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under
@@ -5870,11 +6228,12 @@ def test_mg_o015_mg_o015_v(save_xml):
         instance="msData/modelGroups/mgO015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o011_mg_o011_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under
@@ -5887,11 +6246,12 @@ def test_mg_o011_mg_o011_v(save_xml):
         instance="msData/modelGroups/mgO011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o010_mg_o010_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'choice'
@@ -5903,11 +6263,12 @@ def test_mg_o010_mg_o010_v(save_xml):
         instance="msData/modelGroups/mgO010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o009_mg_o009_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'sequence'
@@ -5919,11 +6280,12 @@ def test_mg_o009_mg_o009_v(save_xml):
         instance="msData/modelGroups/mgO009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o008_mg_o008_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under
@@ -5935,11 +6297,12 @@ def test_mg_o008_mg_o008_v(save_xml):
         instance="msData/modelGroups/mgO008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o006_mg_o006_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'redefine',
@@ -5951,11 +6314,12 @@ def test_mg_o006_mg_o006_v(save_xml):
         instance="msData/modelGroups/mgO006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o005_mg_o005_v(save_xml):
     """
     TEST :model groups (ALL) : group' with 'all', appear under 'schema',
@@ -5967,11 +6331,12 @@ def test_mg_o005_mg_o005_v(save_xml):
         instance="msData/modelGroups/mgO005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o004_mg_o004_v(save_xml):
     """
     TEST :model groups (ALL) : all appear under 'complexType', which is
@@ -5984,11 +6349,12 @@ def test_mg_o004_mg_o004_v(save_xml):
         instance="msData/modelGroups/mgO004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_o002_mg_o002_v(save_xml):
     """
     TEST :model groups (ALL) : all has particle with minOccurs=maxOccur =
@@ -6000,11 +6366,12 @@ def test_mg_o002_mg_o002_v(save_xml):
         instance="msData/modelGroups/mgO002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n016_mg_n016_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence (E1, E2)
@@ -6017,11 +6384,12 @@ def test_mg_n016_mg_n016_i(save_xml):
         instance="msData/modelGroups/mgN016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n015_mg_n015_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence (E1, E2)
@@ -6034,11 +6402,12 @@ def test_mg_n015_mg_n015_i(save_xml):
         instance="msData/modelGroups/mgN015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n014_mg_n014_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence (E1, E2)
@@ -6051,11 +6420,12 @@ def test_mg_n014_mg_n014_i(save_xml):
         instance="msData/modelGroups/mgN014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n013_mg_n013_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence (E1, E2)
@@ -6068,11 +6438,12 @@ def test_mg_n013_mg_n013_i(save_xml):
         instance="msData/modelGroups/mgN013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n012_mg_n012_v(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence (E1, E2)
@@ -6085,11 +6456,12 @@ def test_mg_n012_mg_n012_v(save_xml):
         instance="msData/modelGroups/mgN012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n011_mg_n011_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence (E1, E2)
@@ -6102,11 +6474,12 @@ def test_mg_n011_mg_n011_i(save_xml):
         instance="msData/modelGroups/mgN011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n010_mg_n010_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6119,11 +6492,12 @@ def test_mg_n010_mg_n010_i(save_xml):
         instance="msData/modelGroups/mgN010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n009_mg_n009_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6136,11 +6510,12 @@ def test_mg_n009_mg_n009_i(save_xml):
         instance="msData/modelGroups/mgN009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n008_mg_n008_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6153,11 +6528,12 @@ def test_mg_n008_mg_n008_i(save_xml):
         instance="msData/modelGroups/mgN008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n007_mg_n007_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6170,11 +6546,12 @@ def test_mg_n007_mg_n007_i(save_xml):
         instance="msData/modelGroups/mgN007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n006_mg_n006_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6187,11 +6564,12 @@ def test_mg_n006_mg_n006_i(save_xml):
         instance="msData/modelGroups/mgN006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n005_mg_n005_v(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6204,11 +6582,12 @@ def test_mg_n005_mg_n005_v(save_xml):
         instance="msData/modelGroups/mgN005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n004_mg_n004_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, has 2 sequence as child
@@ -6221,11 +6600,12 @@ def test_mg_n004_mg_n004_i(save_xml):
         instance="msData/modelGroups/mgN004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n003_mg_n003_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, the instant XML has
@@ -6238,11 +6618,12 @@ def test_mg_n003_mg_n003_i(save_xml):
         instance="msData/modelGroups/mgN003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n002_mg_n002_i(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, more than one child
@@ -6255,11 +6636,12 @@ def test_mg_n002_mg_n002_i(save_xml):
         instance="msData/modelGroups/mgN002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_n001_mg_n001_v(save_xml):
     """
     TEST :model groups (ALL) : parent is sequence, more than one child
@@ -6272,11 +6654,12 @@ def test_mg_n001_mg_n001_v(save_xml):
         instance="msData/modelGroups/mgN001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m014_mg_m014_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements instant doc has the
@@ -6288,11 +6671,12 @@ def test_mg_m014_mg_m014_i(save_xml):
         instance="msData/modelGroups/mgM014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m013_mg_m013_v(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements instant doc has a
@@ -6304,11 +6688,12 @@ def test_mg_m013_mg_m013_v(save_xml):
         instance="msData/modelGroups/mgM013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m012_mg_m012_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements instant doc has an
@@ -6320,11 +6705,12 @@ def test_mg_m012_mg_m012_i(save_xml):
         instance="msData/modelGroups/mgM012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m011_mg_m011_v(save_xml):
     """
     TEST :model groups (ALL) : all: with 5 elements instant doc has all
@@ -6336,11 +6722,12 @@ def test_mg_m011_mg_m011_v(save_xml):
         instance="msData/modelGroups/mgM011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m010_mg_m010_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements instant doc has all
@@ -6352,11 +6739,12 @@ def test_mg_m010_mg_m010_i(save_xml):
         instance="msData/modelGroups/mgM010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m009_mg_m009_v(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements 2 element in different
@@ -6368,11 +6756,12 @@ def test_mg_m009_mg_m009_v(save_xml):
         instance="msData/modelGroups/mgM009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m008_mg_m008_v(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements 2 element is in the
@@ -6384,11 +6773,12 @@ def test_mg_m008_mg_m008_v(save_xml):
         instance="msData/modelGroups/mgM008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m007_mg_m007_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements 1 element is in the
@@ -6400,11 +6790,12 @@ def test_mg_m007_mg_m007_i(save_xml):
         instance="msData/modelGroups/mgM007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m006_mg_m006_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 2 elements 0 element is in the
@@ -6416,11 +6807,12 @@ def test_mg_m006_mg_m006_i(save_xml):
         instance="msData/modelGroups/mgM006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m005_mg_m005_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 1 elements 2 element is in the
@@ -6432,11 +6824,12 @@ def test_mg_m005_mg_m005_i(save_xml):
         instance="msData/modelGroups/mgM005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m004_mg_m004_v(save_xml):
     """
     TEST :model groups (ALL) : all: with 1 elements 1 element is in the
@@ -6448,11 +6841,12 @@ def test_mg_m004_mg_m004_v(save_xml):
         instance="msData/modelGroups/mgM004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m003_mg_m003_i(save_xml):
     """
     TEST :model groups (ALL) : all: with 1 elements 0 element is in the
@@ -6464,11 +6858,12 @@ def test_mg_m003_mg_m003_i(save_xml):
         instance="msData/modelGroups/mgM003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_m002_mg_m002_i(save_xml):
     """
     TEST :model groups (ALL) : all: with no elements 1 element is in the
@@ -6480,11 +6875,12 @@ def test_mg_m002_mg_m002_i(save_xml):
         instance="msData/modelGroups/mgM002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l010_mg_l010_i(save_xml):
     """
     TEST :model groups (ALL) : choice: with 5 elements, an undefined
@@ -6496,11 +6892,12 @@ def test_mg_l010_mg_l010_i(save_xml):
         instance="msData/modelGroups/mgL010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l009_mg_l009_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with 5 elements, 1 element in the
@@ -6512,11 +6909,12 @@ def test_mg_l009_mg_l009_v(save_xml):
         instance="msData/modelGroups/mgL009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l008_mg_l008_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with 5 elements, 0 element in the
@@ -6528,11 +6926,12 @@ def test_mg_l008_mg_l008_v(save_xml):
         instance="msData/modelGroups/mgL008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l007_mg_l007_i(save_xml):
     """
     TEST :model groups (ALL) : choice: with 2 elements, 2 element in the
@@ -6544,11 +6943,12 @@ def test_mg_l007_mg_l007_i(save_xml):
         instance="msData/modelGroups/mgL007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l006_mg_l006_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with 2 elements, 1 element in the
@@ -6560,11 +6960,12 @@ def test_mg_l006_mg_l006_v(save_xml):
         instance="msData/modelGroups/mgL006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l005_mg_l005_i(save_xml):
     """
     TEST :model groups (ALL) : choice: with 1 elements, 2 element is in
@@ -6576,11 +6977,12 @@ def test_mg_l005_mg_l005_i(save_xml):
         instance="msData/modelGroups/mgL005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l004_mg_l004_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with 1 elements, 1 element is in
@@ -6592,11 +6994,12 @@ def test_mg_l004_mg_l004_v(save_xml):
         instance="msData/modelGroups/mgL004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l003_mg_l003_i(save_xml):
     """
     TEST :model groups (ALL) : choice: with 1 elements, 0 element is in
@@ -6608,11 +7011,12 @@ def test_mg_l003_mg_l003_i(save_xml):
         instance="msData/modelGroups/mgL003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l002_mg_l002_i(save_xml):
     """
     TEST :model groups (ALL) : choice: with NO elements, 1 element is in
@@ -6624,11 +7028,12 @@ def test_mg_l002_mg_l002_i(save_xml):
         instance="msData/modelGroups/mgL002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_l001_mg_l001_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with NO elements (max=min=absent),
@@ -6640,11 +7045,12 @@ def test_mg_l001_mg_l001_v(save_xml):
         instance="msData/modelGroups/mgL001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k010_mg_k010_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 5 elements, the last 2
@@ -6656,11 +7062,12 @@ def test_mg_k010_mg_k010_i(save_xml):
         instance="msData/modelGroups/mgK010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k009_mg_k009_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 5 elements, all elements
@@ -6672,11 +7079,12 @@ def test_mg_k009_mg_k009_v(save_xml):
         instance="msData/modelGroups/mgK009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k008_mg_k008_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 2 elements, 3 elements is
@@ -6688,11 +7096,12 @@ def test_mg_k008_mg_k008_i(save_xml):
         instance="msData/modelGroups/mgK008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k007_mg_k007_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 2 elements, the elements are
@@ -6704,11 +7113,12 @@ def test_mg_k007_mg_k007_i(save_xml):
         instance="msData/modelGroups/mgK007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k006_mg_k006_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 2 elements, only the 1st
@@ -6720,11 +7130,12 @@ def test_mg_k006_mg_k006_i(save_xml):
         instance="msData/modelGroups/mgK006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k005_mg_k005_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 1 elements, 2 element is in
@@ -6736,11 +7147,12 @@ def test_mg_k005_mg_k005_i(save_xml):
         instance="msData/modelGroups/mgK005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k004_mg_k004_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 1 elements, 1 element is in
@@ -6752,11 +7164,12 @@ def test_mg_k004_mg_k004_v(save_xml):
         instance="msData/modelGroups/mgK004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k003_mg_k003_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with 1 elements, 0 element is in
@@ -6768,11 +7181,12 @@ def test_mg_k003_mg_k003_i(save_xml):
         instance="msData/modelGroups/mgK003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k002_mg_k002_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: with NO elements, 1 element is in
@@ -6784,11 +7198,12 @@ def test_mg_k002_mg_k002_i(save_xml):
         instance="msData/modelGroups/mgK002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_k001_mg_k001_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with NO elements
@@ -6800,11 +7215,12 @@ def test_mg_k001_mg_k001_v(save_xml):
         instance="msData/modelGroups/mgK001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j026_mg_j026_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=3,
@@ -6816,11 +7232,12 @@ def test_mg_j026_mg_j026_v(save_xml):
         instance="msData/modelGroups/mgJ026.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j024_mg_j024_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=3,
@@ -6832,11 +7249,12 @@ def test_mg_j024_mg_j024_i(save_xml):
         instance="msData/modelGroups/mgJ024.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j023_mg_j023_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=2,
@@ -6848,11 +7266,12 @@ def test_mg_j023_mg_j023_v(save_xml):
         instance="msData/modelGroups/mgJ023.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j022_mg_j022_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=1,
@@ -6864,11 +7283,12 @@ def test_mg_j022_mg_j022_v(save_xml):
         instance="msData/modelGroups/mgJ022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j021_mg_j021_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -6880,11 +7300,12 @@ def test_mg_j021_mg_j021_i(save_xml):
         instance="msData/modelGroups/mgJ021.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j020_mg_j020_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=2,
@@ -6896,11 +7317,12 @@ def test_mg_j020_mg_j020_i(save_xml):
         instance="msData/modelGroups/mgJ020.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j019_mg_j019_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=1,
@@ -6912,11 +7334,12 @@ def test_mg_j019_mg_j019_v(save_xml):
         instance="msData/modelGroups/mgJ019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j018_mg_j018_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -6928,11 +7351,12 @@ def test_mg_j018_mg_j018_i(save_xml):
         instance="msData/modelGroups/mgJ018.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j017_mg_j017_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=2,
@@ -6944,11 +7368,12 @@ def test_mg_j017_mg_j017_i(save_xml):
         instance="msData/modelGroups/mgJ017.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j016_mg_j016_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=1,
@@ -6960,11 +7385,12 @@ def test_mg_j016_mg_j016_v(save_xml):
         instance="msData/modelGroups/mgJ016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j015_mg_j015_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -6976,11 +7402,12 @@ def test_mg_j015_mg_j015_i(save_xml):
         instance="msData/modelGroups/mgJ015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j014_mg_j014_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -6992,11 +7419,12 @@ def test_mg_j014_mg_j014_v(save_xml):
         instance="msData/modelGroups/mgJ014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j013_mg_j013_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=1,
@@ -7008,11 +7436,12 @@ def test_mg_j013_mg_j013_i(save_xml):
         instance="msData/modelGroups/mgJ013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j012_mg_j012_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -7024,11 +7453,12 @@ def test_mg_j012_mg_j012_v(save_xml):
         instance="msData/modelGroups/mgJ012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j011_mg_j011_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=2,
@@ -7040,11 +7470,12 @@ def test_mg_j011_mg_j011_i(save_xml):
         instance="msData/modelGroups/mgJ011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j010_mg_j010_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=1,
@@ -7056,11 +7487,12 @@ def test_mg_j010_mg_j010_v(save_xml):
         instance="msData/modelGroups/mgJ010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j009_mg_j009_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -7072,11 +7504,12 @@ def test_mg_j009_mg_j009_v(save_xml):
         instance="msData/modelGroups/mgJ009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j008_mg_j008_i(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=2,
@@ -7088,11 +7521,12 @@ def test_mg_j008_mg_j008_i(save_xml):
         instance="msData/modelGroups/mgJ008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j007_mg_j007_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=1,
@@ -7104,11 +7538,12 @@ def test_mg_j007_mg_j007_v(save_xml):
         instance="msData/modelGroups/mgJ007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j006_mg_j006_v(save_xml):
     """
     TEST :model groups (ALL) : choice: elements in instant XML=0,
@@ -7120,11 +7555,12 @@ def test_mg_j006_mg_j006_v(save_xml):
         instance="msData/modelGroups/mgJ006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j005_mg_j005_i(save_xml):
     """
     TEST :model groups (ALL) : choice: check that maxOccurs default is 1,
@@ -7136,11 +7572,12 @@ def test_mg_j005_mg_j005_i(save_xml):
         instance="msData/modelGroups/mgJ005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j004_mg_j004_v(save_xml):
     """
     TEST :model groups (ALL) : choice: check that minOccurs default is 1,
@@ -7152,11 +7589,12 @@ def test_mg_j004_mg_j004_v(save_xml):
         instance="msData/modelGroups/mgJ004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_j003_mg_j003_i(save_xml):
     """
     TEST :model groups (ALL) : choice: check that minOccurs default is 1,
@@ -7168,11 +7606,12 @@ def test_mg_j003_mg_j003_i(save_xml):
         instance="msData/modelGroups/mgJ003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i019_mg_i019_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children 4 any, 4 elements
@@ -7183,11 +7622,12 @@ def test_mg_i019_mg_i019_v(save_xml):
         instance="msData/modelGroups/mgI019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i018_mg_i018_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children 4 sequence, 4 any
@@ -7198,11 +7638,12 @@ def test_mg_i018_mg_i018_v(save_xml):
         instance="msData/modelGroups/mgI018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i017_mg_i017_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children 4 choice, 4 sequence
@@ -7213,11 +7654,12 @@ def test_mg_i017_mg_i017_v(save_xml):
         instance="msData/modelGroups/mgI017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i016_mg_i016_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children 4 groups, 4 choice
@@ -7228,11 +7670,12 @@ def test_mg_i016_mg_i016_v(save_xml):
         instance="msData/modelGroups/mgI016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i015_mg_i015_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children 4 elements, 4 groups
@@ -7243,11 +7686,12 @@ def test_mg_i015_mg_i015_v(save_xml):
         instance="msData/modelGroups/mgI015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i014_mg_i014_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children any, sequence, group,
@@ -7259,11 +7703,12 @@ def test_mg_i014_mg_i014_v(save_xml):
         instance="msData/modelGroups/mgI014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i013_mg_i013_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children sequence, group,
@@ -7275,11 +7720,12 @@ def test_mg_i013_mg_i013_v(save_xml):
         instance="msData/modelGroups/mgI013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i012_mg_i012_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children choice, any, group,
@@ -7291,11 +7737,12 @@ def test_mg_i012_mg_i012_v(save_xml):
         instance="msData/modelGroups/mgI012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i011_mg_i011_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children group, any, choice,
@@ -7307,11 +7754,12 @@ def test_mg_i011_mg_i011_v(save_xml):
         instance="msData/modelGroups/mgI011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i010_mg_i010_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children element, any,
@@ -7323,11 +7771,12 @@ def test_mg_i010_mg_i010_v(save_xml):
         instance="msData/modelGroups/mgI010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i009_mg_i009_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children annotation, element,
@@ -7339,11 +7788,12 @@ def test_mg_i009_mg_i009_v(save_xml):
         instance="msData/modelGroups/mgI009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i008_mg_i008_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children annotation, any
@@ -7354,11 +7804,12 @@ def test_mg_i008_mg_i008_v(save_xml):
         instance="msData/modelGroups/mgI008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i007_mg_i007_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children annotation, sequence
@@ -7369,11 +7820,12 @@ def test_mg_i007_mg_i007_v(save_xml):
         instance="msData/modelGroups/mgI007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i006_mg_i006_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children annotation, choice
@@ -7384,11 +7836,12 @@ def test_mg_i006_mg_i006_v(save_xml):
         instance="msData/modelGroups/mgI006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i005_mg_i005_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children annotation, group
@@ -7399,11 +7852,12 @@ def test_mg_i005_mg_i005_v(save_xml):
         instance="msData/modelGroups/mgI005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i004_mg_i004_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with children annotation, element
@@ -7414,11 +7868,12 @@ def test_mg_i004_mg_i004_v(save_xml):
         instance="msData/modelGroups/mgI004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i002_mg_i002_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with one annotation only
@@ -7429,11 +7884,12 @@ def test_mg_i002_mg_i002_v(save_xml):
         instance="msData/modelGroups/mgI002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_i001_mg_i001_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with no child node
@@ -7444,11 +7900,12 @@ def test_mg_i001_mg_i001_v(save_xml):
         instance="msData/modelGroups/mgI001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_hb005_mg_hb005_v(save_xml):
     """
     TEST :model groups (ALL) : choice: maxOccurs = 5
@@ -7459,11 +7916,12 @@ def test_mg_hb005_mg_hb005_v(save_xml):
         instance="msData/modelGroups/mgHb005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_hb004_mg_hb004_v(save_xml):
     """
     TEST :model groups (ALL) : choice: maxOccurs = unbounded
@@ -7474,11 +7932,12 @@ def test_mg_hb004_mg_hb004_v(save_xml):
         instance="msData/modelGroups/mgHb004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h018_mg_h018_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with parent sequence
@@ -7489,11 +7948,12 @@ def test_mg_h018_mg_h018_v(save_xml):
         instance="msData/modelGroups/mgH018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h017_mg_h017_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with parent choice
@@ -7504,11 +7964,12 @@ def test_mg_h017_mg_h017_v(save_xml):
         instance="msData/modelGroups/mgH017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h016_mg_h016_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with parent group
@@ -7519,11 +7980,12 @@ def test_mg_h016_mg_h016_v(save_xml):
         instance="msData/modelGroups/mgH016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h015_mg_h015_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with parent extension
@@ -7534,11 +7996,12 @@ def test_mg_h015_mg_h015_v(save_xml):
         instance="msData/modelGroups/mgH015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h014_mg_h014_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with parent restriction
@@ -7549,11 +8012,12 @@ def test_mg_h014_mg_h014_v(save_xml):
         instance="msData/modelGroups/mgH014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h013_mg_h013_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with parent complexType
@@ -7564,11 +8028,12 @@ def test_mg_h013_mg_h013_v(save_xml):
         instance="msData/modelGroups/mgH013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_h001_mg_h001_v(save_xml):
     """
     TEST :model groups (ALL) : choice: id, id="foo"
@@ -7579,11 +8044,12 @@ def test_mg_h001_mg_h001_v(save_xml):
         instance="msData/modelGroups/mgH001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g026_mg_g026_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=3,
@@ -7595,11 +8061,12 @@ def test_mg_g026_mg_g026_v(save_xml):
         instance="msData/modelGroups/mgG026.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g024_mg_g024_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=3,
@@ -7611,11 +8078,12 @@ def test_mg_g024_mg_g024_i(save_xml):
         instance="msData/modelGroups/mgG024.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g023_mg_g023_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=2,
@@ -7627,11 +8095,12 @@ def test_mg_g023_mg_g023_v(save_xml):
         instance="msData/modelGroups/mgG023.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g022_mg_g022_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=1,
@@ -7643,11 +8112,12 @@ def test_mg_g022_mg_g022_v(save_xml):
         instance="msData/modelGroups/mgG022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g021_mg_g021_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7659,11 +8129,12 @@ def test_mg_g021_mg_g021_i(save_xml):
         instance="msData/modelGroups/mgG021.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g020_mg_g020_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=2,
@@ -7675,11 +8146,12 @@ def test_mg_g020_mg_g020_i(save_xml):
         instance="msData/modelGroups/mgG020.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g019_mg_g019_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=1,
@@ -7691,11 +8163,12 @@ def test_mg_g019_mg_g019_v(save_xml):
         instance="msData/modelGroups/mgG019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g018_mg_g018_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7707,11 +8180,12 @@ def test_mg_g018_mg_g018_i(save_xml):
         instance="msData/modelGroups/mgG018.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g017_mg_g017_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=2,
@@ -7723,11 +8197,12 @@ def test_mg_g017_mg_g017_i(save_xml):
         instance="msData/modelGroups/mgG017.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g016_mg_g016_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=1,
@@ -7739,11 +8214,12 @@ def test_mg_g016_mg_g016_v(save_xml):
         instance="msData/modelGroups/mgG016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g015_mg_g015_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7755,11 +8231,12 @@ def test_mg_g015_mg_g015_i(save_xml):
         instance="msData/modelGroups/mgG015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g014_mg_g014_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7771,11 +8248,12 @@ def test_mg_g014_mg_g014_v(save_xml):
         instance="msData/modelGroups/mgG014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g013_mg_g013_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=1,
@@ -7787,11 +8265,12 @@ def test_mg_g013_mg_g013_i(save_xml):
         instance="msData/modelGroups/mgG013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g012_mg_g012_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7803,11 +8282,12 @@ def test_mg_g012_mg_g012_v(save_xml):
         instance="msData/modelGroups/mgG012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g011_mg_g011_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=2,
@@ -7819,11 +8299,12 @@ def test_mg_g011_mg_g011_i(save_xml):
         instance="msData/modelGroups/mgG011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g010_mg_g010_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=1,
@@ -7835,11 +8316,12 @@ def test_mg_g010_mg_g010_v(save_xml):
         instance="msData/modelGroups/mgG010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g009_mg_g009_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7851,11 +8333,12 @@ def test_mg_g009_mg_g009_v(save_xml):
         instance="msData/modelGroups/mgG009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g008_mg_g008_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=2,
@@ -7867,11 +8350,12 @@ def test_mg_g008_mg_g008_i(save_xml):
         instance="msData/modelGroups/mgG008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g007_mg_g007_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=1,
@@ -7883,11 +8367,12 @@ def test_mg_g007_mg_g007_v(save_xml):
         instance="msData/modelGroups/mgG007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g006_mg_g006_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: elements in instant XML=0,
@@ -7899,11 +8384,12 @@ def test_mg_g006_mg_g006_v(save_xml):
         instance="msData/modelGroups/mgG006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g005_mg_g005_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: check that maxOccurs default is
@@ -7915,11 +8401,12 @@ def test_mg_g005_mg_g005_i(save_xml):
         instance="msData/modelGroups/mgG005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g004_mg_g004_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: check that minOccurs default is
@@ -7931,11 +8418,12 @@ def test_mg_g004_mg_g004_v(save_xml):
         instance="msData/modelGroups/mgG004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_g003_mg_g003_i(save_xml):
     """
     TEST :model groups (ALL) : sequence: check that minOccurs default is
@@ -7947,11 +8435,12 @@ def test_mg_g003_mg_g003_i(save_xml):
         instance="msData/modelGroups/mgG003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f019_mg_f019_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children 4 any, 4 elements
@@ -7962,11 +8451,12 @@ def test_mg_f019_mg_f019_v(save_xml):
         instance="msData/modelGroups/mgF019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f018_mg_f018_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children 4 sequence, 4 any
@@ -7977,11 +8467,12 @@ def test_mg_f018_mg_f018_v(save_xml):
         instance="msData/modelGroups/mgF018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f017_mg_f017_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children 4 choice, 4
@@ -7993,11 +8484,12 @@ def test_mg_f017_mg_f017_v(save_xml):
         instance="msData/modelGroups/mgF017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f016_mg_f016_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children 4 groups, 4 choice
@@ -8008,11 +8500,12 @@ def test_mg_f016_mg_f016_v(save_xml):
         instance="msData/modelGroups/mgF016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f015_mg_f015_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children 4 elements, 4
@@ -8024,11 +8517,12 @@ def test_mg_f015_mg_f015_v(save_xml):
         instance="msData/modelGroups/mgF015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f014_mg_f014_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children any, sequence,
@@ -8040,11 +8534,12 @@ def test_mg_f014_mg_f014_v(save_xml):
         instance="msData/modelGroups/mgF014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f013_mg_f013_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children sequence, group,
@@ -8056,11 +8551,12 @@ def test_mg_f013_mg_f013_v(save_xml):
         instance="msData/modelGroups/mgF013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f012_mg_f012_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children choice, any, group,
@@ -8072,11 +8568,12 @@ def test_mg_f012_mg_f012_v(save_xml):
         instance="msData/modelGroups/mgF012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f011_mg_f011_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children group, any, choice,
@@ -8088,11 +8585,12 @@ def test_mg_f011_mg_f011_v(save_xml):
         instance="msData/modelGroups/mgF011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f010_mg_f010_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children element, any,
@@ -8104,11 +8602,12 @@ def test_mg_f010_mg_f010_v(save_xml):
         instance="msData/modelGroups/mgF010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f009_mg_f009_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children annotation,
@@ -8120,11 +8619,12 @@ def test_mg_f009_mg_f009_v(save_xml):
         instance="msData/modelGroups/mgF009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f008_mg_f008_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children annotation, any
@@ -8135,11 +8635,12 @@ def test_mg_f008_mg_f008_v(save_xml):
         instance="msData/modelGroups/mgF008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f007_mg_f007_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children annotation,
@@ -8151,11 +8652,12 @@ def test_mg_f007_mg_f007_v(save_xml):
         instance="msData/modelGroups/mgF007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f006_mg_f006_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children annotation, choice
@@ -8166,11 +8668,12 @@ def test_mg_f006_mg_f006_v(save_xml):
         instance="msData/modelGroups/mgF006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f005_mg_f005_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children annotation, group
@@ -8181,11 +8684,12 @@ def test_mg_f005_mg_f005_v(save_xml):
         instance="msData/modelGroups/mgF005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f004_mg_f004_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with children annotation, element
@@ -8196,11 +8700,12 @@ def test_mg_f004_mg_f004_v(save_xml):
         instance="msData/modelGroups/mgF004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f002_mg_f002_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with one annotation only
@@ -8211,11 +8716,12 @@ def test_mg_f002_mg_f002_v(save_xml):
         instance="msData/modelGroups/mgF002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_f001_mg_f001_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with no child node
@@ -8226,11 +8732,12 @@ def test_mg_f001_mg_f001_v(save_xml):
         instance="msData/modelGroups/mgF001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_eb005_mg_eb005_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: maxOccurs = 8
@@ -8241,11 +8748,12 @@ def test_mg_eb005_mg_eb005_v(save_xml):
         instance="msData/modelGroups/mgEb005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_eb004_mg_eb004_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: maxOccurs = unbounded
@@ -8256,11 +8764,12 @@ def test_mg_eb004_mg_eb004_v(save_xml):
         instance="msData/modelGroups/mgEb004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e018_mg_e018_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with parent sequence
@@ -8271,11 +8780,12 @@ def test_mg_e018_mg_e018_v(save_xml):
         instance="msData/modelGroups/mgE018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e017_mg_e017_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with parent choice
@@ -8286,11 +8796,12 @@ def test_mg_e017_mg_e017_v(save_xml):
         instance="msData/modelGroups/mgE017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e016_mg_e016_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with parent group
@@ -8301,11 +8812,12 @@ def test_mg_e016_mg_e016_v(save_xml):
         instance="msData/modelGroups/mgE016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e015_mg_e015_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with parent extension
@@ -8316,11 +8828,12 @@ def test_mg_e015_mg_e015_v(save_xml):
         instance="msData/modelGroups/mgE015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e014_mg_e014_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with parent restriction
@@ -8331,11 +8844,12 @@ def test_mg_e014_mg_e014_v(save_xml):
         instance="msData/modelGroups/mgE014.xml",
         instance_is_valid=True,
         class_name="Who",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e013_mg_e013_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with parent complexType
@@ -8346,11 +8860,12 @@ def test_mg_e013_mg_e013_v(save_xml):
         instance="msData/modelGroups/mgE013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_e001_mg_e001_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: id, id="foo"
@@ -8361,11 +8876,12 @@ def test_mg_e001_mg_e001_v(save_xml):
         instance="msData/modelGroups/mgE001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_d013_mg_d013_v(save_xml):
     """
     TEST :model groups (ALL) : test using of minOccurs=0 and allowing
@@ -8377,11 +8893,12 @@ def test_mg_d013_mg_d013_v(save_xml):
         instance="msData/modelGroups/mgD013.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_d009_mg_d009_v(save_xml):
     """
     TEST :model groups (ALL) : choice: with any attribute with no schema
@@ -8393,11 +8910,12 @@ def test_mg_d009_mg_d009_v(save_xml):
         instance="msData/modelGroups/mgD009.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_d005_mg_d005_v(save_xml):
     """
     TEST :model groups (ALL) : sequence: with any attribute with no schema
@@ -8409,11 +8927,12 @@ def test_mg_d005_mg_d005_v(save_xml):
         instance="msData/modelGroups/mgD005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_d001_mg_d001_v(save_xml):
     """
     TEST :model groups (ALL) : all: with any attribute with no schema
@@ -8425,11 +8944,12 @@ def test_mg_d001_mg_d001_v(save_xml):
         instance="msData/modelGroups/mgD001.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c014_mg_c014_v(save_xml):
     """
     TEST :model groups (ALL) : all with default minOccurs and maxOccurs
@@ -8441,11 +8961,12 @@ def test_mg_c014_mg_c014_v(save_xml):
         instance="msData/modelGroups/mgC014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c012_mg_c012_i(save_xml):
     """
     TEST :model groups (ALL) : all: elements in instant XML=2,
@@ -8457,11 +8978,12 @@ def test_mg_c012_mg_c012_i(save_xml):
         instance="msData/modelGroups/mgC012.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c011_mg_c011_v(save_xml):
     """
     TEST :model groups (ALL) : all: elements in instant XML=1,
@@ -8473,11 +8995,12 @@ def test_mg_c011_mg_c011_v(save_xml):
         instance="msData/modelGroups/mgC011.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c010_mg_c010_i(save_xml):
     """
     TEST :model groups (ALL) : all: elements in instant XML=0,
@@ -8489,11 +9012,12 @@ def test_mg_c010_mg_c010_i(save_xml):
         instance="msData/modelGroups/mgC010.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c007_mg_c007_i(save_xml):
     """
     TEST :model groups (ALL) : all: elements in instant XML=2,
@@ -8505,11 +9029,12 @@ def test_mg_c007_mg_c007_i(save_xml):
         instance="msData/modelGroups/mgC007.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c006_mg_c006_v(save_xml):
     """
     TEST :model groups (ALL) : all: elements in instant XML=1,
@@ -8521,11 +9046,12 @@ def test_mg_c006_mg_c006_v(save_xml):
         instance="msData/modelGroups/mgC006.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c005_mg_c005_i(save_xml):
     """
     TEST :model groups (ALL) : all: elements in instant XML=0,
@@ -8537,11 +9063,12 @@ def test_mg_c005_mg_c005_i(save_xml):
         instance="msData/modelGroups/mgC005.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c004_mg_c004_v(save_xml):
     """
     TEST :model groups (ALL) : all: minOccurs can have value of 0 or 1 max
@@ -8553,11 +9080,12 @@ def test_mg_c004_mg_c004_v(save_xml):
         instance="msData/modelGroups/mgC004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c003_mg_c003_i(save_xml):
     """
     TEST :model groups (ALL) : all: check that maxOccurs default is 1,
@@ -8569,11 +9097,12 @@ def test_mg_c003_mg_c003_i(save_xml):
         instance="msData/modelGroups/mgC003.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c002_mg_c002_v(save_xml):
     """
     TEST :model groups (ALL) : all: check that minOccurs default is 1,
@@ -8585,11 +9114,12 @@ def test_mg_c002_mg_c002_v(save_xml):
         instance="msData/modelGroups/mgC002.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_c001_mg_c001_i(save_xml):
     """
     TEST :model groups (ALL) : all: check that minOccurs default is 1,
@@ -8601,11 +9131,12 @@ def test_mg_c001_mg_c001_i(save_xml):
         instance="msData/modelGroups/mgC001.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_b006_mg_b006_v(save_xml):
     """
     TEST :model groups (ALL) : all: with one element only
@@ -8616,11 +9147,12 @@ def test_mg_b006_mg_b006_v(save_xml):
         instance="msData/modelGroups/mgB006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_b004_mg_b004_v(save_xml):
     """
     TEST :model groups (ALL) : all: with annotation follow by 1 element
@@ -8631,11 +9163,12 @@ def test_mg_b004_mg_b004_v(save_xml):
         instance="msData/modelGroups/mgB004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_b002_mg_b002_v(save_xml):
     """
     TEST :model groups (ALL) : all: with one annotation only
@@ -8646,11 +9179,12 @@ def test_mg_b002_mg_b002_v(save_xml):
         instance="msData/modelGroups/mgB002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_b001_mg_b001_v(save_xml):
     """
     TEST :model groups (ALL) : all: with no child node
@@ -8661,11 +9195,12 @@ def test_mg_b001_mg_b001_v(save_xml):
         instance="msData/modelGroups/mgB001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_aa003_mg_aa003_v(save_xml):
     """
     TEST :model groups (ALL) : all: minOccurs = 0
@@ -8676,11 +9211,12 @@ def test_mg_aa003_mg_aa003_v(save_xml):
         instance="msData/modelGroups/mgAa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_a017_mg_a017_v(save_xml):
     """
     TEST :model groups (ALL) : all: with parent group
@@ -8691,11 +9227,12 @@ def test_mg_a017_mg_a017_v(save_xml):
         instance="msData/modelGroups/mgA017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_a015_mg_a015_v(save_xml):
     """
     TEST :model groups (ALL) : all: with parent restriction
@@ -8706,11 +9243,12 @@ def test_mg_a015_mg_a015_v(save_xml):
         instance="msData/modelGroups/mgA015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_a014_mg_a014_v(save_xml):
     """
     TEST :model groups (ALL) : all: with parent complexType
@@ -8721,11 +9259,12 @@ def test_mg_a014_mg_a014_v(save_xml):
         instance="msData/modelGroups/mgA014.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mg_a001_mg_a001_v(save_xml):
     """
     TEST :model groups (ALL) : all: id, id="foo"
@@ -8736,11 +9275,12 @@ def test_mg_a001_mg_a001_v(save_xml):
         instance="msData/modelGroups/mgA001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notat_h003_notat_h003_i(save_xml):
     """
     TEST :Notations : Instance document with (Schema with 3 Notations and
@@ -8753,11 +9293,12 @@ def test_notat_h003_notat_h003_i(save_xml):
         instance="msData/notations/notatH003.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notat_h002v_notat_h002v_i(save_xml):
     """
     TEST :Notations : Instance document doesn't declare a notation type
@@ -8768,11 +9309,12 @@ def test_notat_h002v_notat_h002v_i(save_xml):
         instance="msData/notations/notatH002.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_notat_h001v_notat_h001v_v(save_xml):
     """
     TEST :Notations : Instance document declares a notation type
@@ -8783,11 +9325,12 @@ def test_notat_h001v_notat_h001v_v(save_xml):
         instance="msData/notations/notatH001.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z040_particles_z040_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8800,11 +9343,12 @@ def test_particles_z040_particles_z040_i(save_xml):
         instance="msData/particles/particlesZ040.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z036_c_particles_z036_c_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8819,11 +9363,12 @@ def test_particles_z036_c_particles_z036_c_v(save_xml):
         instance="msData/particles/particlesZ036_c.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z036_b2_particles_z036_b2_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8838,11 +9383,12 @@ def test_particles_z036_b2_particles_z036_b2_i(save_xml):
         instance="msData/particles/particlesZ036_b2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z036_b1_particles_z036_b1_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8857,11 +9403,12 @@ def test_particles_z036_b1_particles_z036_b1_i(save_xml):
         instance="msData/particles/particlesZ036_b1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z036_a_particles_z036_a_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8876,11 +9423,12 @@ def test_particles_z036_a_particles_z036_a_i(save_xml):
         instance="msData/particles/particlesZ036_a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z035_a_particles_z035_a_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8893,11 +9441,12 @@ def test_particles_z035_a_particles_z035_a_i(save_xml):
         instance="msData/particles/particlesZ035_a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z034_b_particles_z034_b_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8910,11 +9459,12 @@ def test_particles_z034_b_particles_z034_b_i(save_xml):
         instance="msData/particles/particlesZ034_b1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z034_a3_particles_z034_a3_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8927,11 +9477,12 @@ def test_particles_z034_a3_particles_z034_a3_i(save_xml):
         instance="msData/particles/particlesZ034_a3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z034_a2_particles_z034_a2_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8944,11 +9495,12 @@ def test_particles_z034_a2_particles_z034_a2_i(save_xml):
         instance="msData/particles/particlesZ034_a2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_particles_z034_a1_particles_z034_a1_v(save_xml):
     """
@@ -8962,11 +9514,12 @@ def test_particles_z034_a1_particles_z034_a1_v(save_xml):
         instance="msData/particles/particlesZ034_a1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z026_particles_z026_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8980,11 +9533,12 @@ def test_particles_z026_particles_z026_v(save_xml):
         instance="msData/particles/particlesZ026.xml",
         instance_is_valid=False,
         class_name="Sequence",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z025_particles_z025_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -8996,11 +9550,12 @@ def test_particles_z025_particles_z025_v(save_xml):
         instance="msData/particles/particlesZ025.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z016_particles_z016_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9013,11 +9568,12 @@ def test_particles_z016_particles_z016_i(save_xml):
         instance="msData/particles/particlesZ016.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z015_particles_z015_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9030,7 +9586,7 @@ def test_particles_z015_particles_z015_i(save_xml):
         instance="msData/particles/particlesZ015.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -9053,6 +9609,7 @@ def test_particles_z012_particles_z012_v(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_particles_z008_particles_z008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9065,11 +9622,12 @@ def test_particles_z008_particles_z008_v(save_xml):
         instance="msData/particles/particlesZ008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z007_particles_z007_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9082,11 +9640,12 @@ def test_particles_z007_particles_z007_i(save_xml):
         instance="msData/particles/particlesZ007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z005_particles_z005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9099,11 +9658,12 @@ def test_particles_z005_particles_z005_v(save_xml):
         instance="msData/particles/particlesZ005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z003_particles_z003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9116,11 +9676,12 @@ def test_particles_z003_particles_z003_v(save_xml):
         instance="msData/particles/particlesZ003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z002_particles_z002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9133,11 +9694,12 @@ def test_particles_z002_particles_z002_v(save_xml):
         instance="msData/particles/particlesZ002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_z001_particles_z001_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9151,11 +9713,12 @@ def test_particles_z001_particles_z001_i(save_xml):
         instance="msData/particles/particlesZ001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_w016_particles_w016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9169,11 +9732,12 @@ def test_particles_w016_particles_w016_v(save_xml):
         instance="msData/particles/particlesW016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_w011_particles_w011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9187,11 +9751,12 @@ def test_particles_w011_particles_w011_v(save_xml):
         instance="msData/particles/particlesW011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_w008_particles_w008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9205,11 +9770,12 @@ def test_particles_w008_particles_w008_v(save_xml):
         instance="msData/particles/particlesW008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_w003_particles_w003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9223,11 +9789,12 @@ def test_particles_w003_particles_w003_v(save_xml):
         instance="msData/particles/particlesW003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_w001_particles_w001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9241,11 +9808,12 @@ def test_particles_w001_particles_w001_v(save_xml):
         instance="msData/particles/particlesW001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v015_particles_v015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9259,11 +9827,12 @@ def test_particles_v015_particles_v015_v(save_xml):
         instance="msData/particles/particlesV015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v014_particles_v014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9277,11 +9846,12 @@ def test_particles_v014_particles_v014_v(save_xml):
         instance="msData/particles/particlesV014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v013_particles_v013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9295,11 +9865,12 @@ def test_particles_v013_particles_v013_v(save_xml):
         instance="msData/particles/particlesV013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v012_particles_v012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9313,11 +9884,12 @@ def test_particles_v012_particles_v012_v(save_xml):
         instance="msData/particles/particlesV012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v011_particles_v011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9331,11 +9903,12 @@ def test_particles_v011_particles_v011_v(save_xml):
         instance="msData/particles/particlesV011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v010_particles_v010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9349,11 +9922,12 @@ def test_particles_v010_particles_v010_v(save_xml):
         instance="msData/particles/particlesV010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v009_particles_v009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9367,11 +9941,12 @@ def test_particles_v009_particles_v009_v(save_xml):
         instance="msData/particles/particlesV009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v008_particles_v008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9385,11 +9960,12 @@ def test_particles_v008_particles_v008_v(save_xml):
         instance="msData/particles/particlesV008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v007_particles_v007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9403,11 +9979,12 @@ def test_particles_v007_particles_v007_v(save_xml):
         instance="msData/particles/particlesV007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v006_particles_v006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9421,11 +9998,12 @@ def test_particles_v006_particles_v006_v(save_xml):
         instance="msData/particles/particlesV006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v004_particles_v004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9439,11 +10017,12 @@ def test_particles_v004_particles_v004_v(save_xml):
         instance="msData/particles/particlesV004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_v003_particles_v003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9457,11 +10036,12 @@ def test_particles_v003_particles_v003_v(save_xml):
         instance="msData/particles/particlesV003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_u007_particles_u007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9475,11 +10055,12 @@ def test_particles_u007_particles_u007_v(save_xml):
         instance="msData/particles/particlesU007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_u005_particles_u005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9493,11 +10074,12 @@ def test_particles_u005_particles_u005_v(save_xml):
         instance="msData/particles/particlesU005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_u004_particles_u004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9511,11 +10093,12 @@ def test_particles_u004_particles_u004_v(save_xml):
         instance="msData/particles/particlesU004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_u003_particles_u003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9529,11 +10112,12 @@ def test_particles_u003_particles_u003_v(save_xml):
         instance="msData/particles/particlesU003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_particles_q032_particles_q032_v(save_xml):
     """
@@ -9549,11 +10133,12 @@ def test_particles_q032_particles_q032_v(save_xml):
         instance="msData/particles/particlesQ032.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q030_particles_q030_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9567,11 +10152,12 @@ def test_particles_q030_particles_q030_v(save_xml):
         instance="msData/particles/particlesQ030.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q029_particles_q029_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9585,11 +10171,12 @@ def test_particles_q029_particles_q029_v(save_xml):
         instance="msData/particles/particlesQ029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q024_particles_q024_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9604,11 +10191,12 @@ def test_particles_q024_particles_q024_v(save_xml):
         instance="msData/particles/particlesQ024.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q022_particles_q022_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9622,11 +10210,12 @@ def test_particles_q022_particles_q022_v(save_xml):
         instance="msData/particles/particlesQ022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q020_particles_q020_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9640,11 +10229,12 @@ def test_particles_q020_particles_q020_v(save_xml):
         instance="msData/particles/particlesQ020.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q017_particles_q017_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9658,11 +10248,12 @@ def test_particles_q017_particles_q017_v(save_xml):
         instance="msData/particles/particlesQ017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q016_particles_q016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9676,11 +10267,12 @@ def test_particles_q016_particles_q016_v(save_xml):
         instance="msData/particles/particlesQ016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_particles_q013_particles_q013_v(save_xml):
     """
@@ -9696,11 +10288,12 @@ def test_particles_q013_particles_q013_v(save_xml):
         instance="msData/particles/particlesQ013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q011_particles_q011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9715,11 +10308,12 @@ def test_particles_q011_particles_q011_v(save_xml):
         instance="msData/particles/particlesQ011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q007_particles_q007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9734,11 +10328,12 @@ def test_particles_q007_particles_q007_v(save_xml):
         instance="msData/particles/particlesQ007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q005_particles_q005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9753,11 +10348,12 @@ def test_particles_q005_particles_q005_v(save_xml):
         instance="msData/particles/particlesQ005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q004_particles_q004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9772,11 +10368,12 @@ def test_particles_q004_particles_q004_v(save_xml):
         instance="msData/particles/particlesQ004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q003_particles_q003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9791,11 +10388,12 @@ def test_particles_q003_particles_q003_v(save_xml):
         instance="msData/particles/particlesQ003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q002_particles_q002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9810,11 +10408,12 @@ def test_particles_q002_particles_q002_v(save_xml):
         instance="msData/particles/particlesQ002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_q001_particles_q001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9829,11 +10428,12 @@ def test_particles_q001_particles_q001_v(save_xml):
         instance="msData/particles/particlesQ001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t014_particles_t014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9848,11 +10448,12 @@ def test_particles_t014_particles_t014_v(save_xml):
         instance="msData/particles/particlesT014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t013_particles_t013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9866,11 +10467,12 @@ def test_particles_t013_particles_t013_v(save_xml):
         instance="msData/particles/particlesT013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t012_particles_t012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9885,11 +10487,12 @@ def test_particles_t012_particles_t012_v(save_xml):
         instance="msData/particles/particlesT012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t007_particles_t007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9903,11 +10506,12 @@ def test_particles_t007_particles_t007_v(save_xml):
         instance="msData/particles/particlesT007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t006_particles_t006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9921,11 +10525,12 @@ def test_particles_t006_particles_t006_v(save_xml):
         instance="msData/particles/particlesT006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t005_particles_t005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9939,11 +10544,12 @@ def test_particles_t005_particles_t005_v(save_xml):
         instance="msData/particles/particlesT005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t004_particles_t004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9957,11 +10563,12 @@ def test_particles_t004_particles_t004_v(save_xml):
         instance="msData/particles/particlesT004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t003_particles_t003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9975,11 +10582,12 @@ def test_particles_t003_particles_t003_v(save_xml):
         instance="msData/particles/particlesT003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_t001_particles_t001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -9993,11 +10601,12 @@ def test_particles_t001_particles_t001_v(save_xml):
         instance="msData/particles/particlesT001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r030_particles_r030_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10011,11 +10620,12 @@ def test_particles_r030_particles_r030_v(save_xml):
         instance="msData/particles/particlesR030.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r029_particles_r029_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10029,11 +10639,12 @@ def test_particles_r029_particles_r029_v(save_xml):
         instance="msData/particles/particlesR029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r024_particles_r024_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10048,11 +10659,12 @@ def test_particles_r024_particles_r024_v(save_xml):
         instance="msData/particles/particlesR024.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r022_particles_r022_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10066,11 +10678,12 @@ def test_particles_r022_particles_r022_v(save_xml):
         instance="msData/particles/particlesR022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r020_particles_r020_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10084,11 +10697,12 @@ def test_particles_r020_particles_r020_v(save_xml):
         instance="msData/particles/particlesR020.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r017_particles_r017_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10102,11 +10716,12 @@ def test_particles_r017_particles_r017_v(save_xml):
         instance="msData/particles/particlesR017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r016_particles_r016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10120,11 +10735,12 @@ def test_particles_r016_particles_r016_v(save_xml):
         instance="msData/particles/particlesR016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r015_particles_r015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10138,11 +10754,12 @@ def test_particles_r015_particles_r015_v(save_xml):
         instance="msData/particles/particlesR015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r013_particles_r013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10157,11 +10774,12 @@ def test_particles_r013_particles_r013_v(save_xml):
         instance="msData/particles/particlesR013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r012_particles_r012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10176,11 +10794,12 @@ def test_particles_r012_particles_r012_v(save_xml):
         instance="msData/particles/particlesR012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r011_particles_r011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10195,11 +10814,12 @@ def test_particles_r011_particles_r011_v(save_xml):
         instance="msData/particles/particlesR011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r009_particles_r009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10214,11 +10834,12 @@ def test_particles_r009_particles_r009_v(save_xml):
         instance="msData/particles/particlesR009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r008_particles_r008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10233,11 +10854,12 @@ def test_particles_r008_particles_r008_v(save_xml):
         instance="msData/particles/particlesR008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r007_particles_r007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10252,11 +10874,12 @@ def test_particles_r007_particles_r007_v(save_xml):
         instance="msData/particles/particlesR007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r005_particles_r005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10271,11 +10894,12 @@ def test_particles_r005_particles_r005_v(save_xml):
         instance="msData/particles/particlesR005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r004_particles_r004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10290,11 +10914,12 @@ def test_particles_r004_particles_r004_v(save_xml):
         instance="msData/particles/particlesR004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r003_particles_r003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10309,11 +10934,12 @@ def test_particles_r003_particles_r003_v(save_xml):
         instance="msData/particles/particlesR003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r002_particles_r002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10328,11 +10954,12 @@ def test_particles_r002_particles_r002_v(save_xml):
         instance="msData/particles/particlesR002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_r001_particles_r001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10347,11 +10974,12 @@ def test_particles_r001_particles_r001_v(save_xml):
         instance="msData/particles/particlesR001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_s011_particles_s011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10365,11 +10993,12 @@ def test_particles_s011_particles_s011_v(save_xml):
         instance="msData/particles/particlesS011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_s007_particles_s007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10383,11 +11012,12 @@ def test_particles_s007_particles_s007_v(save_xml):
         instance="msData/particles/particlesS007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_s004_particles_s004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10401,11 +11031,12 @@ def test_particles_s004_particles_s004_v(save_xml):
         instance="msData/particles/particlesS004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_s003_particles_s003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10419,11 +11050,12 @@ def test_particles_s003_particles_s003_v(save_xml):
         instance="msData/particles/particlesS003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_s001_particles_s001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10436,11 +11068,12 @@ def test_particles_s001_particles_s001_v(save_xml):
         instance="msData/particles/particlesS001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_p002_particles_p002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10454,11 +11087,12 @@ def test_particles_p002_particles_p002_v(save_xml):
         instance="msData/particles/particlesP002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob060_particles_ob060_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10473,11 +11107,12 @@ def test_particles_ob060_particles_ob060_v(save_xml):
         instance="msData/particles/particlesOb060.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob059_particles_ob059_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10492,11 +11127,12 @@ def test_particles_ob059_particles_ob059_v(save_xml):
         instance="msData/particles/particlesOb059.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob057_particles_ob057_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10511,11 +11147,12 @@ def test_particles_ob057_particles_ob057_v(save_xml):
         instance="msData/particles/particlesOb057.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob056_particles_ob056_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10529,11 +11166,12 @@ def test_particles_ob056_particles_ob056_v(save_xml):
         instance="msData/particles/particlesOb056.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob055_particles_ob055_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10548,11 +11186,12 @@ def test_particles_ob055_particles_ob055_v(save_xml):
         instance="msData/particles/particlesOb055.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob054_particles_ob054_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10567,11 +11206,12 @@ def test_particles_ob054_particles_ob054_v(save_xml):
         instance="msData/particles/particlesOb054.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob053_particles_ob053_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10585,11 +11225,12 @@ def test_particles_ob053_particles_ob053_v(save_xml):
         instance="msData/particles/particlesOb053.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob052_particles_ob052_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10604,11 +11245,12 @@ def test_particles_ob052_particles_ob052_v(save_xml):
         instance="msData/particles/particlesOb052.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob048_particles_ob048_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10623,11 +11265,12 @@ def test_particles_ob048_particles_ob048_v(save_xml):
         instance="msData/particles/particlesOb048.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob047_particles_ob047_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10642,11 +11285,12 @@ def test_particles_ob047_particles_ob047_v(save_xml):
         instance="msData/particles/particlesOb047.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob042_particles_ob042_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10661,11 +11305,12 @@ def test_particles_ob042_particles_ob042_v(save_xml):
         instance="msData/particles/particlesOb042.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob032_particles_ob032_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10679,11 +11324,12 @@ def test_particles_ob032_particles_ob032_v(save_xml):
         instance="msData/particles/particlesOb032.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob022_particles_ob022_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10698,11 +11344,12 @@ def test_particles_ob022_particles_ob022_v(save_xml):
         instance="msData/particles/particlesOb022.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob015_particles_ob015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10717,11 +11364,12 @@ def test_particles_ob015_particles_ob015_v(save_xml):
         instance="msData/particles/particlesOb015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob012_particles_ob012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10736,11 +11384,12 @@ def test_particles_ob012_particles_ob012_v(save_xml):
         instance="msData/particles/particlesOb012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob007_particles_ob007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10755,11 +11404,12 @@ def test_particles_ob007_particles_ob007_v(save_xml):
         instance="msData/particles/particlesOb007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob006_particles_ob006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10774,11 +11424,12 @@ def test_particles_ob006_particles_ob006_v(save_xml):
         instance="msData/particles/particlesOb006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob005_particles_ob005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10792,11 +11443,12 @@ def test_particles_ob005_particles_ob005_v(save_xml):
         instance="msData/particles/particlesOb005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ob003_particles_ob003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10811,11 +11463,12 @@ def test_particles_ob003_particles_ob003_v(save_xml):
         instance="msData/particles/particlesOb003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa014_particles_oa014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10829,11 +11482,12 @@ def test_particles_oa014_particles_oa014_v(save_xml):
         instance="msData/particles/particlesOa014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa013_particles_oa013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10847,11 +11501,12 @@ def test_particles_oa013_particles_oa013_v(save_xml):
         instance="msData/particles/particlesOa013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa012_particles_oa012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10865,11 +11520,12 @@ def test_particles_oa012_particles_oa012_v(save_xml):
         instance="msData/particles/particlesOa012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa011_particles_oa011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10883,11 +11539,12 @@ def test_particles_oa011_particles_oa011_v(save_xml):
         instance="msData/particles/particlesOa011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa006_particles_oa006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10901,11 +11558,12 @@ def test_particles_oa006_particles_oa006_v(save_xml):
         instance="msData/particles/particlesOa006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa003_particles_oa003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10919,11 +11577,12 @@ def test_particles_oa003_particles_oa003_v(save_xml):
         instance="msData/particles/particlesOa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_oa001_particles_oa001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10937,11 +11596,12 @@ def test_particles_oa001_particles_oa001_v(save_xml):
         instance="msData/particles/particlesOa001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_m035_particles_m035_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10955,11 +11615,12 @@ def test_particles_m035_particles_m035_v(save_xml):
         instance="msData/particles/particlesM035.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_m003_particles_m003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10973,11 +11634,12 @@ def test_particles_m003_particles_m003_v(save_xml):
         instance="msData/particles/particlesM003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_m002_particles_m002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -10991,11 +11653,12 @@ def test_particles_m002_particles_m002_v(save_xml):
         instance="msData/particles/particlesM002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l029_particles_l029_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11010,11 +11673,12 @@ def test_particles_l029_particles_l029_v(save_xml):
         instance="msData/particles/particlesL029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l028_particles_l028_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11029,11 +11693,12 @@ def test_particles_l028_particles_l028_v(save_xml):
         instance="msData/particles/particlesL028.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l025_particles_l025_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11048,11 +11713,12 @@ def test_particles_l025_particles_l025_v(save_xml):
         instance="msData/particles/particlesL025.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l023_particles_l023_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11067,11 +11733,12 @@ def test_particles_l023_particles_l023_v(save_xml):
         instance="msData/particles/particlesL023.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l021_particles_l021_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11086,11 +11753,12 @@ def test_particles_l021_particles_l021_v(save_xml):
         instance="msData/particles/particlesL021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l018_particles_l018_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11105,11 +11773,12 @@ def test_particles_l018_particles_l018_v(save_xml):
         instance="msData/particles/particlesL018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l017_particles_l017_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11124,11 +11793,12 @@ def test_particles_l017_particles_l017_v(save_xml):
         instance="msData/particles/particlesL017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l013_particles_l013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11143,11 +11813,12 @@ def test_particles_l013_particles_l013_v(save_xml):
         instance="msData/particles/particlesL013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l012_particles_l012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11162,11 +11833,12 @@ def test_particles_l012_particles_l012_v(save_xml):
         instance="msData/particles/particlesL012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l007_particles_l007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11181,11 +11853,12 @@ def test_particles_l007_particles_l007_v(save_xml):
         instance="msData/particles/particlesL007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l006_particles_l006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11200,11 +11873,12 @@ def test_particles_l006_particles_l006_v(save_xml):
         instance="msData/particles/particlesL006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_l003_particles_l003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11218,11 +11892,12 @@ def test_particles_l003_particles_l003_v(save_xml):
         instance="msData/particles/particlesL003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_k008_particles_k008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11237,11 +11912,12 @@ def test_particles_k008_particles_k008_v(save_xml):
         instance="msData/particles/particlesK008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_k005_particles_k005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11255,11 +11931,12 @@ def test_particles_k005_particles_k005_v(save_xml):
         instance="msData/particles/particlesK005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_k003_particles_k003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11274,11 +11951,12 @@ def test_particles_k003_particles_k003_v(save_xml):
         instance="msData/particles/particlesK003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_k002_particles_k002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11293,11 +11971,12 @@ def test_particles_k002_particles_k002_v(save_xml):
         instance="msData/particles/particlesK002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_k001_particles_k001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11311,11 +11990,12 @@ def test_particles_k001_particles_k001_v(save_xml):
         instance="msData/particles/particlesK001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ju003_particles_ju003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11331,11 +12011,12 @@ def test_particles_ju003_particles_ju003_v(save_xml):
         instance="msData/particles/particlesJu003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ju002_particles_ju002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11350,11 +12031,12 @@ def test_particles_ju002_particles_ju002_v(save_xml):
         instance="msData/particles/particlesJu002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ju001_particles_ju001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11370,11 +12052,12 @@ def test_particles_ju001_particles_ju001_v(save_xml):
         instance="msData/particles/particlesJu001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_js001_particles_js001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11388,11 +12071,12 @@ def test_particles_js001_particles_js001_v(save_xml):
         instance="msData/particles/particlesJs001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jq010_particles_jq010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11407,11 +12091,12 @@ def test_particles_jq010_particles_jq010_v(save_xml):
         instance="msData/particles/particlesJq010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jq008_particles_jq008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11426,11 +12111,12 @@ def test_particles_jq008_particles_jq008_v(save_xml):
         instance="msData/particles/particlesJq008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jq007_particles_jq007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11445,11 +12131,12 @@ def test_particles_jq007_particles_jq007_v(save_xml):
         instance="msData/particles/particlesJq007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jp005_particles_jp005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11464,11 +12151,12 @@ def test_particles_jp005_particles_jp005_v(save_xml):
         instance="msData/particles/particlesJp005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jp004_particles_jp004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11483,11 +12171,12 @@ def test_particles_jp004_particles_jp004_v(save_xml):
         instance="msData/particles/particlesJp004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jn010_particles_jn010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11502,11 +12191,12 @@ def test_particles_jn010_particles_jn010_v(save_xml):
         instance="msData/particles/particlesJn010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jn008_particles_jn008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11521,11 +12211,12 @@ def test_particles_jn008_particles_jn008_v(save_xml):
         instance="msData/particles/particlesJn008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jn007_particles_jn007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11540,11 +12231,12 @@ def test_particles_jn007_particles_jn007_v(save_xml):
         instance="msData/particles/particlesJn007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jm005_particles_jm005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11559,11 +12251,12 @@ def test_particles_jm005_particles_jm005_v(save_xml):
         instance="msData/particles/particlesJm005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jm004_particles_jm004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11578,11 +12271,12 @@ def test_particles_jm004_particles_jm004_v(save_xml):
         instance="msData/particles/particlesJm004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jl001_particles_jl001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11596,11 +12290,12 @@ def test_particles_jl001_particles_jl001_v(save_xml):
         instance="msData/particles/particlesJl001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk016_particles_jk016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11614,11 +12309,12 @@ def test_particles_jk016_particles_jk016_v(save_xml):
         instance="msData/particles/particlesJk016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk015_particles_jk015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11633,11 +12329,12 @@ def test_particles_jk015_particles_jk015_v(save_xml):
         instance="msData/particles/particlesJk015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk013_particles_jk013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11652,11 +12349,12 @@ def test_particles_jk013_particles_jk013_v(save_xml):
         instance="msData/particles/particlesJk013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk011_particles_jk011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11671,11 +12369,12 @@ def test_particles_jk011_particles_jk011_v(save_xml):
         instance="msData/particles/particlesJk011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk010_particles_jk010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11690,11 +12389,12 @@ def test_particles_jk010_particles_jk010_v(save_xml):
         instance="msData/particles/particlesJk010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk008_particles_jk008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11709,11 +12409,12 @@ def test_particles_jk008_particles_jk008_v(save_xml):
         instance="msData/particles/particlesJk008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk007_particles_jk007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11728,11 +12429,12 @@ def test_particles_jk007_particles_jk007_v(save_xml):
         instance="msData/particles/particlesJk007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk005_particles_jk005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11747,11 +12449,12 @@ def test_particles_jk005_particles_jk005_v(save_xml):
         instance="msData/particles/particlesJk005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk004_particles_jk004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11766,11 +12469,12 @@ def test_particles_jk004_particles_jk004_v(save_xml):
         instance="msData/particles/particlesJk004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk003_particles_jk003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11785,11 +12489,12 @@ def test_particles_jk003_particles_jk003_v(save_xml):
         instance="msData/particles/particlesJk003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk002_particles_jk002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11804,11 +12509,12 @@ def test_particles_jk002_particles_jk002_v(save_xml):
         instance="msData/particles/particlesJk002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jk001_particles_jk001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11823,11 +12529,12 @@ def test_particles_jk001_particles_jk001_v(save_xml):
         instance="msData/particles/particlesJk001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj011_particles_jj011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11842,11 +12549,12 @@ def test_particles_jj011_particles_jj011_v(save_xml):
         instance="msData/particles/particlesJj011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj010_particles_jj010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11861,11 +12569,12 @@ def test_particles_jj010_particles_jj010_v(save_xml):
         instance="msData/particles/particlesJj010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj009_particles_jj009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11880,11 +12589,12 @@ def test_particles_jj009_particles_jj009_v(save_xml):
         instance="msData/particles/particlesJj009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj008_particles_jj008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11899,11 +12609,12 @@ def test_particles_jj008_particles_jj008_v(save_xml):
         instance="msData/particles/particlesJj008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj007_particles_jj007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11918,11 +12629,12 @@ def test_particles_jj007_particles_jj007_v(save_xml):
         instance="msData/particles/particlesJj007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj005_particles_jj005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11937,11 +12649,12 @@ def test_particles_jj005_particles_jj005_v(save_xml):
         instance="msData/particles/particlesJj005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj004_particles_jj004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11956,11 +12669,12 @@ def test_particles_jj004_particles_jj004_v(save_xml):
         instance="msData/particles/particlesJj004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj002_particles_jj002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11975,11 +12689,12 @@ def test_particles_jj002_particles_jj002_v(save_xml):
         instance="msData/particles/particlesJj002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jj001_particles_jj001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -11994,11 +12709,12 @@ def test_particles_jj001_particles_jj001_v(save_xml):
         instance="msData/particles/particlesJj001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf016_particles_jf016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12013,11 +12729,12 @@ def test_particles_jf016_particles_jf016_v(save_xml):
         instance="msData/particles/particlesJf016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf015_particles_jf015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12032,11 +12749,12 @@ def test_particles_jf015_particles_jf015_v(save_xml):
         instance="msData/particles/particlesJf015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf013_particles_jf013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12051,11 +12769,12 @@ def test_particles_jf013_particles_jf013_v(save_xml):
         instance="msData/particles/particlesJf013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf011_particles_jf011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12070,11 +12789,12 @@ def test_particles_jf011_particles_jf011_v(save_xml):
         instance="msData/particles/particlesJf011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf010_particles_jf010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12089,11 +12809,12 @@ def test_particles_jf010_particles_jf010_v(save_xml):
         instance="msData/particles/particlesJf010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf008_particles_jf008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12108,11 +12829,12 @@ def test_particles_jf008_particles_jf008_v(save_xml):
         instance="msData/particles/particlesJf008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf007_particles_jf007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12127,11 +12849,12 @@ def test_particles_jf007_particles_jf007_v(save_xml):
         instance="msData/particles/particlesJf007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf005_particles_jf005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12146,11 +12869,12 @@ def test_particles_jf005_particles_jf005_v(save_xml):
         instance="msData/particles/particlesJf005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf004_particles_jf004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12165,11 +12889,12 @@ def test_particles_jf004_particles_jf004_v(save_xml):
         instance="msData/particles/particlesJf004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf003_particles_jf003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12184,11 +12909,12 @@ def test_particles_jf003_particles_jf003_v(save_xml):
         instance="msData/particles/particlesJf003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf002_particles_jf002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12203,11 +12929,12 @@ def test_particles_jf002_particles_jf002_v(save_xml):
         instance="msData/particles/particlesJf002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jf001_particles_jf001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12222,11 +12949,12 @@ def test_particles_jf001_particles_jf001_v(save_xml):
         instance="msData/particles/particlesJf001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je011_particles_je011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12241,11 +12969,12 @@ def test_particles_je011_particles_je011_v(save_xml):
         instance="msData/particles/particlesJe011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je010_particles_je010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12260,11 +12989,12 @@ def test_particles_je010_particles_je010_v(save_xml):
         instance="msData/particles/particlesJe010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je009_particles_je009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12279,11 +13009,12 @@ def test_particles_je009_particles_je009_v(save_xml):
         instance="msData/particles/particlesJe009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je008_particles_je008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12298,11 +13029,12 @@ def test_particles_je008_particles_je008_v(save_xml):
         instance="msData/particles/particlesJe008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je007_particles_je007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12317,11 +13049,12 @@ def test_particles_je007_particles_je007_v(save_xml):
         instance="msData/particles/particlesJe007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je005_particles_je005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12336,11 +13069,12 @@ def test_particles_je005_particles_je005_v(save_xml):
         instance="msData/particles/particlesJe005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je004_particles_je004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12355,11 +13089,12 @@ def test_particles_je004_particles_je004_v(save_xml):
         instance="msData/particles/particlesJe004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je002_particles_je002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12374,11 +13109,12 @@ def test_particles_je002_particles_je002_v(save_xml):
         instance="msData/particles/particlesJe002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_je001_particles_je001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12393,11 +13129,12 @@ def test_particles_je001_particles_je001_v(save_xml):
         instance="msData/particles/particlesJe001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd016_particles_jd016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12411,11 +13148,12 @@ def test_particles_jd016_particles_jd016_v(save_xml):
         instance="msData/particles/particlesJd016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd015_particles_jd015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12429,11 +13167,12 @@ def test_particles_jd015_particles_jd015_v(save_xml):
         instance="msData/particles/particlesJd015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd013_particles_jd013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12447,11 +13186,12 @@ def test_particles_jd013_particles_jd013_v(save_xml):
         instance="msData/particles/particlesJd013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd011_particles_jd011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12465,11 +13205,12 @@ def test_particles_jd011_particles_jd011_v(save_xml):
         instance="msData/particles/particlesJd011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd010_particles_jd010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12483,11 +13224,12 @@ def test_particles_jd010_particles_jd010_v(save_xml):
         instance="msData/particles/particlesJd010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd008_particles_jd008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12501,11 +13243,12 @@ def test_particles_jd008_particles_jd008_v(save_xml):
         instance="msData/particles/particlesJd008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd007_particles_jd007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12519,11 +13262,12 @@ def test_particles_jd007_particles_jd007_v(save_xml):
         instance="msData/particles/particlesJd007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd005_particles_jd005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12537,11 +13281,12 @@ def test_particles_jd005_particles_jd005_v(save_xml):
         instance="msData/particles/particlesJd005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd004_particles_jd004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12555,11 +13300,12 @@ def test_particles_jd004_particles_jd004_v(save_xml):
         instance="msData/particles/particlesJd004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd003_particles_jd003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12573,11 +13319,12 @@ def test_particles_jd003_particles_jd003_v(save_xml):
         instance="msData/particles/particlesJd003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd002_particles_jd002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12591,11 +13338,12 @@ def test_particles_jd002_particles_jd002_v(save_xml):
         instance="msData/particles/particlesJd002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jd001_particles_jd001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12609,11 +13357,12 @@ def test_particles_jd001_particles_jd001_v(save_xml):
         instance="msData/particles/particlesJd001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc011_particles_jc011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12627,11 +13376,12 @@ def test_particles_jc011_particles_jc011_v(save_xml):
         instance="msData/particles/particlesJc011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc010_particles_jc010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12645,11 +13395,12 @@ def test_particles_jc010_particles_jc010_v(save_xml):
         instance="msData/particles/particlesJc010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc009_particles_jc009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12663,11 +13414,12 @@ def test_particles_jc009_particles_jc009_v(save_xml):
         instance="msData/particles/particlesJc009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc008_particles_jc008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12681,11 +13433,12 @@ def test_particles_jc008_particles_jc008_v(save_xml):
         instance="msData/particles/particlesJc008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc007_particles_jc007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12699,11 +13452,12 @@ def test_particles_jc007_particles_jc007_v(save_xml):
         instance="msData/particles/particlesJc007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc005_particles_jc005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12717,11 +13471,12 @@ def test_particles_jc005_particles_jc005_v(save_xml):
         instance="msData/particles/particlesJc005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc004_particles_jc004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12735,11 +13490,12 @@ def test_particles_jc004_particles_jc004_v(save_xml):
         instance="msData/particles/particlesJc004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc002_particles_jc002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12753,11 +13509,12 @@ def test_particles_jc002_particles_jc002_v(save_xml):
         instance="msData/particles/particlesJc002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jc001_particles_jc001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12771,11 +13528,12 @@ def test_particles_jc001_particles_jc001_v(save_xml):
         instance="msData/particles/particlesJc001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb016_particles_jb016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12789,11 +13547,12 @@ def test_particles_jb016_particles_jb016_v(save_xml):
         instance="msData/particles/particlesJb016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb015_particles_jb015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12807,11 +13566,12 @@ def test_particles_jb015_particles_jb015_v(save_xml):
         instance="msData/particles/particlesJb015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb013_particles_jb013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12825,11 +13585,12 @@ def test_particles_jb013_particles_jb013_v(save_xml):
         instance="msData/particles/particlesJb013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb011_particles_jb011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12843,11 +13604,12 @@ def test_particles_jb011_particles_jb011_v(save_xml):
         instance="msData/particles/particlesJb011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb010_particles_jb010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12861,11 +13623,12 @@ def test_particles_jb010_particles_jb010_v(save_xml):
         instance="msData/particles/particlesJb010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb008_particles_jb008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12879,11 +13642,12 @@ def test_particles_jb008_particles_jb008_v(save_xml):
         instance="msData/particles/particlesJb008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb007_particles_jb007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12897,11 +13661,12 @@ def test_particles_jb007_particles_jb007_v(save_xml):
         instance="msData/particles/particlesJb007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb005_particles_jb005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12915,11 +13680,12 @@ def test_particles_jb005_particles_jb005_v(save_xml):
         instance="msData/particles/particlesJb005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb004_particles_jb004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12933,11 +13699,12 @@ def test_particles_jb004_particles_jb004_v(save_xml):
         instance="msData/particles/particlesJb004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb003_particles_jb003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12951,11 +13718,12 @@ def test_particles_jb003_particles_jb003_v(save_xml):
         instance="msData/particles/particlesJb003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb002_particles_jb002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12969,11 +13737,12 @@ def test_particles_jb002_particles_jb002_v(save_xml):
         instance="msData/particles/particlesJb002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_jb001_particles_jb001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -12987,11 +13756,12 @@ def test_particles_jb001_particles_jb001_v(save_xml):
         instance="msData/particles/particlesJb001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja011_particles_ja011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13005,11 +13775,12 @@ def test_particles_ja011_particles_ja011_v(save_xml):
         instance="msData/particles/particlesJa011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja010_particles_ja010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13023,11 +13794,12 @@ def test_particles_ja010_particles_ja010_v(save_xml):
         instance="msData/particles/particlesJa010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja009_particles_ja009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13041,11 +13813,12 @@ def test_particles_ja009_particles_ja009_v(save_xml):
         instance="msData/particles/particlesJa009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja008_particles_ja008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13059,11 +13832,12 @@ def test_particles_ja008_particles_ja008_v(save_xml):
         instance="msData/particles/particlesJa008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja007_particles_ja007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13077,11 +13851,12 @@ def test_particles_ja007_particles_ja007_v(save_xml):
         instance="msData/particles/particlesJa007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja005_particles_ja005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13095,11 +13870,12 @@ def test_particles_ja005_particles_ja005_v(save_xml):
         instance="msData/particles/particlesJa005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja004_particles_ja004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13113,11 +13889,12 @@ def test_particles_ja004_particles_ja004_v(save_xml):
         instance="msData/particles/particlesJa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja002_particles_ja002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13131,11 +13908,12 @@ def test_particles_ja002_particles_ja002_v(save_xml):
         instance="msData/particles/particlesJa002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ja001_particles_ja001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13149,11 +13927,12 @@ def test_particles_ja001_particles_ja001_v(save_xml):
         instance="msData/particles/particlesJa001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ik026_particles_ik026_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13167,11 +13946,12 @@ def test_particles_ik026_particles_ik026_v(save_xml):
         instance="msData/particles/particlesIk026.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ik012_particles_ik012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13185,11 +13965,12 @@ def test_particles_ik012_particles_ik012_v(save_xml):
         instance="msData/particles/particlesIk012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ik004_particles_ik004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13203,11 +13984,12 @@ def test_particles_ik004_particles_ik004_v(save_xml):
         instance="msData/particles/particlesIk004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ik001_particles_ik001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13221,11 +14003,12 @@ def test_particles_ik001_particles_ik001_v(save_xml):
         instance="msData/particles/particlesIk001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ij006_particles_ij006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13240,11 +14023,12 @@ def test_particles_ij006_particles_ij006_v(save_xml):
         instance="msData/particles/particlesIj006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ij005_particles_ij005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13258,11 +14042,12 @@ def test_particles_ij005_particles_ij005_v(save_xml):
         instance="msData/particles/particlesIj005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ij002_particles_ij002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13276,11 +14061,12 @@ def test_particles_ij002_particles_ij002_v(save_xml):
         instance="msData/particles/particlesIj002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ij001_particles_ij001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13293,11 +14079,12 @@ def test_particles_ij001_particles_ij001_v(save_xml):
         instance="msData/particles/particlesIj001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig015_particles_ig015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13311,11 +14098,12 @@ def test_particles_ig015_particles_ig015_v(save_xml):
         instance="msData/particles/particlesIg015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig014_particles_ig014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13329,11 +14117,12 @@ def test_particles_ig014_particles_ig014_v(save_xml):
         instance="msData/particles/particlesIg014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig012_particles_ig012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13347,11 +14136,12 @@ def test_particles_ig012_particles_ig012_v(save_xml):
         instance="msData/particles/particlesIg012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig011_particles_ig011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13365,11 +14155,12 @@ def test_particles_ig011_particles_ig011_v(save_xml):
         instance="msData/particles/particlesIg011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig005_particles_ig005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13383,11 +14174,12 @@ def test_particles_ig005_particles_ig005_v(save_xml):
         instance="msData/particles/particlesIg005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig003_particles_ig003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13401,11 +14193,12 @@ def test_particles_ig003_particles_ig003_v(save_xml):
         instance="msData/particles/particlesIg003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig002_particles_ig002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13419,11 +14212,12 @@ def test_particles_ig002_particles_ig002_v(save_xml):
         instance="msData/particles/particlesIg002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ig001_particles_ig001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13437,11 +14231,12 @@ def test_particles_ig001_particles_ig001_v(save_xml):
         instance="msData/particles/particlesIg001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_if006_particles_if006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13454,11 +14249,12 @@ def test_particles_if006_particles_if006_v(save_xml):
         instance="msData/particles/particlesIf006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_if005_particles_if005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13471,11 +14267,12 @@ def test_particles_if005_particles_if005_v(save_xml):
         instance="msData/particles/particlesIf005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_if004_particles_if004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13488,11 +14285,12 @@ def test_particles_if004_particles_if004_v(save_xml):
         instance="msData/particles/particlesIf004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_if003_particles_if003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13505,11 +14303,12 @@ def test_particles_if003_particles_if003_v(save_xml):
         instance="msData/particles/particlesIf003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_if002_particles_if002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13522,11 +14321,12 @@ def test_particles_if002_particles_if002_v(save_xml):
         instance="msData/particles/particlesIf002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_if001_particles_if001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13539,11 +14339,12 @@ def test_particles_if001_particles_if001_v(save_xml):
         instance="msData/particles/particlesIf001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie016_particles_ie016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13556,11 +14357,12 @@ def test_particles_ie016_particles_ie016_v(save_xml):
         instance="msData/particles/particlesIe016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie015_particles_ie015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13573,11 +14375,12 @@ def test_particles_ie015_particles_ie015_v(save_xml):
         instance="msData/particles/particlesIe015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie013_particles_ie013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13590,11 +14393,12 @@ def test_particles_ie013_particles_ie013_v(save_xml):
         instance="msData/particles/particlesIe013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie011_particles_ie011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13607,11 +14411,12 @@ def test_particles_ie011_particles_ie011_v(save_xml):
         instance="msData/particles/particlesIe011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie010_particles_ie010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13624,11 +14429,12 @@ def test_particles_ie010_particles_ie010_v(save_xml):
         instance="msData/particles/particlesIe010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie008_particles_ie008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13641,11 +14447,12 @@ def test_particles_ie008_particles_ie008_v(save_xml):
         instance="msData/particles/particlesIe008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie007_particles_ie007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13658,11 +14465,12 @@ def test_particles_ie007_particles_ie007_v(save_xml):
         instance="msData/particles/particlesIe007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie005_particles_ie005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13675,11 +14483,12 @@ def test_particles_ie005_particles_ie005_v(save_xml):
         instance="msData/particles/particlesIe005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie004_particles_ie004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13692,11 +14501,12 @@ def test_particles_ie004_particles_ie004_v(save_xml):
         instance="msData/particles/particlesIe004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie003_particles_ie003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13709,11 +14519,12 @@ def test_particles_ie003_particles_ie003_v(save_xml):
         instance="msData/particles/particlesIe003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie002_particles_ie002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13726,11 +14537,12 @@ def test_particles_ie002_particles_ie002_v(save_xml):
         instance="msData/particles/particlesIe002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ie001_particles_ie001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13743,11 +14555,12 @@ def test_particles_ie001_particles_ie001_v(save_xml):
         instance="msData/particles/particlesIe001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id011_particles_id011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13760,11 +14573,12 @@ def test_particles_id011_particles_id011_v(save_xml):
         instance="msData/particles/particlesId011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id010_particles_id010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13777,11 +14591,12 @@ def test_particles_id010_particles_id010_v(save_xml):
         instance="msData/particles/particlesId010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id009_particles_id009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13794,11 +14609,12 @@ def test_particles_id009_particles_id009_v(save_xml):
         instance="msData/particles/particlesId009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id008_particles_id008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13811,11 +14627,12 @@ def test_particles_id008_particles_id008_v(save_xml):
         instance="msData/particles/particlesId008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id007_particles_id007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13828,11 +14645,12 @@ def test_particles_id007_particles_id007_v(save_xml):
         instance="msData/particles/particlesId007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id005_particles_id005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13845,11 +14663,12 @@ def test_particles_id005_particles_id005_v(save_xml):
         instance="msData/particles/particlesId005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id004_particles_id004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13862,11 +14681,12 @@ def test_particles_id004_particles_id004_v(save_xml):
         instance="msData/particles/particlesId004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id002_particles_id002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13879,11 +14699,12 @@ def test_particles_id002_particles_id002_v(save_xml):
         instance="msData/particles/particlesId002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_id001_particles_id001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13896,11 +14717,12 @@ def test_particles_id001_particles_id001_v(save_xml):
         instance="msData/particles/particlesId001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ic007_particles_ic007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13914,11 +14736,12 @@ def test_particles_ic007_particles_ic007_v(save_xml):
         instance="msData/particles/particlesIc007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ic006_particles_ic006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13932,11 +14755,12 @@ def test_particles_ic006_particles_ic006_v(save_xml):
         instance="msData/particles/particlesIc006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ic005_particles_ic005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13950,11 +14774,12 @@ def test_particles_ic005_particles_ic005_v(save_xml):
         instance="msData/particles/particlesIc005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ic001_particles_ic001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13968,11 +14793,12 @@ def test_particles_ic001_particles_ic001_v(save_xml):
         instance="msData/particles/particlesIc001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ib005_particles_ib005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -13986,11 +14812,12 @@ def test_particles_ib005_particles_ib005_v(save_xml):
         instance="msData/particles/particlesIb005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ib003_particles_ib003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14003,11 +14830,12 @@ def test_particles_ib003_particles_ib003_v(save_xml):
         instance="msData/particles/particlesIb003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ib001_particles_ib001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14020,11 +14848,12 @@ def test_particles_ib001_particles_ib001_v(save_xml):
         instance="msData/particles/particlesIb001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ia005_particles_ia005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14037,11 +14866,12 @@ def test_particles_ia005_particles_ia005_v(save_xml):
         instance="msData/particles/particlesIa005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ia004_particles_ia004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14054,11 +14884,12 @@ def test_particles_ia004_particles_ia004_v(save_xml):
         instance="msData/particles/particlesIa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ia003_particles_ia003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14071,11 +14902,12 @@ def test_particles_ia003_particles_ia003_v(save_xml):
         instance="msData/particles/particlesIa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ia002_particles_ia002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14088,11 +14920,12 @@ def test_particles_ia002_particles_ia002_v(save_xml):
         instance="msData/particles/particlesIa002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ia001_particles_ia001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14105,11 +14938,12 @@ def test_particles_ia001_particles_ia001_v(save_xml):
         instance="msData/particles/particlesIa001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha018_particles_ha018_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14122,11 +14956,12 @@ def test_particles_ha018_particles_ha018_v(save_xml):
         instance="msData/particles/particlesHa018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha017_particles_ha017_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14139,11 +14974,12 @@ def test_particles_ha017_particles_ha017_v(save_xml):
         instance="msData/particles/particlesHa017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha016_particles_ha016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14157,11 +14993,12 @@ def test_particles_ha016_particles_ha016_v(save_xml):
         instance="msData/particles/particlesHa016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha015_particles_ha015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14175,11 +15012,12 @@ def test_particles_ha015_particles_ha015_v(save_xml):
         instance="msData/particles/particlesHa015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha014_particles_ha014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14193,11 +15031,12 @@ def test_particles_ha014_particles_ha014_v(save_xml):
         instance="msData/particles/particlesHa014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha013_particles_ha013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14211,11 +15050,12 @@ def test_particles_ha013_particles_ha013_v(save_xml):
         instance="msData/particles/particlesHa013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha012_particles_ha012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14229,11 +15069,12 @@ def test_particles_ha012_particles_ha012_v(save_xml):
         instance="msData/particles/particlesHa012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha011_particles_ha011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14247,11 +15088,12 @@ def test_particles_ha011_particles_ha011_v(save_xml):
         instance="msData/particles/particlesHa011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha010_particles_ha010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14265,11 +15107,12 @@ def test_particles_ha010_particles_ha010_v(save_xml):
         instance="msData/particles/particlesHa010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha009_particles_ha009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14283,11 +15126,12 @@ def test_particles_ha009_particles_ha009_v(save_xml):
         instance="msData/particles/particlesHa009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha007_particles_ha007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14302,11 +15146,12 @@ def test_particles_ha007_particles_ha007_v(save_xml):
         instance="msData/particles/particlesHa007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha006_particles_ha006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14320,11 +15165,12 @@ def test_particles_ha006_particles_ha006_v(save_xml):
         instance="msData/particles/particlesHa006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha005_particles_ha005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14339,11 +15185,12 @@ def test_particles_ha005_particles_ha005_v(save_xml):
         instance="msData/particles/particlesHa005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha004_particles_ha004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14357,11 +15204,12 @@ def test_particles_ha004_particles_ha004_v(save_xml):
         instance="msData/particles/particlesHa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha003_particles_ha003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14375,11 +15223,12 @@ def test_particles_ha003_particles_ha003_v(save_xml):
         instance="msData/particles/particlesHa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha002_particles_ha002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14393,11 +15242,12 @@ def test_particles_ha002_particles_ha002_v(save_xml):
         instance="msData/particles/particlesHa002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ha001_particles_ha001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14410,11 +15260,12 @@ def test_particles_ha001_particles_ha001_v(save_xml):
         instance="msData/particles/particlesHa001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_fb004_particles_fb004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14427,11 +15278,12 @@ def test_particles_fb004_particles_fb004_v(save_xml):
         instance="msData/particles/particlesFb004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_fb001_particles_fb001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14444,11 +15296,12 @@ def test_particles_fb001_particles_fb001_v(save_xml):
         instance="msData/particles/particlesFb001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_fa005_particles_fa005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14461,11 +15314,12 @@ def test_particles_fa005_particles_fa005_v(save_xml):
         instance="msData/particles/particlesFa005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_fa004_particles_fa004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14478,11 +15332,12 @@ def test_particles_fa004_particles_fa004_v(save_xml):
         instance="msData/particles/particlesFa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_fa003_particles_fa003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14495,11 +15350,12 @@ def test_particles_fa003_particles_fa003_v(save_xml):
         instance="msData/particles/particlesFa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_fa002_particles_fa002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14512,11 +15368,12 @@ def test_particles_fa002_particles_fa002_v(save_xml):
         instance="msData/particles/particlesFa002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec041_particles_ec041_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14529,11 +15386,12 @@ def test_particles_ec041_particles_ec041_i(save_xml):
         instance="msData/particles/particlesEc041.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec040_particles_ec040_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14546,11 +15404,12 @@ def test_particles_ec040_particles_ec040_i(save_xml):
         instance="msData/particles/particlesEc040.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec039_particles_ec039_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14563,11 +15422,12 @@ def test_particles_ec039_particles_ec039_i(save_xml):
         instance="msData/particles/particlesEc039.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec038_particles_ec038_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14580,11 +15440,12 @@ def test_particles_ec038_particles_ec038_i(save_xml):
         instance="msData/particles/particlesEc038.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec037_particles_ec037_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14597,11 +15458,12 @@ def test_particles_ec037_particles_ec037_v(save_xml):
         instance="msData/particles/particlesEc037.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec036_particles_ec036_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14614,11 +15476,12 @@ def test_particles_ec036_particles_ec036_v(save_xml):
         instance="msData/particles/particlesEc036.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec035_particles_ec035_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14631,11 +15494,12 @@ def test_particles_ec035_particles_ec035_v(save_xml):
         instance="msData/particles/particlesEc035.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec034_particles_ec034_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14648,11 +15512,12 @@ def test_particles_ec034_particles_ec034_v(save_xml):
         instance="msData/particles/particlesEc034.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec033_particles_ec033_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14665,11 +15530,12 @@ def test_particles_ec033_particles_ec033_v(save_xml):
         instance="msData/particles/particlesEc033.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec032_particles_ec032_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14682,11 +15548,12 @@ def test_particles_ec032_particles_ec032_v(save_xml):
         instance="msData/particles/particlesEc032.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec031_particles_ec031_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14699,11 +15566,12 @@ def test_particles_ec031_particles_ec031_v(save_xml):
         instance="msData/particles/particlesEc031.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec030_particles_ec030_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14716,11 +15584,12 @@ def test_particles_ec030_particles_ec030_v(save_xml):
         instance="msData/particles/particlesEc030.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec029_particles_ec029_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14733,11 +15602,12 @@ def test_particles_ec029_particles_ec029_v(save_xml):
         instance="msData/particles/particlesEc029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec028_particles_ec028_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14750,11 +15620,12 @@ def test_particles_ec028_particles_ec028_i(save_xml):
         instance="msData/particles/particlesEc028.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec027_particles_ec027_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14767,11 +15638,12 @@ def test_particles_ec027_particles_ec027_i(save_xml):
         instance="msData/particles/particlesEc027.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec026_particles_ec026_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14784,11 +15656,12 @@ def test_particles_ec026_particles_ec026_i(save_xml):
         instance="msData/particles/particlesEc026.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec025_particles_ec025_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14802,11 +15675,12 @@ def test_particles_ec025_particles_ec025_i(save_xml):
         instance="msData/particles/particlesEc025.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec024_particles_ec024_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14820,11 +15694,12 @@ def test_particles_ec024_particles_ec024_i(save_xml):
         instance="msData/particles/particlesEc024.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec023_particles_ec023_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14838,11 +15713,12 @@ def test_particles_ec023_particles_ec023_i(save_xml):
         instance="msData/particles/particlesEc023.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec022_particles_ec022_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14856,11 +15732,12 @@ def test_particles_ec022_particles_ec022_i(save_xml):
         instance="msData/particles/particlesEc022.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec021_particles_ec021_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14874,11 +15751,12 @@ def test_particles_ec021_particles_ec021_v(save_xml):
         instance="msData/particles/particlesEc021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec020_particles_ec020_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14892,11 +15770,12 @@ def test_particles_ec020_particles_ec020_v(save_xml):
         instance="msData/particles/particlesEc020.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec019_particles_ec019_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14910,11 +15789,12 @@ def test_particles_ec019_particles_ec019_v(save_xml):
         instance="msData/particles/particlesEc019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec018_particles_ec018_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14928,11 +15808,12 @@ def test_particles_ec018_particles_ec018_v(save_xml):
         instance="msData/particles/particlesEc018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec017_particles_ec017_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14946,11 +15827,12 @@ def test_particles_ec017_particles_ec017_v(save_xml):
         instance="msData/particles/particlesEc017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec016_particles_ec016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14964,11 +15846,12 @@ def test_particles_ec016_particles_ec016_v(save_xml):
         instance="msData/particles/particlesEc016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec015_particles_ec015_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -14982,11 +15865,12 @@ def test_particles_ec015_particles_ec015_i(save_xml):
         instance="msData/particles/particlesEc015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec014_particles_ec014_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15000,11 +15884,12 @@ def test_particles_ec014_particles_ec014_i(save_xml):
         instance="msData/particles/particlesEc014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec013_particles_ec013_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15018,11 +15903,12 @@ def test_particles_ec013_particles_ec013_i(save_xml):
         instance="msData/particles/particlesEc013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec012_particles_ec012_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15036,11 +15922,12 @@ def test_particles_ec012_particles_ec012_v(save_xml):
         instance="msData/particles/particlesEc012.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec011_particles_ec011_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15054,11 +15941,12 @@ def test_particles_ec011_particles_ec011_i(save_xml):
         instance="msData/particles/particlesEc011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec008_particles_ec008_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15071,11 +15959,12 @@ def test_particles_ec008_particles_ec008_i(save_xml):
         instance="msData/particles/particlesEc008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec007_particles_ec007_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15088,11 +15977,12 @@ def test_particles_ec007_particles_ec007_i(save_xml):
         instance="msData/particles/particlesEc007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec006_particles_ec006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15105,11 +15995,12 @@ def test_particles_ec006_particles_ec006_v(save_xml):
         instance="msData/particles/particlesEc006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec005_particles_ec005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15123,11 +16014,12 @@ def test_particles_ec005_particles_ec005_i(save_xml):
         instance="msData/particles/particlesEc005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec004_particles_ec004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15140,11 +16032,12 @@ def test_particles_ec004_particles_ec004_i(save_xml):
         instance="msData/particles/particlesEc004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec003_particles_ec003_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15157,11 +16050,12 @@ def test_particles_ec003_particles_ec003_i(save_xml):
         instance="msData/particles/particlesEc003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec002_particles_ec002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15174,11 +16068,12 @@ def test_particles_ec002_particles_ec002_v(save_xml):
         instance="msData/particles/particlesEc002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ec001_particles_ec001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15192,11 +16087,12 @@ def test_particles_ec001_particles_ec001_v(save_xml):
         instance="msData/particles/particlesEc001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_particles_eb041_particles_eb041_v(save_xml):
     """
@@ -15210,11 +16106,12 @@ def test_particles_eb041_particles_eb041_v(save_xml):
         instance="msData/particles/particlesEb041.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb039_particles_eb039_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15227,11 +16124,12 @@ def test_particles_eb039_particles_eb039_i(save_xml):
         instance="msData/particles/particlesEb039.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb038_particles_eb038_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15245,11 +16143,12 @@ def test_particles_eb038_particles_eb038_v(save_xml):
         instance="msData/particles/particlesEb038.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb037_particles_eb037_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15263,11 +16162,12 @@ def test_particles_eb037_particles_eb037_i(save_xml):
         instance="msData/particles/particlesEb037.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb036_particles_eb036_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15280,11 +16180,12 @@ def test_particles_eb036_particles_eb036_v(save_xml):
         instance="msData/particles/particlesEb036.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb035_particles_eb035_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15297,11 +16198,12 @@ def test_particles_eb035_particles_eb035_i(save_xml):
         instance="msData/particles/particlesEb035.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb034_particles_eb034_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15314,11 +16216,12 @@ def test_particles_eb034_particles_eb034_i(save_xml):
         instance="msData/particles/particlesEb034.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb033_particles_eb033_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15331,11 +16234,12 @@ def test_particles_eb033_particles_eb033_i(save_xml):
         instance="msData/particles/particlesEb033.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb032_particles_eb032_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15349,11 +16253,12 @@ def test_particles_eb032_particles_eb032_i(save_xml):
         instance="msData/particles/particlesEb032.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb031_particles_eb031_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15367,11 +16272,12 @@ def test_particles_eb031_particles_eb031_i(save_xml):
         instance="msData/particles/particlesEb031.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb030_particles_eb030_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15385,11 +16291,12 @@ def test_particles_eb030_particles_eb030_i(save_xml):
         instance="msData/particles/particlesEb030.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb029_particles_eb029_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15403,11 +16310,12 @@ def test_particles_eb029_particles_eb029_i(save_xml):
         instance="msData/particles/particlesEb029.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb028_particles_eb028_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15421,11 +16329,12 @@ def test_particles_eb028_particles_eb028_i(save_xml):
         instance="msData/particles/particlesEb028.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb027_particles_eb027_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15439,11 +16348,12 @@ def test_particles_eb027_particles_eb027_v(save_xml):
         instance="msData/particles/particlesEb027.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb026_particles_eb026_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15457,11 +16367,12 @@ def test_particles_eb026_particles_eb026_v(save_xml):
         instance="msData/particles/particlesEb026.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb025_particles_eb025_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15475,11 +16386,12 @@ def test_particles_eb025_particles_eb025_i(save_xml):
         instance="msData/particles/particlesEb025.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb024_particles_eb024_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15493,11 +16405,12 @@ def test_particles_eb024_particles_eb024_i(save_xml):
         instance="msData/particles/particlesEb024.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb023_particles_eb023_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15511,11 +16424,12 @@ def test_particles_eb023_particles_eb023_i(save_xml):
         instance="msData/particles/particlesEb023.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb022_particles_eb022_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15529,11 +16443,12 @@ def test_particles_eb022_particles_eb022_i(save_xml):
         instance="msData/particles/particlesEb022.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb021_particles_eb021_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15547,11 +16462,12 @@ def test_particles_eb021_particles_eb021_i(save_xml):
         instance="msData/particles/particlesEb021.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb020_particles_eb020_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15565,11 +16481,12 @@ def test_particles_eb020_particles_eb020_i(save_xml):
         instance="msData/particles/particlesEb020.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb019_particles_eb019_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15583,11 +16500,12 @@ def test_particles_eb019_particles_eb019_v(save_xml):
         instance="msData/particles/particlesEb019.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb018_particles_eb018_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15601,11 +16519,12 @@ def test_particles_eb018_particles_eb018_i(save_xml):
         instance="msData/particles/particlesEb018.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb017_particles_eb017_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15619,11 +16538,12 @@ def test_particles_eb017_particles_eb017_i(save_xml):
         instance="msData/particles/particlesEb017.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb014_particles_eb014_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15637,11 +16557,12 @@ def test_particles_eb014_particles_eb014_i(save_xml):
         instance="msData/particles/particlesEb014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb013_particles_eb013_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15655,11 +16576,12 @@ def test_particles_eb013_particles_eb013_i(save_xml):
         instance="msData/particles/particlesEb013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb012_particles_eb012_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15673,11 +16595,12 @@ def test_particles_eb012_particles_eb012_i(save_xml):
         instance="msData/particles/particlesEb012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb011_particles_eb011_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15691,11 +16614,12 @@ def test_particles_eb011_particles_eb011_i(save_xml):
         instance="msData/particles/particlesEb011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb010_particles_eb010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15709,11 +16633,12 @@ def test_particles_eb010_particles_eb010_v(save_xml):
         instance="msData/particles/particlesEb010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb009_particles_eb009_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15726,11 +16651,12 @@ def test_particles_eb009_particles_eb009_i(save_xml):
         instance="msData/particles/particlesEb009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb008_particles_eb008_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15744,11 +16670,12 @@ def test_particles_eb008_particles_eb008_i(save_xml):
         instance="msData/particles/particlesEb008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb007_particles_eb007_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15761,11 +16688,12 @@ def test_particles_eb007_particles_eb007_i(save_xml):
         instance="msData/particles/particlesEb007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb006_particles_eb006_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15779,11 +16707,12 @@ def test_particles_eb006_particles_eb006_i(save_xml):
         instance="msData/particles/particlesEb006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb005_particles_eb005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15797,11 +16726,12 @@ def test_particles_eb005_particles_eb005_i(save_xml):
         instance="msData/particles/particlesEb005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb004_particles_eb004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15815,11 +16745,12 @@ def test_particles_eb004_particles_eb004_i(save_xml):
         instance="msData/particles/particlesEb004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb003_particles_eb003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15833,11 +16764,12 @@ def test_particles_eb003_particles_eb003_v(save_xml):
         instance="msData/particles/particlesEb003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb002_particles_eb002_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15850,11 +16782,12 @@ def test_particles_eb002_particles_eb002_i(save_xml):
         instance="msData/particles/particlesEb002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_eb001_particles_eb001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15868,11 +16801,12 @@ def test_particles_eb001_particles_eb001_v(save_xml):
         instance="msData/particles/particlesEb001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea021_particles_ea021_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15886,11 +16820,12 @@ def test_particles_ea021_particles_ea021_i(save_xml):
         instance="msData/particles/particlesEa021.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea020_particles_ea020_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15904,11 +16839,12 @@ def test_particles_ea020_particles_ea020_i(save_xml):
         instance="msData/particles/particlesEa020.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea019_particles_ea019_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15922,11 +16858,12 @@ def test_particles_ea019_particles_ea019_i(save_xml):
         instance="msData/particles/particlesEa019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea018_particles_ea018_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15940,11 +16877,12 @@ def test_particles_ea018_particles_ea018_v(save_xml):
         instance="msData/particles/particlesEa018.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea017_particles_ea017_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15958,11 +16896,12 @@ def test_particles_ea017_particles_ea017_v(save_xml):
         instance="msData/particles/particlesEa017.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea016_particles_ea016_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15976,11 +16915,12 @@ def test_particles_ea016_particles_ea016_i(save_xml):
         instance="msData/particles/particlesEa016.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea015_particles_ea015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15994,11 +16934,12 @@ def test_particles_ea015_particles_ea015_v(save_xml):
         instance="msData/particles/particlesEa015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea014_particles_ea014_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16011,11 +16952,12 @@ def test_particles_ea014_particles_ea014_i(save_xml):
         instance="msData/particles/particlesEa014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea013_particles_ea013_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16028,11 +16970,12 @@ def test_particles_ea013_particles_ea013_i(save_xml):
         instance="msData/particles/particlesEa013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea012_particles_ea012_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16045,11 +16988,12 @@ def test_particles_ea012_particles_ea012_i(save_xml):
         instance="msData/particles/particlesEa012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea011_particles_ea011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16062,11 +17006,12 @@ def test_particles_ea011_particles_ea011_v(save_xml):
         instance="msData/particles/particlesEa011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea010_particles_ea010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16079,11 +17024,12 @@ def test_particles_ea010_particles_ea010_v(save_xml):
         instance="msData/particles/particlesEa010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea009_particles_ea009_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16096,11 +17042,12 @@ def test_particles_ea009_particles_ea009_i(save_xml):
         instance="msData/particles/particlesEa009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea008_particles_ea008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16114,11 +17061,12 @@ def test_particles_ea008_particles_ea008_v(save_xml):
         instance="msData/particles/particlesEa008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea007_particles_ea007_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16132,11 +17080,12 @@ def test_particles_ea007_particles_ea007_i(save_xml):
         instance="msData/particles/particlesEa007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea006_particles_ea006_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16150,11 +17099,12 @@ def test_particles_ea006_particles_ea006_i(save_xml):
         instance="msData/particles/particlesEa006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea005_particles_ea005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16168,11 +17118,12 @@ def test_particles_ea005_particles_ea005_i(save_xml):
         instance="msData/particles/particlesEa005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea004_particles_ea004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16186,11 +17137,12 @@ def test_particles_ea004_particles_ea004_v(save_xml):
         instance="msData/particles/particlesEa004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea003_particles_ea003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16204,11 +17156,12 @@ def test_particles_ea003_particles_ea003_v(save_xml):
         instance="msData/particles/particlesEa003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea002_particles_ea002_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16222,11 +17175,12 @@ def test_particles_ea002_particles_ea002_i(save_xml):
         instance="msData/particles/particlesEa002.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_ea001_particles_ea001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16240,11 +17194,12 @@ def test_particles_ea001_particles_ea001_v(save_xml):
         instance="msData/particles/particlesEa001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc009_particles_dc009_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16259,11 +17214,12 @@ def test_particles_dc009_particles_dc009_i(save_xml):
         instance="msData/particles/particlesDc009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc008_particles_dc008_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16277,11 +17233,12 @@ def test_particles_dc008_particles_dc008_i(save_xml):
         instance="msData/particles/particlesDc008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc007_particles_dc007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16295,11 +17252,12 @@ def test_particles_dc007_particles_dc007_v(save_xml):
         instance="msData/particles/particlesDc007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc006_particles_dc006_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16313,11 +17271,12 @@ def test_particles_dc006_particles_dc006_i(save_xml):
         instance="msData/particles/particlesDc006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc005_particles_dc005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16331,11 +17290,12 @@ def test_particles_dc005_particles_dc005_i(save_xml):
         instance="msData/particles/particlesDc005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc004_particles_dc004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16349,11 +17309,12 @@ def test_particles_dc004_particles_dc004_i(save_xml):
         instance="msData/particles/particlesDc004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc003_particles_dc003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16367,11 +17328,12 @@ def test_particles_dc003_particles_dc003_v(save_xml):
         instance="msData/particles/particlesDc003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc002_particles_dc002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16385,11 +17347,12 @@ def test_particles_dc002_particles_dc002_v(save_xml):
         instance="msData/particles/particlesDc002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_dc001_particles_dc001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16403,11 +17366,12 @@ def test_particles_dc001_particles_dc001_v(save_xml):
         instance="msData/particles/particlesDc001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db011_particles_db011_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16420,11 +17384,12 @@ def test_particles_db011_particles_db011_i(save_xml):
         instance="msData/particles/particlesDb011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db010_particles_db010_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16438,11 +17403,12 @@ def test_particles_db010_particles_db010_i(save_xml):
         instance="msData/particles/particlesDb010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db009_particles_db009_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16455,11 +17421,12 @@ def test_particles_db009_particles_db009_i(save_xml):
         instance="msData/particles/particlesDb009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db008_particles_db008_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16472,11 +17439,12 @@ def test_particles_db008_particles_db008_i(save_xml):
         instance="msData/particles/particlesDb008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db007_particles_db007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16489,11 +17457,12 @@ def test_particles_db007_particles_db007_v(save_xml):
         instance="msData/particles/particlesDb007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db006_particles_db006_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16507,11 +17476,12 @@ def test_particles_db006_particles_db006_i(save_xml):
         instance="msData/particles/particlesDb006.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db005_particles_db005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16524,11 +17494,12 @@ def test_particles_db005_particles_db005_i(save_xml):
         instance="msData/particles/particlesDb005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db004_particles_db004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16541,11 +17512,12 @@ def test_particles_db004_particles_db004_i(save_xml):
         instance="msData/particles/particlesDb004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db003_particles_db003_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16558,11 +17530,12 @@ def test_particles_db003_particles_db003_i(save_xml):
         instance="msData/particles/particlesDb003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db002_particles_db002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16575,11 +17548,12 @@ def test_particles_db002_particles_db002_v(save_xml):
         instance="msData/particles/particlesDb002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_db001_particles_db001_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16593,11 +17567,12 @@ def test_particles_db001_particles_db001_i(save_xml):
         instance="msData/particles/particlesDb001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_da005_particles_da005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16611,11 +17586,12 @@ def test_particles_da005_particles_da005_i(save_xml):
         instance="msData/particles/particlesDa005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_da004_particles_da004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16628,11 +17604,12 @@ def test_particles_da004_particles_da004_i(save_xml):
         instance="msData/particles/particlesDa004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_da003_particles_da003_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16645,11 +17622,12 @@ def test_particles_da003_particles_da003_i(save_xml):
         instance="msData/particles/particlesDa003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_da002_particles_da002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16662,11 +17640,12 @@ def test_particles_da002_particles_da002_v(save_xml):
         instance="msData/particles/particlesDa002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_da001_particles_da001_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16680,11 +17659,12 @@ def test_particles_da001_particles_da001_i(save_xml):
         instance="msData/particles/particlesDa001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c048_particles_c048_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16697,11 +17677,12 @@ def test_particles_c048_particles_c048_i(save_xml):
         instance="msData/particles/particlesC048.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c047_particles_c047_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16716,11 +17697,12 @@ def test_particles_c047_particles_c047_i(save_xml):
         instance="msData/particles/particlesC047.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c046_particles_c046_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16734,11 +17716,12 @@ def test_particles_c046_particles_c046_v(save_xml):
         instance="msData/particles/particlesC046.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c045_particles_c045_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16752,11 +17735,12 @@ def test_particles_c045_particles_c045_v(save_xml):
         instance="msData/particles/particlesC045.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c044_particles_c044_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16769,11 +17753,12 @@ def test_particles_c044_particles_c044_v(save_xml):
         instance="msData/particles/particlesC044.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c043_particles_c043_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16786,11 +17771,12 @@ def test_particles_c043_particles_c043_v(save_xml):
         instance="msData/particles/particlesC043.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c042_particles_c042_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16805,11 +17791,12 @@ def test_particles_c042_particles_c042_i(save_xml):
         instance="msData/particles/particlesC042.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c041_particles_c041_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16823,11 +17810,12 @@ def test_particles_c041_particles_c041_v(save_xml):
         instance="msData/particles/particlesC041.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c040_particles_c040_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16841,11 +17829,12 @@ def test_particles_c040_particles_c040_v(save_xml):
         instance="msData/particles/particlesC040.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c039_particles_c039_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16858,11 +17847,12 @@ def test_particles_c039_particles_c039_i(save_xml):
         instance="msData/particles/particlesC039.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c038_particles_c038_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16876,11 +17866,12 @@ def test_particles_c038_particles_c038_i(save_xml):
         instance="msData/particles/particlesC038.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c037_particles_c037_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16893,11 +17884,12 @@ def test_particles_c037_particles_c037_v(save_xml):
         instance="msData/particles/particlesC037.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c036_particles_c036_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16910,11 +17902,12 @@ def test_particles_c036_particles_c036_i(save_xml):
         instance="msData/particles/particlesC036.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c035_particles_c035_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16927,11 +17920,12 @@ def test_particles_c035_particles_c035_i(save_xml):
         instance="msData/particles/particlesC035.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c034_particles_c034_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16944,11 +17938,12 @@ def test_particles_c034_particles_c034_v(save_xml):
         instance="msData/particles/particlesC034.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c033_particles_c033_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16962,11 +17957,12 @@ def test_particles_c033_particles_c033_i(save_xml):
         instance="msData/particles/particlesC033.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c032_particles_c032_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16979,11 +17975,12 @@ def test_particles_c032_particles_c032_i(save_xml):
         instance="msData/particles/particlesC032.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c031_particles_c031_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -16996,11 +17993,12 @@ def test_particles_c031_particles_c031_i(save_xml):
         instance="msData/particles/particlesC031.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c030_particles_c030_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -17013,6 +18011,6 @@ def test_particles_c030_particles_c030_v(save_xml):
         instance="msData/particles/particlesC030.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_ms_meta_4000.py
+++ b/tests/test_ms_meta_4000.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_particles_c029_particles_c029_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -15,11 +16,12 @@ def test_particles_c029_particles_c029_v(save_xml):
         instance="msData/particles/particlesC029.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c028_particles_c028_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -32,11 +34,12 @@ def test_particles_c028_particles_c028_v(save_xml):
         instance="msData/particles/particlesC028.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c027_particles_c027_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -49,11 +52,12 @@ def test_particles_c027_particles_c027_v(save_xml):
         instance="msData/particles/particlesC027.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c026_particles_c026_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -67,11 +71,12 @@ def test_particles_c026_particles_c026_i(save_xml):
         instance="msData/particles/particlesC026.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c025_particles_c025_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -84,11 +89,12 @@ def test_particles_c025_particles_c025_i(save_xml):
         instance="msData/particles/particlesC025.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c024_particles_c024_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -101,11 +107,12 @@ def test_particles_c024_particles_c024_i(save_xml):
         instance="msData/particles/particlesC024.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c023_particles_c023_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -118,11 +125,12 @@ def test_particles_c023_particles_c023_i(save_xml):
         instance="msData/particles/particlesC023.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c022_particles_c022_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -136,11 +144,12 @@ def test_particles_c022_particles_c022_i(save_xml):
         instance="msData/particles/particlesC022.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c021_particles_c021_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -153,11 +162,12 @@ def test_particles_c021_particles_c021_v(save_xml):
         instance="msData/particles/particlesC021.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c020_particles_c020_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -170,11 +180,12 @@ def test_particles_c020_particles_c020_i(save_xml):
         instance="msData/particles/particlesC020.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c019_particles_c019_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -187,11 +198,12 @@ def test_particles_c019_particles_c019_i(save_xml):
         instance="msData/particles/particlesC019.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c018_particles_c018_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -204,11 +216,12 @@ def test_particles_c018_particles_c018_i(save_xml):
         instance="msData/particles/particlesC018.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c017_particles_c017_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -221,11 +234,12 @@ def test_particles_c017_particles_c017_i(save_xml):
         instance="msData/particles/particlesC017.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c016_particles_c016_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -238,11 +252,12 @@ def test_particles_c016_particles_c016_v(save_xml):
         instance="msData/particles/particlesC016.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c015_particles_c015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -255,11 +270,12 @@ def test_particles_c015_particles_c015_v(save_xml):
         instance="msData/particles/particlesC015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c014_particles_c014_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -272,11 +288,12 @@ def test_particles_c014_particles_c014_i(save_xml):
         instance="msData/particles/particlesC014.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c013_particles_c013_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -289,11 +306,12 @@ def test_particles_c013_particles_c013_i(save_xml):
         instance="msData/particles/particlesC013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c012_particles_c012_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -306,11 +324,12 @@ def test_particles_c012_particles_c012_i(save_xml):
         instance="msData/particles/particlesC012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c011_particles_c011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -323,11 +342,12 @@ def test_particles_c011_particles_c011_v(save_xml):
         instance="msData/particles/particlesC011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c010_particles_c010_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -342,11 +362,12 @@ def test_particles_c010_particles_c010_i(save_xml):
         instance="msData/particles/particlesC010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c009_particles_c009_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -361,11 +382,12 @@ def test_particles_c009_particles_c009_i(save_xml):
         instance="msData/particles/particlesC009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c008_particles_c008_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -378,11 +400,12 @@ def test_particles_c008_particles_c008_v(save_xml):
         instance="msData/particles/particlesC008.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c007_particles_c007_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -395,11 +418,12 @@ def test_particles_c007_particles_c007_i(save_xml):
         instance="msData/particles/particlesC007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c006_particles_c006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -412,11 +436,12 @@ def test_particles_c006_particles_c006_v(save_xml):
         instance="msData/particles/particlesC006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c005_particles_c005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -429,11 +454,12 @@ def test_particles_c005_particles_c005_v(save_xml):
         instance="msData/particles/particlesC005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c004_particles_c004_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -446,11 +472,12 @@ def test_particles_c004_particles_c004_v(save_xml):
         instance="msData/particles/particlesC004.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c003_particles_c003_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -463,11 +490,12 @@ def test_particles_c003_particles_c003_v(save_xml):
         instance="msData/particles/particlesC003.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c002_particles_c002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -480,11 +508,12 @@ def test_particles_c002_particles_c002_v(save_xml):
         instance="msData/particles/particlesC002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_c001_particles_c001_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -497,11 +526,12 @@ def test_particles_c001_particles_c001_v(save_xml):
         instance="msData/particles/particlesC001.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b015_particles_b015_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -514,11 +544,12 @@ def test_particles_b015_particles_b015_i(save_xml):
         instance="msData/particles/particlesB015.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b014_particles_b014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -531,11 +562,12 @@ def test_particles_b014_particles_b014_v(save_xml):
         instance="msData/particles/particlesB014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b013_particles_b013_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -548,11 +580,12 @@ def test_particles_b013_particles_b013_v(save_xml):
         instance="msData/particles/particlesB013.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b012_particles_b012_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -565,11 +598,12 @@ def test_particles_b012_particles_b012_i(save_xml):
         instance="msData/particles/particlesB012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b011_particles_b011_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -582,11 +616,12 @@ def test_particles_b011_particles_b011_i(save_xml):
         instance="msData/particles/particlesB011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b010_particles_b010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -599,11 +634,12 @@ def test_particles_b010_particles_b010_v(save_xml):
         instance="msData/particles/particlesB010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b009_particles_b009_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -616,11 +652,12 @@ def test_particles_b009_particles_b009_v(save_xml):
         instance="msData/particles/particlesB009.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b008_particles_b008_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -633,11 +670,12 @@ def test_particles_b008_particles_b008_i(save_xml):
         instance="msData/particles/particlesB008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b007_particles_b007_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -650,11 +688,12 @@ def test_particles_b007_particles_b007_i(save_xml):
         instance="msData/particles/particlesB007.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b006_particles_b006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -667,11 +706,12 @@ def test_particles_b006_particles_b006_v(save_xml):
         instance="msData/particles/particlesB006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b005_particles_b005_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -684,11 +724,12 @@ def test_particles_b005_particles_b005_v(save_xml):
         instance="msData/particles/particlesB005.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b004_particles_b004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -701,11 +742,12 @@ def test_particles_b004_particles_b004_i(save_xml):
         instance="msData/particles/particlesB004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b003_particles_b003_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -718,11 +760,12 @@ def test_particles_b003_particles_b003_i(save_xml):
         instance="msData/particles/particlesB003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b002_particles_b002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -735,11 +778,12 @@ def test_particles_b002_particles_b002_v(save_xml):
         instance="msData/particles/particlesB002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_b001_particles_b001_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -752,11 +796,12 @@ def test_particles_b001_particles_b001_i(save_xml):
         instance="msData/particles/particlesB001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a015_particles_a015_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -769,11 +814,12 @@ def test_particles_a015_particles_a015_v(save_xml):
         instance="msData/particles/particlesA015.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a014_particles_a014_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -786,11 +832,12 @@ def test_particles_a014_particles_a014_v(save_xml):
         instance="msData/particles/particlesA014.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a013_particles_a013_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -803,11 +850,12 @@ def test_particles_a013_particles_a013_i(save_xml):
         instance="msData/particles/particlesA013.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a012_particles_a012_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -820,11 +868,12 @@ def test_particles_a012_particles_a012_i(save_xml):
         instance="msData/particles/particlesA012.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a011_particles_a011_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -837,11 +886,12 @@ def test_particles_a011_particles_a011_v(save_xml):
         instance="msData/particles/particlesA011.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a010_particles_a010_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -854,11 +904,12 @@ def test_particles_a010_particles_a010_v(save_xml):
         instance="msData/particles/particlesA010.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a009_particles_a009_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -871,11 +922,12 @@ def test_particles_a009_particles_a009_i(save_xml):
         instance="msData/particles/particlesA009.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a008_particles_a008_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -888,11 +940,12 @@ def test_particles_a008_particles_a008_i(save_xml):
         instance="msData/particles/particlesA008.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a007_particles_a007_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -905,11 +958,12 @@ def test_particles_a007_particles_a007_v(save_xml):
         instance="msData/particles/particlesA007.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a006_particles_a006_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -922,11 +976,12 @@ def test_particles_a006_particles_a006_v(save_xml):
         instance="msData/particles/particlesA006.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a005_particles_a005_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -939,11 +994,12 @@ def test_particles_a005_particles_a005_i(save_xml):
         instance="msData/particles/particlesA005.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a004_particles_a004_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -956,11 +1012,12 @@ def test_particles_a004_particles_a004_i(save_xml):
         instance="msData/particles/particlesA004.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a003_particles_a003_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -973,11 +1030,12 @@ def test_particles_a003_particles_a003_i(save_xml):
         instance="msData/particles/particlesA003.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a002_particles_a002_v(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -990,11 +1048,12 @@ def test_particles_a002_particles_a002_v(save_xml):
         instance="msData/particles/particlesA002.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles_a001_particles_a001_i(save_xml):
     """
     TEST :3.9.1 The Particle Schema Component [ check length of element
@@ -1007,11 +1066,12 @@ def test_particles_a001_particles_a001_i(save_xml):
         instance="msData/particles/particlesA001.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z006i_re_z006i_i(save_xml):
     r"""
     TEST :branch : Invalid characeter mappings from character sequence \c
@@ -1022,11 +1082,12 @@ def test_re_z006i_re_z006i_i(save_xml):
         instance="msData/regex/invalid.c.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z006v_re_z006v_v(save_xml):
     r"""
     TEST :branch : Valid characeter mappings from character sequence \c
@@ -1037,11 +1098,12 @@ def test_re_z006v_re_z006v_v(save_xml):
         instance="msData/regex/valid.c.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z005i_re_z005i_i(save_xml):
     r"""
     TEST :branch : Invalid characeter mappings from character sequence \i
@@ -1052,11 +1114,12 @@ def test_re_z005i_re_z005i_i(save_xml):
         instance="msData/regex/invalid.i.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z005v_re_z005v_v(save_xml):
     r"""
     TEST :branch : Valid characeter mappings from character sequence \i
@@ -1067,11 +1130,12 @@ def test_re_z005v_re_z005v_v(save_xml):
         instance="msData/regex/valid.i.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z004i_re_z004i_i(save_xml):
     r"""
     TEST :branch : Invalid characeter mappings from character sequence \d
@@ -1082,11 +1146,12 @@ def test_re_z004i_re_z004i_i(save_xml):
         instance="msData/regex/invalid.d.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z004v_re_z004v_v(save_xml):
     r"""
     TEST :branch : Valid characeter mappings from character sequence \d
@@ -1097,11 +1162,12 @@ def test_re_z004v_re_z004v_v(save_xml):
         instance="msData/regex/valid.d.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z003v_re_z003v_v(save_xml):
     r"""
     TEST :branch : Valid characeter mappings from character sequence \w
@@ -1112,11 +1178,12 @@ def test_re_z003v_re_z003v_v(save_xml):
         instance="msData/regex/reZ003v.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z002_re_z002_i(save_xml):
     """
     TEST :branch : 381386 : character class escape whack w in pattern
@@ -1128,11 +1195,12 @@ def test_re_z002_re_z002_i(save_xml):
         instance="msData/regex/reZ002.xml",
         instance_is_valid=False,
         class_name="Document",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_z001_re_z001_v(save_xml):
     """
     TEST :branch : XSD: an email regex pattern takes more than one minute
@@ -1144,11 +1212,12 @@ def test_re_z001_re_z001_v(save_xml):
         instance="msData/regex/reZ001.xml",
         instance_is_valid=False,
         class_name="Email",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_specials_specials_v(save_xml):
     """
     TEST :branch : Specials
@@ -1159,11 +1228,12 @@ def test_specials_specials_v(save_xml):
         instance="msData/regex/Specials.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_halfwidthand_fullwidth_forms_halfwidthand_fullwidth_forms_v(save_xml):
     """
     TEST :branch : HalfwidthandFullwidthForms
@@ -1174,11 +1244,12 @@ def test_halfwidthand_fullwidth_forms_halfwidthand_fullwidth_forms_v(save_xml):
         instance="msData/regex/HalfwidthandFullwidthForms.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_small_form_variants_small_form_variants_v(save_xml):
     """
     TEST :branch : SmallFormVariants
@@ -1189,11 +1260,12 @@ def test_small_form_variants_small_form_variants_v(save_xml):
         instance="msData/regex/SmallFormVariants.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cjkcompatibility_forms_cjkcompatibility_forms_v(save_xml):
     """
     TEST :branch : CJKCompatibilityForms
@@ -1204,11 +1276,12 @@ def test_cjkcompatibility_forms_cjkcompatibility_forms_v(save_xml):
         instance="msData/regex/CJKCompatibilityForms.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_combining_half_marks_combining_half_marks_v(save_xml):
     """
     TEST :branch : CombiningHalfMarks
@@ -1219,11 +1292,12 @@ def test_combining_half_marks_combining_half_marks_v(save_xml):
         instance="msData/regex/CombiningHalfMarks.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_arabic_presentation_forms_a_arabic_presentation_forms_a_v(save_xml):
     """
     TEST :branch : ArabicPresentationForms-A
@@ -1234,11 +1308,12 @@ def test_arabic_presentation_forms_a_arabic_presentation_forms_a_v(save_xml):
         instance="msData/regex/ArabicPresentationForms-A.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_alphabetic_presentation_forms_alphabetic_presentation_forms_v(save_xml):
     """
     TEST :branch : AlphabeticPresentationForms
@@ -1249,11 +1324,12 @@ def test_alphabetic_presentation_forms_alphabetic_presentation_forms_v(save_xml)
         instance="msData/regex/AlphabeticPresentationForms.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cjkcompatibility_ideographs_cjkcompatibility_ideographs_v(save_xml):
     """
     TEST :branch : CJKCompatibilityIdeographs
@@ -1264,11 +1340,12 @@ def test_cjkcompatibility_ideographs_cjkcompatibility_ideographs_v(save_xml):
         instance="msData/regex/CJKCompatibilityIdeographs.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_high_surrogates_high_surrogates_i(save_xml):
     """
     TEST :branch : HighSurrogates
@@ -1279,11 +1356,12 @@ def test_high_surrogates_high_surrogates_i(save_xml):
         instance="msData/regex/HighSurrogates.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_yi_radicals_yi_radicals_v(save_xml):
     """
     TEST :branch : YiRadicals
@@ -1294,11 +1372,12 @@ def test_yi_radicals_yi_radicals_v(save_xml):
         instance="msData/regex/YiRadicals.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_yi_syllables_yi_syllables_v(save_xml):
     """
     TEST :branch : YiSyllables
@@ -1309,11 +1388,12 @@ def test_yi_syllables_yi_syllables_v(save_xml):
         instance="msData/regex/YiSyllables.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cjkunified_ideographs_cjkunified_ideographs_v(save_xml):
     """
     TEST :branch : CJKUnifiedIdeographs
@@ -1324,11 +1404,12 @@ def test_cjkunified_ideographs_cjkunified_ideographs_v(save_xml):
         instance="msData/regex/CJKUnifiedIdeographs.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cjkcompatibility_cjkcompatibility_v(save_xml):
     """
     TEST :branch : CJKCompatibility
@@ -1339,11 +1420,12 @@ def test_cjkcompatibility_cjkcompatibility_v(save_xml):
         instance="msData/regex/CJKCompatibility.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_enclosed_cjklettersand_months_enclosed_cjklettersand_months_v(save_xml):
     """
     TEST :branch : EnclosedCJKLettersandMonths
@@ -1354,11 +1436,12 @@ def test_enclosed_cjklettersand_months_enclosed_cjklettersand_months_v(save_xml)
         instance="msData/regex/EnclosedCJKLettersandMonths.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_bopomofo_extended_bopomofo_extended_v(save_xml):
     """
     TEST :branch : BopomofoExtended
@@ -1369,11 +1452,12 @@ def test_bopomofo_extended_bopomofo_extended_v(save_xml):
         instance="msData/regex/BopomofoExtended.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_kanbun_kanbun_v(save_xml):
     """
     TEST :branch : Kanbun
@@ -1384,11 +1468,12 @@ def test_kanbun_kanbun_v(save_xml):
         instance="msData/regex/Kanbun.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hangul_compatibility_jamo_hangul_compatibility_jamo_v(save_xml):
     """
     TEST :branch : HangulCompatibilityJamo
@@ -1399,11 +1484,12 @@ def test_hangul_compatibility_jamo_hangul_compatibility_jamo_v(save_xml):
         instance="msData/regex/HangulCompatibilityJamo.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_bopomofo_bopomofo_v(save_xml):
     """
     TEST :branch : Bopomofo
@@ -1414,11 +1500,12 @@ def test_bopomofo_bopomofo_v(save_xml):
         instance="msData/regex/Bopomofo.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_katakana_katakana_v(save_xml):
     """
     TEST :branch : Katakana
@@ -1429,11 +1516,12 @@ def test_katakana_katakana_v(save_xml):
         instance="msData/regex/Katakana.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hiragana_hiragana_v(save_xml):
     """
     TEST :branch : Hiragana
@@ -1444,11 +1532,12 @@ def test_hiragana_hiragana_v(save_xml):
         instance="msData/regex/Hiragana.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cjksymbolsand_punctuation_cjksymbolsand_punctuation_v(save_xml):
     """
     TEST :branch : CJKSymbolsandPunctuation
@@ -1459,11 +1548,12 @@ def test_cjksymbolsand_punctuation_cjksymbolsand_punctuation_v(save_xml):
         instance="msData/regex/CJKSymbolsandPunctuation.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ideographic_description_characters_ideographic_description_characters_v(save_xml):
     """
     TEST :branch : IdeographicDescriptionCharacters
@@ -1474,11 +1564,12 @@ def test_ideographic_description_characters_ideographic_description_characters_v
         instance="msData/regex/IdeographicDescriptionCharacters.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_kangxi_radicals_kangxi_radicals_v(save_xml):
     """
     TEST :branch : KangxiRadicals
@@ -1489,11 +1580,12 @@ def test_kangxi_radicals_kangxi_radicals_v(save_xml):
         instance="msData/regex/KangxiRadicals.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cjkradicals_supplement_cjkradicals_supplement_v(save_xml):
     """
     TEST :branch : CJKRadicalsSupplement
@@ -1504,11 +1596,12 @@ def test_cjkradicals_supplement_cjkradicals_supplement_v(save_xml):
         instance="msData/regex/CJKRadicalsSupplement.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_braille_patterns_braille_patterns_v(save_xml):
     """
     TEST :branch : BraillePatterns
@@ -1519,11 +1612,12 @@ def test_braille_patterns_braille_patterns_v(save_xml):
         instance="msData/regex/BraillePatterns.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_dingbats_dingbats_v(save_xml):
     """
     TEST :branch : Dingbats
@@ -1534,11 +1628,12 @@ def test_dingbats_dingbats_v(save_xml):
         instance="msData/regex/Dingbats.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_miscellaneous_symbols_miscellaneous_symbols_v(save_xml):
     """
     TEST :branch : MiscellaneousSymbols
@@ -1549,11 +1644,12 @@ def test_miscellaneous_symbols_miscellaneous_symbols_v(save_xml):
         instance="msData/regex/MiscellaneousSymbols.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_geometric_shapes_geometric_shapes_v(save_xml):
     """
     TEST :branch : GeometricShapes
@@ -1564,11 +1660,12 @@ def test_geometric_shapes_geometric_shapes_v(save_xml):
         instance="msData/regex/GeometricShapes.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_block_elements_block_elements_v(save_xml):
     """
     TEST :branch : BlockElements
@@ -1579,11 +1676,12 @@ def test_block_elements_block_elements_v(save_xml):
         instance="msData/regex/BlockElements.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_box_drawing_box_drawing_v(save_xml):
     """
     TEST :branch : BoxDrawing
@@ -1594,11 +1692,12 @@ def test_box_drawing_box_drawing_v(save_xml):
         instance="msData/regex/BoxDrawing.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_enclosed_alphanumerics_enclosed_alphanumerics_v(save_xml):
     """
     TEST :branch : EnclosedAlphanumerics
@@ -1609,11 +1708,12 @@ def test_enclosed_alphanumerics_enclosed_alphanumerics_v(save_xml):
         instance="msData/regex/EnclosedAlphanumerics.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_optical_character_recognition_optical_character_recognition_v(save_xml):
     """
     TEST :branch : OpticalCharacterRecognition
@@ -1624,11 +1724,12 @@ def test_optical_character_recognition_optical_character_recognition_v(save_xml)
         instance="msData/regex/OpticalCharacterRecognition.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_control_pictures_control_pictures_v(save_xml):
     """
     TEST :branch : ControlPictures
@@ -1639,11 +1740,12 @@ def test_control_pictures_control_pictures_v(save_xml):
         instance="msData/regex/ControlPictures.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_miscellaneous_technical_miscellaneous_technical_v(save_xml):
     """
     TEST :branch : MiscellaneousTechnical
@@ -1654,11 +1756,12 @@ def test_miscellaneous_technical_miscellaneous_technical_v(save_xml):
         instance="msData/regex/MiscellaneousTechnical.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mathematical_operators_mathematical_operators_v(save_xml):
     """
     TEST :branch : MathematicalOperators
@@ -1669,11 +1772,12 @@ def test_mathematical_operators_mathematical_operators_v(save_xml):
         instance="msData/regex/MathematicalOperators.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_arrows_arrows_v(save_xml):
     """
     TEST :branch : Arrows
@@ -1684,11 +1788,12 @@ def test_arrows_arrows_v(save_xml):
         instance="msData/regex/Arrows.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_number_forms_number_forms_v(save_xml):
     """
     TEST :branch : NumberForms
@@ -1699,11 +1804,12 @@ def test_number_forms_number_forms_v(save_xml):
         instance="msData/regex/NumberForms.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_letterlike_symbols_letterlike_symbols_v(save_xml):
     """
     TEST :branch : LetterlikeSymbols
@@ -1714,11 +1820,12 @@ def test_letterlike_symbols_letterlike_symbols_v(save_xml):
         instance="msData/regex/LetterlikeSymbols.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_currency_symbols_currency_symbols_v(save_xml):
     """
     TEST :branch : CurrencySymbols
@@ -1729,11 +1836,12 @@ def test_currency_symbols_currency_symbols_v(save_xml):
         instance="msData/regex/CurrencySymbols.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_superscriptsand_subscripts_superscriptsand_subscripts_v(save_xml):
     """
     TEST :branch : SuperscriptsandSubscripts
@@ -1744,11 +1852,12 @@ def test_superscriptsand_subscripts_superscriptsand_subscripts_v(save_xml):
         instance="msData/regex/SuperscriptsandSubscripts.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_general_punctuation_general_punctuation_v(save_xml):
     """
     TEST :branch : GeneralPunctuation
@@ -1759,11 +1868,12 @@ def test_general_punctuation_general_punctuation_v(save_xml):
         instance="msData/regex/GeneralPunctuation.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_greek_extended_greek_extended_v(save_xml):
     """
     TEST :branch : GreekExtended
@@ -1774,11 +1884,12 @@ def test_greek_extended_greek_extended_v(save_xml):
         instance="msData/regex/GreekExtended.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_latin_extended_additional_latin_extended_additional_v(save_xml):
     """
     TEST :branch : LatinExtendedAdditional
@@ -1789,11 +1900,12 @@ def test_latin_extended_additional_latin_extended_additional_v(save_xml):
         instance="msData/regex/LatinExtendedAdditional.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_mongolian_mongolian_v(save_xml):
     """
     TEST :branch : Mongolian
@@ -1804,11 +1916,12 @@ def test_mongolian_mongolian_v(save_xml):
         instance="msData/regex/Mongolian.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_khmer_khmer_v(save_xml):
     """
     TEST :branch : Khmer
@@ -1819,11 +1932,12 @@ def test_khmer_khmer_v(save_xml):
         instance="msData/regex/Khmer.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_runic_runic_v(save_xml):
     """
     TEST :branch : Runic
@@ -1834,11 +1948,12 @@ def test_runic_runic_v(save_xml):
         instance="msData/regex/Runic.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ogham_ogham_v(save_xml):
     """
     TEST :branch : Ogham
@@ -1849,11 +1964,12 @@ def test_ogham_ogham_v(save_xml):
         instance="msData/regex/Ogham.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unified_canadian_aboriginal_syllabics_unified_canadian_aboriginal_syllabics_v(save_xml):
     """
     TEST :branch : UnifiedCanadianAboriginalSyllabics
@@ -1864,11 +1980,12 @@ def test_unified_canadian_aboriginal_syllabics_unified_canadian_aboriginal_sylla
         instance="msData/regex/UnifiedCanadianAboriginalSyllabics.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cherokee_cherokee_v(save_xml):
     """
     TEST :branch : Cherokee
@@ -1879,11 +1996,12 @@ def test_cherokee_cherokee_v(save_xml):
         instance="msData/regex/Cherokee.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ethiopic_ethiopic_v(save_xml):
     """
     TEST :branch : Ethiopic
@@ -1894,11 +2012,12 @@ def test_ethiopic_ethiopic_v(save_xml):
         instance="msData/regex/Ethiopic.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hangul_jamo_hangul_jamo_v(save_xml):
     """
     TEST :branch : HangulJamo
@@ -1909,11 +2028,12 @@ def test_hangul_jamo_hangul_jamo_v(save_xml):
         instance="msData/regex/HangulJamo.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_georgian_georgian_v(save_xml):
     """
     TEST :branch : Georgian
@@ -1924,11 +2044,12 @@ def test_georgian_georgian_v(save_xml):
         instance="msData/regex/Georgian.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_myanmar_myanmar_v(save_xml):
     """
     TEST :branch : Myanmar
@@ -1939,11 +2060,12 @@ def test_myanmar_myanmar_v(save_xml):
         instance="msData/regex/Myanmar.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_tibetan_tibetan_v(save_xml):
     """
     TEST :branch : Tibetan
@@ -1954,11 +2076,12 @@ def test_tibetan_tibetan_v(save_xml):
         instance="msData/regex/Tibetan.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_lao_lao_v(save_xml):
     """
     TEST :branch : Lao
@@ -1969,11 +2092,12 @@ def test_lao_lao_v(save_xml):
         instance="msData/regex/Lao.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_thai_thai_v(save_xml):
     """
     TEST :branch : Thai
@@ -1984,11 +2108,12 @@ def test_thai_thai_v(save_xml):
         instance="msData/regex/Thai.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sinhala_sinhala_v(save_xml):
     """
     TEST :branch : Sinhala
@@ -1999,11 +2124,12 @@ def test_sinhala_sinhala_v(save_xml):
         instance="msData/regex/Sinhala.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_malayalam_malayalam_v(save_xml):
     """
     TEST :branch : Malayalam
@@ -2014,11 +2140,12 @@ def test_malayalam_malayalam_v(save_xml):
         instance="msData/regex/Malayalam.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_kannada_kannada_v(save_xml):
     """
     TEST :branch : Kannada
@@ -2029,11 +2156,12 @@ def test_kannada_kannada_v(save_xml):
         instance="msData/regex/Kannada.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_telugu_telugu_v(save_xml):
     """
     TEST :branch : Telugu
@@ -2044,11 +2172,12 @@ def test_telugu_telugu_v(save_xml):
         instance="msData/regex/Telugu.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_tamil_tamil_v(save_xml):
     """
     TEST :branch : Tamil
@@ -2059,11 +2188,12 @@ def test_tamil_tamil_v(save_xml):
         instance="msData/regex/Tamil.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_oriya_oriya_v(save_xml):
     """
     TEST :branch : Oriya
@@ -2074,11 +2204,12 @@ def test_oriya_oriya_v(save_xml):
         instance="msData/regex/Oriya.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_gujarati_gujarati_v(save_xml):
     """
     TEST :branch : Gujarati
@@ -2089,11 +2220,12 @@ def test_gujarati_gujarati_v(save_xml):
         instance="msData/regex/Gujarati.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_gurmukhi_gurmukhi_v(save_xml):
     """
     TEST :branch : Gurmukhi
@@ -2104,11 +2236,12 @@ def test_gurmukhi_gurmukhi_v(save_xml):
         instance="msData/regex/Gurmukhi.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_bengali_bengali_v(save_xml):
     """
     TEST :branch : Bengali
@@ -2119,11 +2252,12 @@ def test_bengali_bengali_v(save_xml):
         instance="msData/regex/Bengali.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_devanagari_devanagari_v(save_xml):
     """
     TEST :branch : Devanagari
@@ -2134,11 +2268,12 @@ def test_devanagari_devanagari_v(save_xml):
         instance="msData/regex/Devanagari.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_thaana_thaana_v(save_xml):
     """
     TEST :branch : Thaana
@@ -2149,11 +2284,12 @@ def test_thaana_thaana_v(save_xml):
         instance="msData/regex/Thaana.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_syriac_syriac_v(save_xml):
     """
     TEST :branch : Syriac
@@ -2164,11 +2300,12 @@ def test_syriac_syriac_v(save_xml):
         instance="msData/regex/Syriac.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_arabic_arabic_v(save_xml):
     """
     TEST :branch : Arabic
@@ -2179,11 +2316,12 @@ def test_arabic_arabic_v(save_xml):
         instance="msData/regex/Arabic.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_hebrew_hebrew_v(save_xml):
     """
     TEST :branch : Hebrew
@@ -2194,11 +2332,12 @@ def test_hebrew_hebrew_v(save_xml):
         instance="msData/regex/Hebrew.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_armenian_armenian_v(save_xml):
     """
     TEST :branch : Armenian
@@ -2209,11 +2348,12 @@ def test_armenian_armenian_v(save_xml):
         instance="msData/regex/Armenian.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cyrillic_cyrillic_v(save_xml):
     """
     TEST :branch : Cyrillic
@@ -2224,11 +2364,12 @@ def test_cyrillic_cyrillic_v(save_xml):
         instance="msData/regex/Cyrillic.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_combining_diacritical_marks_combining_diacritical_marks_v(save_xml):
     """
     TEST :branch : CombiningDiacriticalMarks
@@ -2239,11 +2380,12 @@ def test_combining_diacritical_marks_combining_diacritical_marks_v(save_xml):
         instance="msData/regex/CombiningDiacriticalMarks.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_spacing_modifier_letters_spacing_modifier_letters_v(save_xml):
     """
     TEST :branch : SpacingModifierLetters
@@ -2254,11 +2396,12 @@ def test_spacing_modifier_letters_spacing_modifier_letters_v(save_xml):
         instance="msData/regex/SpacingModifierLetters.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ipaextensions_ipaextensions_v(save_xml):
     """
     TEST :branch : IPAExtensions
@@ -2269,11 +2412,12 @@ def test_ipaextensions_ipaextensions_v(save_xml):
         instance="msData/regex/IPAExtensions.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_latin_extended_b_latin_extended_b_v(save_xml):
     """
     TEST :branch : LatinExtended-B
@@ -2284,11 +2428,12 @@ def test_latin_extended_b_latin_extended_b_v(save_xml):
         instance="msData/regex/LatinExtended-B.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_latin_extended_a_latin_extended_a_v(save_xml):
     """
     TEST :branch : LatinExtended-A
@@ -2299,11 +2444,12 @@ def test_latin_extended_a_latin_extended_a_v(save_xml):
         instance="msData/regex/LatinExtended-A.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_latin_1_supplement_latin_1_supplement_v(save_xml):
     """
     TEST :branch : Latin-1Supplement
@@ -2314,11 +2460,12 @@ def test_latin_1_supplement_latin_1_supplement_v(save_xml):
         instance="msData/regex/Latin-1Supplement.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basic_latin_basic_latin_v(save_xml):
     """
     TEST :branch : BasicLatin
@@ -2329,11 +2476,12 @@ def test_basic_latin_basic_latin_v(save_xml):
         instance="msData/regex/BasicLatin.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_535_regex_test_535_v(save_xml):
     """
     TEST :branch : RegexTest_535
@@ -2344,11 +2492,12 @@ def test_regex_test_535_regex_test_535_v(save_xml):
         instance="msData/regex/RegexTest_535.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_533_regex_test_533_i(save_xml):
     """
     TEST :branch : RegexTest_533
@@ -2359,11 +2508,12 @@ def test_regex_test_533_regex_test_533_i(save_xml):
         instance="msData/regex/RegexTest_533.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_532_regex_test_532_i(save_xml):
     """
     TEST :branch : RegexTest_532
@@ -2374,11 +2524,12 @@ def test_regex_test_532_regex_test_532_i(save_xml):
         instance="msData/regex/RegexTest_532.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_531_regex_test_531_i(save_xml):
     """
     TEST :branch : RegexTest_531
@@ -2389,11 +2540,12 @@ def test_regex_test_531_regex_test_531_i(save_xml):
         instance="msData/regex/RegexTest_531.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_530_regex_test_530_v(save_xml):
     """
     TEST :branch : RegexTest_530
@@ -2404,11 +2556,12 @@ def test_regex_test_530_regex_test_530_v(save_xml):
         instance="msData/regex/RegexTest_530.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_529_regex_test_529_i(save_xml):
     """
     TEST :branch : RegexTest_529
@@ -2419,11 +2572,12 @@ def test_regex_test_529_regex_test_529_i(save_xml):
         instance="msData/regex/RegexTest_529.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_528_regex_test_528_i(save_xml):
     """
     TEST :branch : RegexTest_528
@@ -2434,11 +2588,12 @@ def test_regex_test_528_regex_test_528_i(save_xml):
         instance="msData/regex/RegexTest_528.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_525_regex_test_525_v(save_xml):
     """
     TEST :branch : RegexTest_525
@@ -2449,11 +2604,12 @@ def test_regex_test_525_regex_test_525_v(save_xml):
         instance="msData/regex/RegexTest_525.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_522_regex_test_522_v(save_xml):
     """
     TEST :branch : RegexTest_522
@@ -2464,11 +2620,12 @@ def test_regex_test_522_regex_test_522_v(save_xml):
         instance="msData/regex/RegexTest_522.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_520_regex_test_520_i(save_xml):
     """
     TEST :branch : RegexTest_520
@@ -2479,11 +2636,12 @@ def test_regex_test_520_regex_test_520_i(save_xml):
         instance="msData/regex/RegexTest_520.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_515_regex_test_515_v(save_xml):
     """
     TEST :branch : RegexTest_515
@@ -2494,11 +2652,12 @@ def test_regex_test_515_regex_test_515_v(save_xml):
         instance="msData/regex/RegexTest_515.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_514_regex_test_514_i(save_xml):
     """
     TEST :branch : RegexTest_514
@@ -2509,11 +2668,12 @@ def test_regex_test_514_regex_test_514_i(save_xml):
         instance="msData/regex/RegexTest_514.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_513_regex_test_513_v(save_xml):
     """
     TEST :branch : RegexTest_513
@@ -2524,11 +2684,12 @@ def test_regex_test_513_regex_test_513_v(save_xml):
         instance="msData/regex/RegexTest_513.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_508_regex_test_508_i(save_xml):
     """
     TEST :branch : RegexTest_508
@@ -2539,11 +2700,12 @@ def test_regex_test_508_regex_test_508_i(save_xml):
         instance="msData/regex/RegexTest_508.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_506_regex_test_506_i(save_xml):
     """
     TEST :branch : RegexTest_506
@@ -2554,11 +2716,12 @@ def test_regex_test_506_regex_test_506_i(save_xml):
         instance="msData/regex/RegexTest_506.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_504_regex_test_504_i(save_xml):
     """
     TEST :branch : RegexTest_504
@@ -2569,11 +2732,12 @@ def test_regex_test_504_regex_test_504_i(save_xml):
         instance="msData/regex/RegexTest_504.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_503_regex_test_503_i(save_xml):
     """
     TEST :branch : RegexTest_503
@@ -2584,11 +2748,12 @@ def test_regex_test_503_regex_test_503_i(save_xml):
         instance="msData/regex/RegexTest_503.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_502_regex_test_502_i(save_xml):
     """
     TEST :branch : RegexTest_502
@@ -2599,11 +2764,12 @@ def test_regex_test_502_regex_test_502_i(save_xml):
         instance="msData/regex/RegexTest_502.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_501_regex_test_501_i(save_xml):
     """
     TEST :branch : RegexTest_501
@@ -2614,11 +2780,12 @@ def test_regex_test_501_regex_test_501_i(save_xml):
         instance="msData/regex/RegexTest_501.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_500_regex_test_500_i(save_xml):
     """
     TEST :branch : RegexTest_500
@@ -2629,11 +2796,12 @@ def test_regex_test_500_regex_test_500_i(save_xml):
         instance="msData/regex/RegexTest_500.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_499_regex_test_499_i(save_xml):
     """
     TEST :branch : RegexTest_499
@@ -2644,11 +2812,12 @@ def test_regex_test_499_regex_test_499_i(save_xml):
         instance="msData/regex/RegexTest_499.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_498_regex_test_498_i(save_xml):
     """
     TEST :branch : RegexTest_498
@@ -2659,11 +2828,12 @@ def test_regex_test_498_regex_test_498_i(save_xml):
         instance="msData/regex/RegexTest_498.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_497_regex_test_497_i(save_xml):
     """
     TEST :branch : RegexTest_497
@@ -2674,11 +2844,12 @@ def test_regex_test_497_regex_test_497_i(save_xml):
         instance="msData/regex/RegexTest_497.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_496_regex_test_496_i(save_xml):
     """
     TEST :branch : RegexTest_496
@@ -2689,11 +2860,12 @@ def test_regex_test_496_regex_test_496_i(save_xml):
         instance="msData/regex/RegexTest_496.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_495_regex_test_495_v(save_xml):
     """
     TEST :branch : RegexTest_495
@@ -2704,11 +2876,12 @@ def test_regex_test_495_regex_test_495_v(save_xml):
         instance="msData/regex/RegexTest_495.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_494_regex_test_494_i(save_xml):
     """
     TEST :branch : RegexTest_494
@@ -2719,11 +2892,12 @@ def test_regex_test_494_regex_test_494_i(save_xml):
         instance="msData/regex/RegexTest_494.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_493_regex_test_493_i(save_xml):
     """
     TEST :branch : RegexTest_493
@@ -2734,11 +2908,12 @@ def test_regex_test_493_regex_test_493_i(save_xml):
         instance="msData/regex/RegexTest_493.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_492_regex_test_492_i(save_xml):
     """
     TEST :branch : RegexTest_492
@@ -2749,11 +2924,12 @@ def test_regex_test_492_regex_test_492_i(save_xml):
         instance="msData/regex/RegexTest_492.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_491_regex_test_491_i(save_xml):
     """
     TEST :branch : RegexTest_491
@@ -2764,11 +2940,12 @@ def test_regex_test_491_regex_test_491_i(save_xml):
         instance="msData/regex/RegexTest_491.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_489_regex_test_489_i(save_xml):
     """
     TEST :branch : RegexTest_489
@@ -2779,11 +2956,12 @@ def test_regex_test_489_regex_test_489_i(save_xml):
         instance="msData/regex/RegexTest_489.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_488_regex_test_488_i(save_xml):
     """
     TEST :branch : RegexTest_488
@@ -2794,11 +2972,12 @@ def test_regex_test_488_regex_test_488_i(save_xml):
         instance="msData/regex/RegexTest_488.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_476_regex_test_476_i(save_xml):
     """
     TEST :branch : RegexTest_476
@@ -2809,11 +2988,12 @@ def test_regex_test_476_regex_test_476_i(save_xml):
         instance="msData/regex/RegexTest_476.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_475_regex_test_475_i(save_xml):
     """
     TEST :branch : RegexTest_475
@@ -2824,11 +3004,12 @@ def test_regex_test_475_regex_test_475_i(save_xml):
         instance="msData/regex/RegexTest_475.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_474_regex_test_474_i(save_xml):
     """
     TEST :branch : RegexTest_474
@@ -2839,11 +3020,12 @@ def test_regex_test_474_regex_test_474_i(save_xml):
         instance="msData/regex/RegexTest_474.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_468_regex_test_468_i(save_xml):
     """
     TEST :branch : RegexTest_468
@@ -2854,11 +3036,12 @@ def test_regex_test_468_regex_test_468_i(save_xml):
         instance="msData/regex/RegexTest_468.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_467_regex_test_467_i(save_xml):
     """
     TEST :branch : RegexTest_467
@@ -2869,11 +3052,12 @@ def test_regex_test_467_regex_test_467_i(save_xml):
         instance="msData/regex/RegexTest_467.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_466_regex_test_466_i(save_xml):
     """
     TEST :branch : RegexTest_466
@@ -2884,11 +3068,12 @@ def test_regex_test_466_regex_test_466_i(save_xml):
         instance="msData/regex/RegexTest_466.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_462_regex_test_462_i(save_xml):
     """
     TEST :branch : RegexTest_462
@@ -2899,11 +3084,12 @@ def test_regex_test_462_regex_test_462_i(save_xml):
         instance="msData/regex/RegexTest_462.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_461_regex_test_461_i(save_xml):
     """
     TEST :branch : RegexTest_461
@@ -2914,11 +3100,12 @@ def test_regex_test_461_regex_test_461_i(save_xml):
         instance="msData/regex/RegexTest_461.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_460_regex_test_460_i(save_xml):
     """
     TEST :branch : RegexTest_460
@@ -2929,11 +3116,12 @@ def test_regex_test_460_regex_test_460_i(save_xml):
         instance="msData/regex/RegexTest_460.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_459_regex_test_459_i(save_xml):
     """
     TEST :branch : RegexTest_459
@@ -2944,11 +3132,12 @@ def test_regex_test_459_regex_test_459_i(save_xml):
         instance="msData/regex/RegexTest_459.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_439_regex_test_439_i(save_xml):
     """
     TEST :branch : RegexTest_439
@@ -2959,11 +3148,12 @@ def test_regex_test_439_regex_test_439_i(save_xml):
         instance="msData/regex/RegexTest_439.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_438_regex_test_438_i(save_xml):
     """
     TEST :branch : RegexTest_438
@@ -2974,11 +3164,12 @@ def test_regex_test_438_regex_test_438_i(save_xml):
         instance="msData/regex/RegexTest_438.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_434_regex_test_434_i(save_xml):
     """
     TEST :branch : RegexTest_434
@@ -2989,11 +3180,12 @@ def test_regex_test_434_regex_test_434_i(save_xml):
         instance="msData/regex/RegexTest_434.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_433_regex_test_433_i(save_xml):
     """
     TEST :branch : RegexTest_433
@@ -3004,11 +3196,12 @@ def test_regex_test_433_regex_test_433_i(save_xml):
         instance="msData/regex/RegexTest_433.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_430_regex_test_430_i(save_xml):
     """
     TEST :branch : RegexTest_430
@@ -3019,11 +3212,12 @@ def test_regex_test_430_regex_test_430_i(save_xml):
         instance="msData/regex/RegexTest_430.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_429_regex_test_429_i(save_xml):
     """
     TEST :branch : RegexTest_429
@@ -3034,11 +3228,12 @@ def test_regex_test_429_regex_test_429_i(save_xml):
         instance="msData/regex/RegexTest_429.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_426_regex_test_426_i(save_xml):
     """
     TEST :branch : RegexTest_426
@@ -3049,11 +3244,12 @@ def test_regex_test_426_regex_test_426_i(save_xml):
         instance="msData/regex/RegexTest_426.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_425_regex_test_425_i(save_xml):
     """
     TEST :branch : RegexTest_425
@@ -3064,11 +3260,12 @@ def test_regex_test_425_regex_test_425_i(save_xml):
         instance="msData/regex/RegexTest_425.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_424_regex_test_424_i(save_xml):
     """
     TEST :branch : RegexTest_424
@@ -3079,11 +3276,12 @@ def test_regex_test_424_regex_test_424_i(save_xml):
         instance="msData/regex/RegexTest_424.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_422_regex_test_422_i(save_xml):
     """
     TEST :branch : RegexTest_422
@@ -3094,11 +3292,12 @@ def test_regex_test_422_regex_test_422_i(save_xml):
         instance="msData/regex/RegexTest_422.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_421_regex_test_421_i(save_xml):
     """
     TEST :branch : RegexTest_421
@@ -3109,11 +3308,12 @@ def test_regex_test_421_regex_test_421_i(save_xml):
         instance="msData/regex/RegexTest_421.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_420_regex_test_420_i(save_xml):
     """
     TEST :branch : RegexTest_420
@@ -3124,11 +3324,12 @@ def test_regex_test_420_regex_test_420_i(save_xml):
         instance="msData/regex/RegexTest_420.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_375_regex_test_375_i(save_xml):
     """
     TEST :branch : RegexTest_375
@@ -3139,11 +3340,12 @@ def test_regex_test_375_regex_test_375_i(save_xml):
         instance="msData/regex/RegexTest_375.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_374_regex_test_374_i(save_xml):
     """
     TEST :branch : RegexTest_374
@@ -3154,11 +3356,12 @@ def test_regex_test_374_regex_test_374_i(save_xml):
         instance="msData/regex/RegexTest_374.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_373_regex_test_373_i(save_xml):
     """
     TEST :branch : RegexTest_373
@@ -3169,11 +3372,12 @@ def test_regex_test_373_regex_test_373_i(save_xml):
         instance="msData/regex/RegexTest_373.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_372_regex_test_372_i(save_xml):
     """
     TEST :branch : RegexTest_372
@@ -3184,11 +3388,12 @@ def test_regex_test_372_regex_test_372_i(save_xml):
         instance="msData/regex/RegexTest_372.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_371_regex_test_371_i(save_xml):
     """
     TEST :branch : RegexTest_371
@@ -3199,11 +3404,12 @@ def test_regex_test_371_regex_test_371_i(save_xml):
         instance="msData/regex/RegexTest_371.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_370_regex_test_370_i(save_xml):
     """
     TEST :branch : RegexTest_370
@@ -3214,11 +3420,12 @@ def test_regex_test_370_regex_test_370_i(save_xml):
         instance="msData/regex/RegexTest_370.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_367_regex_test_367_i(save_xml):
     """
     TEST :branch : RegexTest_367
@@ -3229,11 +3436,12 @@ def test_regex_test_367_regex_test_367_i(save_xml):
         instance="msData/regex/RegexTest_367.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_365_regex_test_365_i(save_xml):
     """
     TEST :branch : RegexTest_365
@@ -3244,11 +3452,12 @@ def test_regex_test_365_regex_test_365_i(save_xml):
         instance="msData/regex/RegexTest_365.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_364_regex_test_364_i(save_xml):
     """
     TEST :branch : RegexTest_364
@@ -3259,11 +3468,12 @@ def test_regex_test_364_regex_test_364_i(save_xml):
         instance="msData/regex/RegexTest_364.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_363_regex_test_363_i(save_xml):
     """
     TEST :branch : RegexTest_363
@@ -3274,11 +3484,12 @@ def test_regex_test_363_regex_test_363_i(save_xml):
         instance="msData/regex/RegexTest_363.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_359_regex_test_359_i(save_xml):
     """
     TEST :branch : RegexTest_359
@@ -3289,11 +3500,12 @@ def test_regex_test_359_regex_test_359_i(save_xml):
         instance="msData/regex/RegexTest_359.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_358_regex_test_358_i(save_xml):
     """
     TEST :branch : RegexTest_358
@@ -3304,11 +3516,12 @@ def test_regex_test_358_regex_test_358_i(save_xml):
         instance="msData/regex/RegexTest_358.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_357_regex_test_357_i(save_xml):
     """
     TEST :branch : RegexTest_357
@@ -3319,11 +3532,12 @@ def test_regex_test_357_regex_test_357_i(save_xml):
         instance="msData/regex/RegexTest_357.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_356_regex_test_356_i(save_xml):
     """
     TEST :branch : RegexTest_356
@@ -3334,11 +3548,12 @@ def test_regex_test_356_regex_test_356_i(save_xml):
         instance="msData/regex/RegexTest_356.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_354_regex_test_354_i(save_xml):
     """
     TEST :branch : RegexTest_354
@@ -3349,11 +3564,12 @@ def test_regex_test_354_regex_test_354_i(save_xml):
         instance="msData/regex/RegexTest_354.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_353_regex_test_353_i(save_xml):
     """
     TEST :branch : RegexTest_353
@@ -3364,11 +3580,12 @@ def test_regex_test_353_regex_test_353_i(save_xml):
         instance="msData/regex/RegexTest_353.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_352_regex_test_352_i(save_xml):
     """
     TEST :branch : RegexTest_352
@@ -3379,11 +3596,12 @@ def test_regex_test_352_regex_test_352_i(save_xml):
         instance="msData/regex/RegexTest_352.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_350_regex_test_350_i(save_xml):
     """
     TEST :branch : RegexTest_350
@@ -3394,11 +3612,12 @@ def test_regex_test_350_regex_test_350_i(save_xml):
         instance="msData/regex/RegexTest_350.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_349_regex_test_349_i(save_xml):
     """
     TEST :branch : RegexTest_349
@@ -3409,11 +3628,12 @@ def test_regex_test_349_regex_test_349_i(save_xml):
         instance="msData/regex/RegexTest_349.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_348_regex_test_348_i(save_xml):
     """
     TEST :branch : RegexTest_348
@@ -3424,11 +3644,12 @@ def test_regex_test_348_regex_test_348_i(save_xml):
         instance="msData/regex/RegexTest_348.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_347_regex_test_347_i(save_xml):
     """
     TEST :branch : RegexTest_347
@@ -3439,11 +3660,12 @@ def test_regex_test_347_regex_test_347_i(save_xml):
         instance="msData/regex/RegexTest_347.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_346_regex_test_346_i(save_xml):
     """
     TEST :branch : RegexTest_346
@@ -3454,11 +3676,12 @@ def test_regex_test_346_regex_test_346_i(save_xml):
         instance="msData/regex/RegexTest_346.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_345_regex_test_345_i(save_xml):
     """
     TEST :branch : RegexTest_345
@@ -3469,11 +3692,12 @@ def test_regex_test_345_regex_test_345_i(save_xml):
         instance="msData/regex/RegexTest_345.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_344_regex_test_344_i(save_xml):
     """
     TEST :branch : RegexTest_344
@@ -3484,11 +3708,12 @@ def test_regex_test_344_regex_test_344_i(save_xml):
         instance="msData/regex/RegexTest_344.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_343_regex_test_343_i(save_xml):
     """
     TEST :branch : RegexTest_343
@@ -3499,11 +3724,12 @@ def test_regex_test_343_regex_test_343_i(save_xml):
         instance="msData/regex/RegexTest_343.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_342_regex_test_342_i(save_xml):
     """
     TEST :branch : RegexTest_342
@@ -3514,11 +3740,12 @@ def test_regex_test_342_regex_test_342_i(save_xml):
         instance="msData/regex/RegexTest_342.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_341_regex_test_341_i(save_xml):
     """
     TEST :branch : RegexTest_341
@@ -3529,11 +3756,12 @@ def test_regex_test_341_regex_test_341_i(save_xml):
         instance="msData/regex/RegexTest_341.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_340_regex_test_340_i(save_xml):
     """
     TEST :branch : RegexTest_340
@@ -3544,11 +3772,12 @@ def test_regex_test_340_regex_test_340_i(save_xml):
         instance="msData/regex/RegexTest_340.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_339_regex_test_339_i(save_xml):
     """
     TEST :branch : RegexTest_339
@@ -3559,11 +3788,12 @@ def test_regex_test_339_regex_test_339_i(save_xml):
         instance="msData/regex/RegexTest_339.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_337_regex_test_337_i(save_xml):
     """
     TEST :branch : RegexTest_337
@@ -3574,11 +3804,12 @@ def test_regex_test_337_regex_test_337_i(save_xml):
         instance="msData/regex/RegexTest_337.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_336_regex_test_336_i(save_xml):
     """
     TEST :branch : RegexTest_336
@@ -3589,11 +3820,12 @@ def test_regex_test_336_regex_test_336_i(save_xml):
         instance="msData/regex/RegexTest_336.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_335_regex_test_335_i(save_xml):
     """
     TEST :branch : RegexTest_335
@@ -3604,11 +3836,12 @@ def test_regex_test_335_regex_test_335_i(save_xml):
         instance="msData/regex/RegexTest_335.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_334_regex_test_334_i(save_xml):
     """
     TEST :branch : RegexTest_334
@@ -3619,11 +3852,12 @@ def test_regex_test_334_regex_test_334_i(save_xml):
         instance="msData/regex/RegexTest_334.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_333_regex_test_333_i(save_xml):
     """
     TEST :branch : RegexTest_333
@@ -3634,11 +3868,12 @@ def test_regex_test_333_regex_test_333_i(save_xml):
         instance="msData/regex/RegexTest_333.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_332_regex_test_332_i(save_xml):
     """
     TEST :branch : RegexTest_332
@@ -3649,11 +3884,12 @@ def test_regex_test_332_regex_test_332_i(save_xml):
         instance="msData/regex/RegexTest_332.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_329_regex_test_329_i(save_xml):
     """
     TEST :branch : RegexTest_329
@@ -3664,11 +3900,12 @@ def test_regex_test_329_regex_test_329_i(save_xml):
         instance="msData/regex/RegexTest_329.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_328_regex_test_328_i(save_xml):
     """
     TEST :branch : RegexTest_328
@@ -3679,11 +3916,12 @@ def test_regex_test_328_regex_test_328_i(save_xml):
         instance="msData/regex/RegexTest_328.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_327_regex_test_327_i(save_xml):
     """
     TEST :branch : RegexTest_327
@@ -3694,11 +3932,12 @@ def test_regex_test_327_regex_test_327_i(save_xml):
         instance="msData/regex/RegexTest_327.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_326_regex_test_326_i(save_xml):
     """
     TEST :branch : RegexTest_326
@@ -3709,11 +3948,12 @@ def test_regex_test_326_regex_test_326_i(save_xml):
         instance="msData/regex/RegexTest_326.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_325_regex_test_325_i(save_xml):
     """
     TEST :branch : RegexTest_325
@@ -3724,11 +3964,12 @@ def test_regex_test_325_regex_test_325_i(save_xml):
         instance="msData/regex/RegexTest_325.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_324_regex_test_324_i(save_xml):
     """
     TEST :branch : RegexTest_324
@@ -3739,11 +3980,12 @@ def test_regex_test_324_regex_test_324_i(save_xml):
         instance="msData/regex/RegexTest_324.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_323_regex_test_323_i(save_xml):
     """
     TEST :branch : RegexTest_323
@@ -3754,11 +3996,12 @@ def test_regex_test_323_regex_test_323_i(save_xml):
         instance="msData/regex/RegexTest_323.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_322_regex_test_322_i(save_xml):
     """
     TEST :branch : RegexTest_322
@@ -3769,11 +4012,12 @@ def test_regex_test_322_regex_test_322_i(save_xml):
         instance="msData/regex/RegexTest_322.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_319_regex_test_319_v(save_xml):
     """
     TEST :branch : RegexTest_319
@@ -3784,11 +4028,12 @@ def test_regex_test_319_regex_test_319_v(save_xml):
         instance="msData/regex/RegexTest_319.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_286_regex_test_286_i(save_xml):
     """
     TEST :branch : RegexTest_286
@@ -3799,11 +4044,12 @@ def test_regex_test_286_regex_test_286_i(save_xml):
         instance="msData/regex/RegexTest_286.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_285_regex_test_285_i(save_xml):
     """
     TEST :branch : RegexTest_285
@@ -3814,11 +4060,12 @@ def test_regex_test_285_regex_test_285_i(save_xml):
         instance="msData/regex/RegexTest_285.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_284_regex_test_284_i(save_xml):
     """
     TEST :branch : RegexTest_284
@@ -3829,11 +4076,12 @@ def test_regex_test_284_regex_test_284_i(save_xml):
         instance="msData/regex/RegexTest_284.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_283_regex_test_283_i(save_xml):
     """
     TEST :branch : RegexTest_283
@@ -3844,11 +4092,12 @@ def test_regex_test_283_regex_test_283_i(save_xml):
         instance="msData/regex/RegexTest_283.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_282_regex_test_282_i(save_xml):
     """
     TEST :branch : RegexTest_282
@@ -3859,11 +4108,12 @@ def test_regex_test_282_regex_test_282_i(save_xml):
         instance="msData/regex/RegexTest_282.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_281_regex_test_281_i(save_xml):
     """
     TEST :branch : RegexTest_281
@@ -3874,11 +4124,12 @@ def test_regex_test_281_regex_test_281_i(save_xml):
         instance="msData/regex/RegexTest_281.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_280_regex_test_280_i(save_xml):
     """
     TEST :branch : RegexTest_280
@@ -3889,11 +4140,12 @@ def test_regex_test_280_regex_test_280_i(save_xml):
         instance="msData/regex/RegexTest_280.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_279_regex_test_279_i(save_xml):
     """
     TEST :branch : RegexTest_279
@@ -3904,11 +4156,12 @@ def test_regex_test_279_regex_test_279_i(save_xml):
         instance="msData/regex/RegexTest_279.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_278_regex_test_278_i(save_xml):
     """
     TEST :branch : RegexTest_278
@@ -3919,11 +4172,12 @@ def test_regex_test_278_regex_test_278_i(save_xml):
         instance="msData/regex/RegexTest_278.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_277_regex_test_277_i(save_xml):
     """
     TEST :branch : RegexTest_277
@@ -3934,11 +4188,12 @@ def test_regex_test_277_regex_test_277_i(save_xml):
         instance="msData/regex/RegexTest_277.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_276_regex_test_276_i(save_xml):
     """
     TEST :branch : RegexTest_276
@@ -3949,11 +4204,12 @@ def test_regex_test_276_regex_test_276_i(save_xml):
         instance="msData/regex/RegexTest_276.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_275_regex_test_275_i(save_xml):
     """
     TEST :branch : RegexTest_275
@@ -3964,11 +4220,12 @@ def test_regex_test_275_regex_test_275_i(save_xml):
         instance="msData/regex/RegexTest_275.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_274_regex_test_274_i(save_xml):
     """
     TEST :branch : RegexTest_274
@@ -3979,11 +4236,12 @@ def test_regex_test_274_regex_test_274_i(save_xml):
         instance="msData/regex/RegexTest_274.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_273_regex_test_273_i(save_xml):
     """
     TEST :branch : RegexTest_273
@@ -3994,11 +4252,12 @@ def test_regex_test_273_regex_test_273_i(save_xml):
         instance="msData/regex/RegexTest_273.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_272_regex_test_272_i(save_xml):
     """
     TEST :branch : RegexTest_272
@@ -4009,11 +4268,12 @@ def test_regex_test_272_regex_test_272_i(save_xml):
         instance="msData/regex/RegexTest_272.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_271_regex_test_271_i(save_xml):
     """
     TEST :branch : RegexTest_271
@@ -4024,11 +4284,12 @@ def test_regex_test_271_regex_test_271_i(save_xml):
         instance="msData/regex/RegexTest_271.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_270_regex_test_270_i(save_xml):
     """
     TEST :branch : RegexTest_270
@@ -4039,11 +4300,12 @@ def test_regex_test_270_regex_test_270_i(save_xml):
         instance="msData/regex/RegexTest_270.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_269_regex_test_269_i(save_xml):
     """
     TEST :branch : RegexTest_269
@@ -4054,11 +4316,12 @@ def test_regex_test_269_regex_test_269_i(save_xml):
         instance="msData/regex/RegexTest_269.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_268_regex_test_268_i(save_xml):
     """
     TEST :branch : RegexTest_268
@@ -4069,11 +4332,12 @@ def test_regex_test_268_regex_test_268_i(save_xml):
         instance="msData/regex/RegexTest_268.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_267_regex_test_267_i(save_xml):
     """
     TEST :branch : RegexTest_267
@@ -4084,11 +4348,12 @@ def test_regex_test_267_regex_test_267_i(save_xml):
         instance="msData/regex/RegexTest_267.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_264_regex_test_264_v(save_xml):
     """
     TEST :branch : RegexTest_264
@@ -4099,11 +4364,12 @@ def test_regex_test_264_regex_test_264_v(save_xml):
         instance="msData/regex/RegexTest_264.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_263_regex_test_263_v(save_xml):
     """
     TEST :branch : RegexTest_263
@@ -4114,11 +4380,12 @@ def test_regex_test_263_regex_test_263_v(save_xml):
         instance="msData/regex/RegexTest_263.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_262_regex_test_262_v(save_xml):
     """
     TEST :branch : RegexTest_262
@@ -4129,11 +4396,12 @@ def test_regex_test_262_regex_test_262_v(save_xml):
         instance="msData/regex/RegexTest_262.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_261_regex_test_261_v(save_xml):
     """
     TEST :branch : RegexTest_261
@@ -4144,11 +4412,12 @@ def test_regex_test_261_regex_test_261_v(save_xml):
         instance="msData/regex/RegexTest_261.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_260_regex_test_260_v(save_xml):
     """
     TEST :branch : RegexTest_260
@@ -4159,11 +4428,12 @@ def test_regex_test_260_regex_test_260_v(save_xml):
         instance="msData/regex/RegexTest_260.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_259_regex_test_259_v(save_xml):
     """
     TEST :branch : RegexTest_259
@@ -4174,11 +4444,12 @@ def test_regex_test_259_regex_test_259_v(save_xml):
         instance="msData/regex/RegexTest_259.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_255_regex_test_255_i(save_xml):
     """
     TEST :branch : RegexTest_255
@@ -4189,11 +4460,12 @@ def test_regex_test_255_regex_test_255_i(save_xml):
         instance="msData/regex/RegexTest_255.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_254_regex_test_254_i(save_xml):
     """
     TEST :branch : RegexTest_254
@@ -4204,11 +4476,12 @@ def test_regex_test_254_regex_test_254_i(save_xml):
         instance="msData/regex/RegexTest_254.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_253_regex_test_253_i(save_xml):
     """
     TEST :branch : RegexTest_253
@@ -4219,11 +4492,12 @@ def test_regex_test_253_regex_test_253_i(save_xml):
         instance="msData/regex/RegexTest_253.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_252_regex_test_252_i(save_xml):
     """
     TEST :branch : RegexTest_252
@@ -4234,11 +4508,12 @@ def test_regex_test_252_regex_test_252_i(save_xml):
         instance="msData/regex/RegexTest_252.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_251_regex_test_251_i(save_xml):
     """
     TEST :branch : RegexTest_251
@@ -4249,11 +4524,12 @@ def test_regex_test_251_regex_test_251_i(save_xml):
         instance="msData/regex/RegexTest_251.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_250_regex_test_250_i(save_xml):
     """
     TEST :branch : RegexTest_250
@@ -4264,11 +4540,12 @@ def test_regex_test_250_regex_test_250_i(save_xml):
         instance="msData/regex/RegexTest_250.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_239_regex_test_239_i(save_xml):
     """
     TEST :branch : RegexTest_239
@@ -4279,11 +4556,12 @@ def test_regex_test_239_regex_test_239_i(save_xml):
         instance="msData/regex/RegexTest_239.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_236_regex_test_236_i(save_xml):
     """
     TEST :branch : RegexTest_236
@@ -4294,11 +4572,12 @@ def test_regex_test_236_regex_test_236_i(save_xml):
         instance="msData/regex/RegexTest_236.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_235_regex_test_235_i(save_xml):
     """
     TEST :branch : RegexTest_235
@@ -4309,11 +4588,12 @@ def test_regex_test_235_regex_test_235_i(save_xml):
         instance="msData/regex/RegexTest_235.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_234_regex_test_234_v(save_xml):
     """
     TEST :branch : RegexTest_234
@@ -4324,11 +4604,12 @@ def test_regex_test_234_regex_test_234_v(save_xml):
         instance="msData/regex/RegexTest_234.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_182_regex_test_182_i(save_xml):
     """
     TEST :branch : RegexTest_182
@@ -4339,11 +4620,12 @@ def test_regex_test_182_regex_test_182_i(save_xml):
         instance="msData/regex/RegexTest_182.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_181_regex_test_181_i(save_xml):
     """
     TEST :branch : RegexTest_181
@@ -4354,11 +4636,12 @@ def test_regex_test_181_regex_test_181_i(save_xml):
         instance="msData/regex/RegexTest_181.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_180_regex_test_180_i(save_xml):
     """
     TEST :branch : RegexTest_180
@@ -4369,11 +4652,12 @@ def test_regex_test_180_regex_test_180_i(save_xml):
         instance="msData/regex/RegexTest_180.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_177_regex_test_177_i(save_xml):
     """
     TEST :branch : RegexTest_177
@@ -4384,11 +4668,12 @@ def test_regex_test_177_regex_test_177_i(save_xml):
         instance="msData/regex/RegexTest_177.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_176_regex_test_176_i(save_xml):
     """
     TEST :branch : RegexTest_176
@@ -4399,11 +4684,12 @@ def test_regex_test_176_regex_test_176_i(save_xml):
         instance="msData/regex/RegexTest_176.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_175_regex_test_175_i(save_xml):
     """
     TEST :branch : RegexTest_175
@@ -4414,11 +4700,12 @@ def test_regex_test_175_regex_test_175_i(save_xml):
         instance="msData/regex/RegexTest_175.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_118_regex_test_118_i(save_xml):
     """
     TEST :branch : RegexTest_118
@@ -4429,11 +4716,12 @@ def test_regex_test_118_regex_test_118_i(save_xml):
         instance="msData/regex/RegexTest_118.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_117_regex_test_117_i(save_xml):
     """
     TEST :branch : RegexTest_117
@@ -4444,11 +4732,12 @@ def test_regex_test_117_regex_test_117_i(save_xml):
         instance="msData/regex/RegexTest_117.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_81_regex_test_81_v(save_xml):
     """
     TEST :branch : RegexTest_81
@@ -4459,11 +4748,12 @@ def test_regex_test_81_regex_test_81_v(save_xml):
         instance="msData/regex/RegexTest_81.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_80_regex_test_80_v(save_xml):
     """
     TEST :branch : RegexTest_80
@@ -4474,11 +4764,12 @@ def test_regex_test_80_regex_test_80_v(save_xml):
         instance="msData/regex/RegexTest_80.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_79_regex_test_79_i(save_xml):
     """
     TEST :branch : RegexTest_79
@@ -4489,11 +4780,12 @@ def test_regex_test_79_regex_test_79_i(save_xml):
         instance="msData/regex/RegexTest_79.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_78_regex_test_78_i(save_xml):
     """
     TEST :branch : RegexTest_78
@@ -4504,11 +4796,12 @@ def test_regex_test_78_regex_test_78_i(save_xml):
         instance="msData/regex/RegexTest_78.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_77_regex_test_77_i(save_xml):
     """
     TEST :branch : RegexTest_77
@@ -4519,11 +4812,12 @@ def test_regex_test_77_regex_test_77_i(save_xml):
         instance="msData/regex/RegexTest_77.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_76_regex_test_76_i(save_xml):
     """
     TEST :branch : RegexTest_76
@@ -4534,11 +4828,12 @@ def test_regex_test_76_regex_test_76_i(save_xml):
         instance="msData/regex/RegexTest_76.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_75_regex_test_75_i(save_xml):
     """
     TEST :branch : RegexTest_75
@@ -4549,11 +4844,12 @@ def test_regex_test_75_regex_test_75_i(save_xml):
         instance="msData/regex/RegexTest_75.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_74_regex_test_74_i(save_xml):
     """
     TEST :branch : RegexTest_74
@@ -4564,11 +4860,12 @@ def test_regex_test_74_regex_test_74_i(save_xml):
         instance="msData/regex/RegexTest_74.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_73_regex_test_73_v(save_xml):
     """
     TEST :branch : RegexTest_73
@@ -4579,11 +4876,12 @@ def test_regex_test_73_regex_test_73_v(save_xml):
         instance="msData/regex/RegexTest_73.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_72_regex_test_72_v(save_xml):
     """
     TEST :branch : RegexTest_72
@@ -4594,11 +4892,12 @@ def test_regex_test_72_regex_test_72_v(save_xml):
         instance="msData/regex/RegexTest_72.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_71_regex_test_71_i(save_xml):
     """
     TEST :branch : RegexTest_71
@@ -4609,11 +4908,12 @@ def test_regex_test_71_regex_test_71_i(save_xml):
         instance="msData/regex/RegexTest_71.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_70_regex_test_70_i(save_xml):
     """
     TEST :branch : RegexTest_70
@@ -4624,11 +4924,12 @@ def test_regex_test_70_regex_test_70_i(save_xml):
         instance="msData/regex/RegexTest_70.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_69_regex_test_69_i(save_xml):
     """
     TEST :branch : RegexTest_69
@@ -4639,11 +4940,12 @@ def test_regex_test_69_regex_test_69_i(save_xml):
         instance="msData/regex/RegexTest_69.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_68_regex_test_68_i(save_xml):
     """
     TEST :branch : RegexTest_68
@@ -4654,11 +4956,12 @@ def test_regex_test_68_regex_test_68_i(save_xml):
         instance="msData/regex/RegexTest_68.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_67_regex_test_67_i(save_xml):
     """
     TEST :branch : RegexTest_67
@@ -4669,11 +4972,12 @@ def test_regex_test_67_regex_test_67_i(save_xml):
         instance="msData/regex/RegexTest_67.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_66_regex_test_66_i(save_xml):
     """
     TEST :branch : RegexTest_66
@@ -4684,11 +4988,12 @@ def test_regex_test_66_regex_test_66_i(save_xml):
         instance="msData/regex/RegexTest_66.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_63_regex_test_63_i(save_xml):
     """
     TEST :branch : RegexTest_63
@@ -4699,11 +5004,12 @@ def test_regex_test_63_regex_test_63_i(save_xml):
         instance="msData/regex/RegexTest_63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_42_regex_test_42_v(save_xml):
     """
     TEST :branch : RegexTest_42
@@ -4714,11 +5020,12 @@ def test_regex_test_42_regex_test_42_v(save_xml):
         instance="msData/regex/RegexTest_42.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_41_regex_test_41_v(save_xml):
     """
     TEST :branch : RegexTest_41
@@ -4729,11 +5036,12 @@ def test_regex_test_41_regex_test_41_v(save_xml):
         instance="msData/regex/RegexTest_41.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_40_regex_test_40_i(save_xml):
     """
     TEST :branch : RegexTest_40
@@ -4744,11 +5052,12 @@ def test_regex_test_40_regex_test_40_i(save_xml):
         instance="msData/regex/RegexTest_40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_39_regex_test_39_i(save_xml):
     """
     TEST :branch : RegexTest_39
@@ -4759,11 +5068,12 @@ def test_regex_test_39_regex_test_39_i(save_xml):
         instance="msData/regex/RegexTest_39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_38_regex_test_38_i(save_xml):
     """
     TEST :branch : RegexTest_38
@@ -4774,11 +5084,12 @@ def test_regex_test_38_regex_test_38_i(save_xml):
         instance="msData/regex/RegexTest_38.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_37_regex_test_37_i(save_xml):
     """
     TEST :branch : RegexTest_37
@@ -4789,11 +5100,12 @@ def test_regex_test_37_regex_test_37_i(save_xml):
         instance="msData/regex/RegexTest_37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_36_regex_test_36_i(save_xml):
     """
     TEST :branch : RegexTest_36
@@ -4804,11 +5116,12 @@ def test_regex_test_36_regex_test_36_i(save_xml):
         instance="msData/regex/RegexTest_36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_35_regex_test_35_i(save_xml):
     """
     TEST :branch : RegexTest_35
@@ -4819,11 +5132,12 @@ def test_regex_test_35_regex_test_35_i(save_xml):
         instance="msData/regex/RegexTest_35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_21_regex_test_21_v(save_xml):
     """
     TEST :branch : RegexTest_21
@@ -4834,11 +5148,12 @@ def test_regex_test_21_regex_test_21_v(save_xml):
         instance="msData/regex/RegexTest_21.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_20_regex_test_20_v(save_xml):
     """
     TEST :branch : RegexTest_20
@@ -4849,11 +5164,12 @@ def test_regex_test_20_regex_test_20_v(save_xml):
         instance="msData/regex/RegexTest_20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_13_regex_test_13_i(save_xml):
     """
     TEST :branch : RegexTest_13
@@ -4864,11 +5180,12 @@ def test_regex_test_13_regex_test_13_i(save_xml):
         instance="msData/regex/RegexTest_13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_12_regex_test_12_i(save_xml):
     """
     TEST :branch : RegexTest_12
@@ -4879,11 +5196,12 @@ def test_regex_test_12_regex_test_12_i(save_xml):
         instance="msData/regex/RegexTest_12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_10_regex_test_10_i(save_xml):
     """
     TEST :branch : RegexTest_10
@@ -4894,11 +5212,12 @@ def test_regex_test_10_regex_test_10_i(save_xml):
         instance="msData/regex/RegexTest_10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_8_regex_test_8_i(save_xml):
     """
     TEST :branch : RegexTest_8
@@ -4909,11 +5228,12 @@ def test_regex_test_8_regex_test_8_i(save_xml):
         instance="msData/regex/RegexTest_8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_7_regex_test_7_i(save_xml):
     """
     TEST :branch : RegexTest_7
@@ -4924,11 +5244,12 @@ def test_regex_test_7_regex_test_7_i(save_xml):
         instance="msData/regex/RegexTest_7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_6_regex_test_6_v(save_xml):
     """
     TEST :branch : RegexTest_6
@@ -4939,11 +5260,12 @@ def test_regex_test_6_regex_test_6_v(save_xml):
         instance="msData/regex/RegexTest_6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_5_regex_test_5_v(save_xml):
     """
     TEST :branch : RegexTest_5
@@ -4954,11 +5276,12 @@ def test_regex_test_5_regex_test_5_v(save_xml):
         instance="msData/regex/RegexTest_5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_4_regex_test_4_v(save_xml):
     """
     TEST :branch : RegexTest_4
@@ -4969,11 +5292,12 @@ def test_regex_test_4_regex_test_4_v(save_xml):
         instance="msData/regex/RegexTest_4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_3_regex_test_3_v(save_xml):
     """
     TEST :branch : RegexTest_3
@@ -4984,11 +5308,12 @@ def test_regex_test_3_regex_test_3_v(save_xml):
         instance="msData/regex/RegexTest_3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_2_regex_test_2_v(save_xml):
     """
     TEST :branch : RegexTest_2
@@ -4999,11 +5324,12 @@ def test_regex_test_2_regex_test_2_v(save_xml):
         instance="msData/regex/RegexTest_2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_regex_test_1_regex_test_1_v(save_xml):
     """
     TEST :branch : RegexTest_1
@@ -5014,11 +5340,12 @@ def test_regex_test_1_regex_test_1_v(save_xml):
         instance="msData/regex/RegexTest_1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p21_p21_i(save_xml):
     """
     TEST :branch : restriction of two patterns in a simple type (1)
@@ -5031,11 +5358,12 @@ def test_p21_p21_i(save_xml):
         instance="msData/regex/p21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p20_p20_v(save_xml):
     """
     TEST :branch : restriction of two patterns in a simple type (1)
@@ -5048,11 +5376,12 @@ def test_p20_p20_v(save_xml):
         instance="msData/regex/p20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p19_p19_i(save_xml):
     """
     TEST :branch : two patterns in a simple type (1) "[abc]+" (2)
@@ -5064,11 +5393,12 @@ def test_p19_p19_i(save_xml):
         instance="msData/regex/p19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p18_p18_i(save_xml):
     """
     TEST :branch : two patterns in a simple type (1) "[abc]+" (2)
@@ -5080,11 +5410,12 @@ def test_p18_p18_i(save_xml):
         instance="msData/regex/p18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p17_p17_v(save_xml):
     """
     TEST :branch : two patterns in a simple type (1) "[abc]+" (2)
@@ -5097,11 +5428,12 @@ def test_p17_p17_v(save_xml):
         instance="msData/regex/p17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p16_p16_v(save_xml):
     """
     TEST :branch : two patterns in a simple type (1) "[abc]+" (2)
@@ -5113,11 +5445,12 @@ def test_p16_p16_v(save_xml):
         instance="msData/regex/p16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p15_p15_i(save_xml):
     r"""
     TEST :branch : regex\pattern=123]+|[abc]+, value=a1[invalid]
@@ -5128,11 +5461,12 @@ def test_p15_p15_i(save_xml):
         instance="msData/regex/p15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p14_p14_i(save_xml):
     r"""
     TEST :branch : regex\pattern=123]+|[abc]+, value=1a[invalid]
@@ -5143,11 +5477,12 @@ def test_p14_p14_i(save_xml):
         instance="msData/regex/p14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p13_p13_v(save_xml):
     r"""
     TEST :branch : regex\pattern=123]+|[abc]+, value=abcaabbccabc [valid]
@@ -5158,11 +5493,12 @@ def test_p13_p13_v(save_xml):
         instance="msData/regex/p13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p12_p12_v(save_xml):
     """
     TEST :branch :
@@ -5173,11 +5509,12 @@ def test_p12_p12_v(save_xml):
         instance="msData/regex/p12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p11_p11_v(save_xml):
     r"""
     TEST :branch : regex\restriction of a type that defined as emum
@@ -5189,11 +5526,12 @@ def test_p11_p11_v(save_xml):
         instance="msData/regex/p11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p10_p10_i(save_xml):
     r"""
     TEST :branch : regex\restriction of a type that defined as emum
@@ -5205,11 +5543,12 @@ def test_p10_p10_i(save_xml):
         instance="msData/regex/p10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p9_p9_v(save_xml):
     r"""
     TEST :branch : regex\restriction of a type that defined as emum
@@ -5221,11 +5560,12 @@ def test_p9_p9_v(save_xml):
         instance="msData/regex/p9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p8_p8_v(save_xml):
     r"""
     TEST :branch : restriction of a type that defined as integer,
@@ -5237,11 +5577,12 @@ def test_p8_p8_v(save_xml):
         instance="msData/regex/p8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p7_p7_i(save_xml):
     r"""
     TEST :branch : regex\restriction of a type that defined as integer,
@@ -5253,11 +5594,12 @@ def test_p7_p7_i(save_xml):
         instance="msData/regex/p7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p6_p6_v(save_xml):
     r"""
     TEST :branch : regex\restriction of a type that defined as integer,
@@ -5269,11 +5611,12 @@ def test_p6_p6_v(save_xml):
         instance="msData/regex/p6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p5_p5_v(save_xml):
     """
     TEST :branch : restriction of a type that defined as integer,
@@ -5285,11 +5628,12 @@ def test_p5_p5_v(save_xml):
         instance="msData/regex/p5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p4_p4_i(save_xml):
     """
     TEST :branch : restriction of a type that defined as integer,
@@ -5301,11 +5645,12 @@ def test_p4_p4_i(save_xml):
         instance="msData/regex/p4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p3_p3_v(save_xml):
     """
     TEST :branch : restriction of a type that defined as integer,
@@ -5317,11 +5662,12 @@ def test_p3_p3_v(save_xml):
         instance="msData/regex/p3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_p2_p2_i(save_xml):
     """
     TEST :branch : restriction of a type that defined as integer,
@@ -5333,11 +5679,12 @@ def test_p2_p2_i(save_xml):
         instance="msData/regex/p2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di14_re_di14_v(save_xml):
     r"""
     TEST :branch : base='positiveInteger', pattern='\d+', value='123',
@@ -5349,11 +5696,12 @@ def test_re_di14_re_di14_v(save_xml):
         instance="msData/regex/reDI14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di13_re_di13_i(save_xml):
     r"""
     TEST :branch : base='unshgiedByte', pattern='\d+', value='123',
@@ -5365,11 +5713,12 @@ def test_re_di13_re_di13_i(save_xml):
         instance="msData/regex/reDI13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di12_re_di12_i(save_xml):
     r"""
     TEST :branch : base='unsignedShort', pattern='\d+', value='123',
@@ -5381,11 +5730,12 @@ def test_re_di12_re_di12_i(save_xml):
         instance="msData/regex/reDI12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di11_re_di11_v(save_xml):
     r"""
     TEST :branch : base='unsignedInt', pattern='\d+', value='123',
@@ -5397,11 +5747,12 @@ def test_re_di11_re_di11_v(save_xml):
         instance="msData/regex/reDI11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di10_re_di10_v(save_xml):
     r"""
     TEST :branch : base='unsignedLong', pattern='\d+', value='123',
@@ -5413,11 +5764,12 @@ def test_re_di10_re_di10_v(save_xml):
         instance="msData/regex/reDI10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di9_re_di9_v(save_xml):
     r"""
     TEST :branch : base='nonNegativeInteger', pattern='\d+', value='1111',
@@ -5429,11 +5781,12 @@ def test_re_di9_re_di9_v(save_xml):
         instance="msData/regex/reDI9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di8_re_di8_v(save_xml):
     r"""
     TEST :branch : base='byte', pattern='(\- |
@@ -5446,11 +5799,12 @@ def test_re_di8_re_di8_v(save_xml):
         instance="msData/regex/reDI8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di7_re_di7_v(save_xml):
     r"""
     TEST :branch : base='short', pattern='\-?[0-3]{3}', value='-300',
@@ -5462,11 +5816,12 @@ def test_re_di7_re_di7_v(save_xml):
         instance="msData/regex/reDI7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di6_re_di6_v(save_xml):
     r"""
     TEST :branch : base='int', pattern='\d+', value='123', type='valid',
@@ -5478,11 +5833,12 @@ def test_re_di6_re_di6_v(save_xml):
         instance="msData/regex/reDI6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di5_re_di5_i(save_xml):
     r"""
     TEST :branch : base='long', pattern='\d+', value='a', type='invalid',
@@ -5494,11 +5850,12 @@ def test_re_di5_re_di5_i(save_xml):
         instance="msData/regex/reDI5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di4_re_di4_i(save_xml):
     r"""
     TEST :branch : base='negativeInteger', pattern='\-?\d', value='+1',
@@ -5510,11 +5867,12 @@ def test_re_di4_re_di4_i(save_xml):
         instance="msData/regex/reDI4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di3_re_di3_i(save_xml):
     r"""
     TEST :branch : base='nonPositiveIntebger', pattern='\-\d\d',
@@ -5526,11 +5884,12 @@ def test_re_di3_re_di3_i(save_xml):
         instance="msData/regex/reDI3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di2_re_di2_v(save_xml):
     r"""
     TEST :branch : base='integer', pattern='\p{Nd}+', value='10000201',
@@ -5542,11 +5901,12 @@ def test_re_di2_re_di2_v(save_xml):
         instance="msData/regex/reDI2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_di1_re_di1_v(save_xml):
     r"""
     TEST :branch : base='decimal', pattern='\p{Nd}+', value='10000101',
@@ -5558,11 +5918,12 @@ def test_re_di1_re_di1_v(save_xml):
         instance="msData/regex/reDI1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh11_re_dh11_v(save_xml):
     r"""
     TEST :branch : base='NMTOKEN', pattern='\c[\c\d]*', value='name1',
@@ -5574,11 +5935,12 @@ def test_re_dh11_re_dh11_v(save_xml):
         instance="msData/regex/reDH11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh7a_re_dh7a_i(save_xml):
     r"""
     TEST :branch : base='IDREF', pattern='\c[\c\d]*', value='ab',
@@ -5590,11 +5952,12 @@ def test_re_dh7a_re_dh7a_i(save_xml):
         instance="msData/regex/reDH7a.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh7_re_dh7_v(save_xml):
     r"""
     TEST :branch : base='IDREF', pattern='\c[\c\d]*', value='ab',
@@ -5606,11 +5969,12 @@ def test_re_dh7_re_dh7_v(save_xml):
         instance="msData/regex/reDH7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh6_re_dh6_v(save_xml):
     r"""
     TEST :branch : base='ID', pattern='\c[\c\d]*', value='a1b',
@@ -5622,11 +5986,12 @@ def test_re_dh6_re_dh6_v(save_xml):
         instance="msData/regex/reDH6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh5_re_dh5_v(save_xml):
     r"""
     TEST :branch : base='NCName', pattern='[\i-[:]][\c-[:]]*',
@@ -5638,11 +6003,12 @@ def test_re_dh5_re_dh5_v(save_xml):
         instance="msData/regex/reDH5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh4_re_dh4_v(save_xml):
     r"""
     TEST :branch : base='Name', pattern='\c+', value='abcdef',
@@ -5654,11 +6020,12 @@ def test_re_dh4_re_dh4_v(save_xml):
         instance="msData/regex/reDH4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh3_re_dh3_v(save_xml):
     r"""
     TEST :branch : base='language', pattern='\c{2,4}', value='ch-a',
@@ -5670,11 +6037,12 @@ def test_re_dh3_re_dh3_v(save_xml):
         instance="msData/regex/reDH3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dh2_re_dh2_v(save_xml):
     r"""
     TEST :branch : base='token', pattern='\c+', value='a', type='valid',
@@ -5686,11 +6054,12 @@ def test_re_dh2_re_dh2_v(save_xml):
         instance="msData/regex/reDH2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg7_re_dg7_v(save_xml):
     """
     TEST :branch : base='gMonth', pattern='[123456789]|(10|11|12)',
@@ -5702,11 +6071,12 @@ def test_re_dg7_re_dg7_v(save_xml):
         instance="msData/regex/reDG7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg6_re_dg6_v(save_xml):
     """
     TEST :branch : base='gDay', pattern='([123]0)|([12]?[1-9])|(31)',
@@ -5718,11 +6088,12 @@ def test_re_dg6_re_dg6_v(save_xml):
         instance="msData/regex/reDG6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg5_re_dg5_v(save_xml):
     r"""
     TEST :branch : base='gMonthDay', pattern='0[123]\-(12|14)',
@@ -5734,11 +6105,12 @@ def test_re_dg5_re_dg5_v(save_xml):
         instance="msData/regex/reDG5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg4_re_dg4_i(save_xml):
     r"""
     TEST :branch : base='gYear', pattern='\p{Nd}{2}', value='1999',
@@ -5750,11 +6122,12 @@ def test_re_dg4_re_dg4_i(save_xml):
         instance="msData/regex/reDG4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg3_re_dg3_v(save_xml):
     r"""
     TEST :branch : base='gYear', pattern='\p{Nd}{4}', value='1999',
@@ -5766,11 +6139,12 @@ def test_re_dg3_re_dg3_v(save_xml):
         instance="msData/regex/reDG3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg2_re_dg2_i(save_xml):
     r"""
     TEST :branch : base='gYearMonth', pattern='\p{Nd}{4}-\p{Nd}{2}',
@@ -5783,11 +6157,12 @@ def test_re_dg2_re_dg2_i(save_xml):
         instance="msData/regex/reDG2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dg1_re_dg1_v(save_xml):
     r"""
     TEST :branch : base='date', pattern='\p{Nd}{4}-\p{Nd}{2}-\p{Nd}{2}',
@@ -5799,11 +6174,12 @@ def test_re_dg1_re_dg1_v(save_xml):
         instance="msData/regex/reDG1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_df5_re_df5_i(save_xml):
     r"""
     TEST :branch : base='time', pattern='\p{Nd}+:\d\d:\d\d(\-\d\d:\d\d)?',
@@ -5815,11 +6191,12 @@ def test_re_df5_re_df5_i(save_xml):
         instance="msData/regex/reDF5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_df3_re_df3_i(save_xml):
     r"""
     TEST :branch : base='time', pattern='\c+', value='abc',
@@ -5831,11 +6208,12 @@ def test_re_df3_re_df3_i(save_xml):
         instance="msData/regex/reDF3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_df2_re_df2_v(save_xml):
     r"""
     TEST :branch : base='time',
@@ -5848,11 +6226,12 @@ def test_re_df2_re_df2_v(save_xml):
         instance="msData/regex/reDF2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_df1_re_df1_v(save_xml):
     r"""
     TEST :branch : base='time',
@@ -5865,11 +6244,12 @@ def test_re_df1_re_df1_v(save_xml):
         instance="msData/regex/reDF1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_de4_re_de4_i(save_xml):
     r"""
     TEST :branch : base='dateTime',
@@ -5882,11 +6262,12 @@ def test_re_de4_re_de4_i(save_xml):
         instance="msData/regex/reDE4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_de3_re_de3_i(save_xml):
     r"""
     TEST :branch : base='dateTime',
@@ -5899,11 +6280,12 @@ def test_re_de3_re_de3_i(save_xml):
         instance="msData/regex/reDE3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_de2_re_de2_i(save_xml):
     r"""
     TEST :branch : base='dateTime',
@@ -5916,11 +6298,12 @@ def test_re_de2_re_de2_i(save_xml):
         instance="msData/regex/reDE2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_de1_re_de1_v(save_xml):
     r"""
     TEST :branch : base='dateTime',
@@ -5933,11 +6316,12 @@ def test_re_de1_re_de1_v(save_xml):
         instance="msData/regex/reDE1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd8_re_dd8_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -5949,11 +6333,12 @@ def test_re_dd8_re_dd8_i(save_xml):
         instance="msData/regex/reDD8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd7_re_dd7_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -5965,11 +6350,12 @@ def test_re_dd7_re_dd7_i(save_xml):
         instance="msData/regex/reDD7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd6_re_dd6_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -5981,11 +6367,12 @@ def test_re_dd6_re_dd6_i(save_xml):
         instance="msData/regex/reDD6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd5_re_dd5_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -5997,11 +6384,12 @@ def test_re_dd5_re_dd5_i(save_xml):
         instance="msData/regex/reDD5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd4_re_dd4_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -6013,11 +6401,12 @@ def test_re_dd4_re_dd4_i(save_xml):
         instance="msData/regex/reDD4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd3_re_dd3_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -6029,11 +6418,12 @@ def test_re_dd3_re_dd3_i(save_xml):
         instance="msData/regex/reDD3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd2_re_dd2_i(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -6045,11 +6435,12 @@ def test_re_dd2_re_dd2_i(save_xml):
         instance="msData/regex/reDD2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dd1_re_dd1_v(save_xml):
     r"""
     TEST :branch : base='duration', pattern='P\p{Nd}{4}Y\p{Nd}{2}M',
@@ -6061,11 +6452,12 @@ def test_re_dd1_re_dd1_v(save_xml):
         instance="msData/regex/reDD1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dc5_re_dc5_v(save_xml):
     r"""
     TEST :branch : base='Qname',
@@ -6078,11 +6470,12 @@ def test_re_dc5_re_dc5_v(save_xml):
         instance="msData/regex/reDC5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dc4_re_dc4_v(save_xml):
     r"""
     TEST :branch : base='anyURI', pattern='http://\c*',
@@ -6094,11 +6487,12 @@ def test_re_dc4_re_dc4_v(save_xml):
         instance="msData/regex/reDC4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dc3_re_dc3_v(save_xml):
     r"""
     TEST :branch : base='double', pattern='\d*\.\d+', value='1.001',
@@ -6110,11 +6504,12 @@ def test_re_dc3_re_dc3_v(save_xml):
         instance="msData/regex/reDC3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dc2_re_dc2_v(save_xml):
     r"""
     TEST :branch : base='float', pattern='\d*\.\d+', value='1.001',
@@ -6126,11 +6521,12 @@ def test_re_dc2_re_dc2_v(save_xml):
         instance="msData/regex/reDC2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_dc1_re_dc1_v(save_xml):
     """
     TEST :branch : base='hexBinary', pattern='AF01D1', value='AF01D1',
@@ -6142,11 +6538,12 @@ def test_re_dc1_re_dc1_v(save_xml):
         instance="msData/regex/reDC1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_db6_re_db6_i(save_xml):
     """
     TEST :branch : base='base64Binary', pattern='([0-1]{4} | (0 | 1){8})',
@@ -6158,11 +6555,12 @@ def test_re_db6_re_db6_i(save_xml):
         instance="msData/regex/reDB6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_db5_re_db5_i(save_xml):
     """
     TEST :branch : base='base64Binary', pattern='([0-1]{4} | (0 | 1){8})',
@@ -6174,11 +6572,12 @@ def test_re_db5_re_db5_i(save_xml):
         instance="msData/regex/reDB5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_db4_re_db4_i(save_xml):
     """
     TEST :branch : base='base64Binary', pattern='([0-1]{4} | (0 | 1){8})',
@@ -6190,11 +6589,12 @@ def test_re_db4_re_db4_i(save_xml):
         instance="msData/regex/reDB4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_db3_re_db3_i(save_xml):
     """
     TEST :branch : base='base64Binary', pattern='([0-1]{4} | (0 | 1){8})',
@@ -6206,11 +6606,12 @@ def test_re_db3_re_db3_i(save_xml):
         instance="msData/regex/reDB3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_db2_re_db2_v(save_xml):
     """
     TEST :branch : base='base64Binary', pattern='([0-1]{4} | (0 | 1){8})',
@@ -6222,11 +6623,12 @@ def test_re_db2_re_db2_v(save_xml):
         instance="msData/regex/reDB2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_db1_re_db1_v(save_xml):
     """
     TEST :branch : base='base64Binary', pattern='([0-1]{4} | (0 | 1){8})',
@@ -6238,11 +6640,12 @@ def test_re_db1_re_db1_v(save_xml):
         instance="msData/regex/reDB1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da15_re_da15_v(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true|false|0|0)',
@@ -6254,11 +6657,12 @@ def test_re_da15_re_da15_v(save_xml):
         instance="msData/regex/reDA15.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da14_re_da14_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true)', value='2',
@@ -6270,11 +6674,12 @@ def test_re_da14_re_da14_i(save_xml):
         instance="msData/regex/reDA14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da13_re_da13_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true)', value='',
@@ -6286,11 +6691,12 @@ def test_re_da13_re_da13_i(save_xml):
         instance="msData/regex/reDA13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da12_re_da12_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true)', value='FALSE',
@@ -6302,11 +6708,12 @@ def test_re_da12_re_da12_i(save_xml):
         instance="msData/regex/reDA12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da11_re_da11_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true)', value='0',
@@ -6318,11 +6725,12 @@ def test_re_da11_re_da11_i(save_xml):
         instance="msData/regex/reDA11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da10_re_da10_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true)', value='TRUE',
@@ -6334,11 +6742,12 @@ def test_re_da10_re_da10_i(save_xml):
         instance="msData/regex/reDA10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da9_re_da9_v(save_xml):
     """
     TEST :branch : base='boolean', pattern='(1|true)', value='1',
@@ -6350,11 +6759,12 @@ def test_re_da9_re_da9_v(save_xml):
         instance="msData/regex/reDA9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da6_re_da6_v(save_xml):
     """
     TEST :branch : base='boolean', pattern='(true|false)', value='false',
@@ -6366,11 +6776,12 @@ def test_re_da6_re_da6_v(save_xml):
         instance="msData/regex/reDA6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da5_re_da5_v(save_xml):
     """
     TEST :branch : base='boolean', pattern='(true|false)', value='true',
@@ -6382,11 +6793,12 @@ def test_re_da5_re_da5_v(save_xml):
         instance="msData/regex/reDA5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da4_re_da4_v(save_xml):
     """
     TEST :branch : base='boolean', pattern='false', value='false',
@@ -6398,11 +6810,12 @@ def test_re_da4_re_da4_v(save_xml):
         instance="msData/regex/reDA4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da3_re_da3_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='false', value='true',
@@ -6414,11 +6827,12 @@ def test_re_da3_re_da3_i(save_xml):
         instance="msData/regex/reDA3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da2_re_da2_i(save_xml):
     """
     TEST :branch : base='boolean', pattern='true', value='false',
@@ -6430,11 +6844,12 @@ def test_re_da2_re_da2_i(save_xml):
         instance="msData/regex/reDA2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_da1_re_da1_v(save_xml):
     """
     TEST :branch : base='boolean', pattern='true', value='true',
@@ -6446,11 +6861,12 @@ def test_re_da1_re_da1_v(save_xml):
         instance="msData/regex/reDA1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v43_re_v43_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D1DD;',
@@ -6462,11 +6878,12 @@ def test_re_v43_re_v43_i(save_xml):
         instance="msData/regex/reV43.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v42_re_v42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x3190;',
@@ -6478,11 +6895,12 @@ def test_re_v42_re_v42_i(save_xml):
         instance="msData/regex/reV42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v41_re_v41_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x3190;',
@@ -6494,11 +6912,12 @@ def test_re_v41_re_v41_i(save_xml):
         instance="msData/regex/reV41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v40_re_v40_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xFFE3;',
@@ -6510,11 +6929,12 @@ def test_re_v40_re_v40_i(save_xml):
         instance="msData/regex/reV40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v39_re_v39_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x309B;',
@@ -6526,11 +6946,12 @@ def test_re_v39_re_v39_i(save_xml):
         instance="msData/regex/reV39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v38_re_v38_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x309B;',
@@ -6542,11 +6963,12 @@ def test_re_v38_re_v38_i(save_xml):
         instance="msData/regex/reV38.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v37_re_v37_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xFFE6;',
@@ -6558,11 +6980,12 @@ def test_re_v37_re_v37_i(save_xml):
         instance="msData/regex/reV37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v36_re_v36_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x20A0;',
@@ -6574,11 +6997,12 @@ def test_re_v36_re_v36_i(save_xml):
         instance="msData/regex/reV36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v35_re_v35_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x20A0;',
@@ -6590,11 +7014,12 @@ def test_re_v35_re_v35_i(save_xml):
         instance="msData/regex/reV35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v34_re_v34_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xFFE2;',
@@ -6606,11 +7031,12 @@ def test_re_v34_re_v34_i(save_xml):
         instance="msData/regex/reV34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v33_re_v33_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x2044;',
@@ -6622,11 +7048,12 @@ def test_re_v33_re_v33_i(save_xml):
         instance="msData/regex/reV33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v32_re_v32_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x10323;',
@@ -6638,11 +7065,12 @@ def test_re_v32_re_v32_i(save_xml):
         instance="msData/regex/reV32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v31_re_v31_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xB2;',
@@ -6654,11 +7082,12 @@ def test_re_v31_re_v31_i(save_xml):
         instance="msData/regex/reV31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v30_re_v30_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xB2;',
@@ -6670,11 +7099,12 @@ def test_re_v30_re_v30_i(save_xml):
         instance="msData/regex/reV30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v29_re_v29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x3025;',
@@ -6686,11 +7116,12 @@ def test_re_v29_re_v29_i(save_xml):
         instance="msData/regex/reV29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v28_re_v28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1034A;',
@@ -6702,11 +7133,12 @@ def test_re_v28_re_v28_i(save_xml):
         instance="msData/regex/reV28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v27_re_v27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1034A;',
@@ -6718,11 +7150,12 @@ def test_re_v27_re_v27_i(save_xml):
         instance="msData/regex/reV27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v26_re_v26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D7FF;',
@@ -6734,11 +7167,12 @@ def test_re_v26_re_v26_i(save_xml):
         instance="msData/regex/reV26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v25_re_v25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xFF10;',
@@ -6750,11 +7184,12 @@ def test_re_v25_re_v25_i(save_xml):
         instance="msData/regex/reV25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v24_re_v24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x20E2;',
@@ -6766,11 +7201,12 @@ def test_re_v24_re_v24_i(save_xml):
         instance="msData/regex/reV24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v23_re_v23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x20DD;',
@@ -6782,11 +7218,12 @@ def test_re_v23_re_v23_i(save_xml):
         instance="msData/regex/reV23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v22_re_v22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x20DD;',
@@ -6798,11 +7235,12 @@ def test_re_v22_re_v22_i(save_xml):
         instance="msData/regex/reV22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v21_re_v21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D172;',
@@ -6814,11 +7252,12 @@ def test_re_v21_re_v21_i(save_xml):
         instance="msData/regex/reV21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v20_re_v20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x903;',
@@ -6830,11 +7269,12 @@ def test_re_v20_re_v20_i(save_xml):
         instance="msData/regex/reV20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v19_re_v19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D172;',
@@ -6846,11 +7286,12 @@ def test_re_v19_re_v19_i(save_xml):
         instance="msData/regex/reV19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v18_re_v18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x903;',
@@ -6862,11 +7303,12 @@ def test_re_v18_re_v18_i(save_xml):
         instance="msData/regex/reV18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v17_re_v17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D1AD;',
@@ -6878,11 +7320,12 @@ def test_re_v17_re_v17_i(save_xml):
         instance="msData/regex/reV17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v16_re_v16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x64B;',
@@ -6894,11 +7337,12 @@ def test_re_v16_re_v16_i(save_xml):
         instance="msData/regex/reV16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v15_re_v15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x2FA1D;',
@@ -6910,11 +7354,12 @@ def test_re_v15_re_v15_i(save_xml):
         instance="msData/regex/reV15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v14_re_v14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x5D0;',
@@ -6926,11 +7371,12 @@ def test_re_v14_re_v14_i(save_xml):
         instance="msData/regex/reV14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v13_re_v13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x5D0;',
@@ -6942,11 +7388,12 @@ def test_re_v13_re_v13_i(save_xml):
         instance="msData/regex/reV13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v12_re_v12_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#xFF9F;',
@@ -6958,11 +7405,12 @@ def test_re_v12_re_v12_i(save_xml):
         instance="msData/regex/reV12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v11_re_v11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x2B0;',
@@ -6974,11 +7422,12 @@ def test_re_v11_re_v11_i(save_xml):
         instance="msData/regex/reV11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v10_re_v10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x2B0;',
@@ -6990,11 +7439,12 @@ def test_re_v10_re_v10_i(save_xml):
         instance="msData/regex/reV10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v9_re_v9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1FFC;',
@@ -7006,11 +7456,12 @@ def test_re_v9_re_v9_i(save_xml):
         instance="msData/regex/reV9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v8_re_v8_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1C5;',
@@ -7022,11 +7473,12 @@ def test_re_v8_re_v8_i(save_xml):
         instance="msData/regex/reV8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v7_re_v7_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1C5;',
@@ -7038,11 +7490,12 @@ def test_re_v7_re_v7_i(save_xml):
         instance="msData/regex/reV7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v6_re_v6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D7C9;',
@@ -7054,11 +7507,12 @@ def test_re_v6_re_v6_i(save_xml):
         instance="msData/regex/reV6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v5_re_v5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x61;',
@@ -7070,11 +7524,12 @@ def test_re_v5_re_v5_i(save_xml):
         instance="msData/regex/reV5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v4_re_v4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x61;',
@@ -7086,11 +7541,12 @@ def test_re_v4_re_v4_i(save_xml):
         instance="msData/regex/reV4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v3_re_v3_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x1D7A8;',
@@ -7102,11 +7558,12 @@ def test_re_v3_re_v3_i(save_xml):
         instance="msData/regex/reV3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_v2_re_v2_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\W', value='#x41;',
@@ -7118,11 +7575,12 @@ def test_re_v2_re_v2_i(save_xml):
         instance="msData/regex/reV2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u15_re_u15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x2029;',
@@ -7134,11 +7592,12 @@ def test_re_u15_re_u15_i(save_xml):
         instance="msData/regex/reU15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u14_re_u14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x2028;',
@@ -7150,11 +7609,12 @@ def test_re_u14_re_u14_i(save_xml):
         instance="msData/regex/reU14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u13_re_u13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x0020;',
@@ -7166,11 +7626,12 @@ def test_re_u13_re_u13_i(save_xml):
         instance="msData/regex/reU13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u12_re_u12_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x0F04;',
@@ -7182,11 +7643,12 @@ def test_re_u12_re_u12_i(save_xml):
         instance="msData/regex/reU12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u11_re_u11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x00BB;',
@@ -7198,11 +7660,12 @@ def test_re_u11_re_u11_i(save_xml):
         instance="msData/regex/reU11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u10_re_u10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x201C;',
@@ -7214,11 +7677,12 @@ def test_re_u10_re_u10_i(save_xml):
         instance="msData/regex/reU10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u9_re_u9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x007D;',
@@ -7230,11 +7694,12 @@ def test_re_u9_re_u9_i(save_xml):
         instance="msData/regex/reU9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u8_re_u8_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#xFE37;',
@@ -7246,11 +7711,12 @@ def test_re_u8_re_u8_i(save_xml):
         instance="msData/regex/reU8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u7_re_u7_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x2010;',
@@ -7262,11 +7728,12 @@ def test_re_u7_re_u7_i(save_xml):
         instance="msData/regex/reU7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u6_re_u6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x023F;',
@@ -7278,11 +7745,12 @@ def test_re_u6_re_u6_i(save_xml):
         instance="msData/regex/reU6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u5_re_u5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x007F;',
@@ -7294,11 +7762,12 @@ def test_re_u5_re_u5_i(save_xml):
         instance="msData/regex/reU5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u4_re_u4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#x070F;',
@@ -7310,11 +7779,12 @@ def test_re_u4_re_u4_i(save_xml):
         instance="msData/regex/reU4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_u3_re_u3_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\w', value='#xF8FF;',
@@ -7326,11 +7796,12 @@ def test_re_u3_re_u3_i(save_xml):
         instance="msData/regex/reU3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t84_re_t84_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1D800;',
@@ -7342,11 +7813,12 @@ def test_re_t84_re_t84_i(save_xml):
         instance="msData/regex/reT84.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t83_re_t83_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#xFF1A;',
@@ -7358,11 +7830,12 @@ def test_re_t83_re_t83_v(save_xml):
         instance="msData/regex/reT83.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t82_re_t82_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x181A;',
@@ -7374,11 +7847,12 @@ def test_re_t82_re_t82_v(save_xml):
         instance="msData/regex/reT82.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t81_re_t81_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x17EA;',
@@ -7390,11 +7864,12 @@ def test_re_t81_re_t81_v(save_xml):
         instance="msData/regex/reT81.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t80_re_t80_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1372;',
@@ -7406,11 +7881,12 @@ def test_re_t80_re_t80_v(save_xml):
         instance="msData/regex/reT80.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t79_re_t79_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x104A;',
@@ -7422,11 +7898,12 @@ def test_re_t79_re_t79_v(save_xml):
         instance="msData/regex/reT79.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t78_re_t78_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0F2A;',
@@ -7438,11 +7915,12 @@ def test_re_t78_re_t78_v(save_xml):
         instance="msData/regex/reT78.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t77_re_t77_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0EDA;',
@@ -7454,11 +7932,12 @@ def test_re_t77_re_t77_v(save_xml):
         instance="msData/regex/reT77.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t76_re_t76_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0E5A;',
@@ -7470,11 +7949,12 @@ def test_re_t76_re_t76_v(save_xml):
         instance="msData/regex/reT76.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t75_re_t75_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0D70;',
@@ -7486,11 +7966,12 @@ def test_re_t75_re_t75_v(save_xml):
         instance="msData/regex/reT75.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t74_re_t74_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0CF0;',
@@ -7502,11 +7983,12 @@ def test_re_t74_re_t74_v(save_xml):
         instance="msData/regex/reT74.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t73_re_t73_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0C70;',
@@ -7518,11 +8000,12 @@ def test_re_t73_re_t73_v(save_xml):
         instance="msData/regex/reT73.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t72_re_t72_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0BF0;',
@@ -7534,11 +8017,12 @@ def test_re_t72_re_t72_v(save_xml):
         instance="msData/regex/reT72.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t71_re_t71_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0B70;',
@@ -7550,11 +8034,12 @@ def test_re_t71_re_t71_v(save_xml):
         instance="msData/regex/reT71.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t70_re_t70_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0AF0;',
@@ -7566,11 +8051,12 @@ def test_re_t70_re_t70_v(save_xml):
         instance="msData/regex/reT70.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t69_re_t69_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0A79;',
@@ -7582,11 +8068,12 @@ def test_re_t69_re_t69_v(save_xml):
         instance="msData/regex/reT69.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t68_re_t68_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x09F0;',
@@ -7598,11 +8085,12 @@ def test_re_t68_re_t68_v(save_xml):
         instance="msData/regex/reT68.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t67_re_t67_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0970;',
@@ -7614,11 +8102,12 @@ def test_re_t67_re_t67_v(save_xml):
         instance="msData/regex/reT67.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t66_re_t66_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x06FA;',
@@ -7630,11 +8119,12 @@ def test_re_t66_re_t66_v(save_xml):
         instance="msData/regex/reT66.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t65_re_t65_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x066A;',
@@ -7646,11 +8136,12 @@ def test_re_t65_re_t65_v(save_xml):
         instance="msData/regex/reT65.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t64_re_t64_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x003A;',
@@ -7662,11 +8153,12 @@ def test_re_t64_re_t64_v(save_xml):
         instance="msData/regex/reT64.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t63_re_t63_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1D7CD;',
@@ -7678,11 +8170,12 @@ def test_re_t63_re_t63_i(save_xml):
         instance="msData/regex/reT63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t62_re_t62_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#xFF09;',
@@ -7694,11 +8187,12 @@ def test_re_t62_re_t62_v(save_xml):
         instance="msData/regex/reT62.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t61_re_t61_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1809;',
@@ -7710,11 +8204,12 @@ def test_re_t61_re_t61_v(save_xml):
         instance="msData/regex/reT61.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t60_re_t60_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x17DF;',
@@ -7726,11 +8221,12 @@ def test_re_t60_re_t60_v(save_xml):
         instance="msData/regex/reT60.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t59_re_t59_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1368;',
@@ -7742,11 +8238,12 @@ def test_re_t59_re_t59_v(save_xml):
         instance="msData/regex/reT59.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t58_re_t58_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1039;',
@@ -7758,11 +8255,12 @@ def test_re_t58_re_t58_v(save_xml):
         instance="msData/regex/reT58.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t57_re_t57_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0F19;',
@@ -7774,11 +8272,12 @@ def test_re_t57_re_t57_v(save_xml):
         instance="msData/regex/reT57.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t56_re_t56_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0ECF;',
@@ -7790,11 +8289,12 @@ def test_re_t56_re_t56_v(save_xml):
         instance="msData/regex/reT56.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t55_re_t55_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0E49;',
@@ -7806,11 +8306,12 @@ def test_re_t55_re_t55_v(save_xml):
         instance="msData/regex/reT55.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t54_re_t54_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0D65;',
@@ -7822,11 +8323,12 @@ def test_re_t54_re_t54_v(save_xml):
         instance="msData/regex/reT54.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t53_re_t53_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0CE5;',
@@ -7838,11 +8340,12 @@ def test_re_t53_re_t53_v(save_xml):
         instance="msData/regex/reT53.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t52_re_t52_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0C65;',
@@ -7854,11 +8357,12 @@ def test_re_t52_re_t52_v(save_xml):
         instance="msData/regex/reT52.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t51_re_t51_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0BE6;',
@@ -7870,11 +8374,12 @@ def test_re_t51_re_t51_v(save_xml):
         instance="msData/regex/reT51.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t50_re_t50_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0B65;',
@@ -7886,11 +8391,12 @@ def test_re_t50_re_t50_v(save_xml):
         instance="msData/regex/reT50.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t49_re_t49_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0AE5;',
@@ -7902,11 +8408,12 @@ def test_re_t49_re_t49_v(save_xml):
         instance="msData/regex/reT49.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t48_re_t48_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0A65;',
@@ -7918,11 +8425,12 @@ def test_re_t48_re_t48_v(save_xml):
         instance="msData/regex/reT48.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t47_re_t47_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x09E5;',
@@ -7934,11 +8442,12 @@ def test_re_t47_re_t47_v(save_xml):
         instance="msData/regex/reT47.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t46_re_t46_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0965;',
@@ -7950,11 +8459,12 @@ def test_re_t46_re_t46_v(save_xml):
         instance="msData/regex/reT46.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t45_re_t45_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x06EE;',
@@ -7966,11 +8476,12 @@ def test_re_t45_re_t45_v(save_xml):
         instance="msData/regex/reT45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t44_re_t44_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0659;',
@@ -7982,11 +8493,12 @@ def test_re_t44_re_t44_v(save_xml):
         instance="msData/regex/reT44.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t43_re_t43_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0029;',
@@ -7998,11 +8510,12 @@ def test_re_t43_re_t43_v(save_xml):
         instance="msData/regex/reT43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t42_re_t42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1D7FF;',
@@ -8014,11 +8527,12 @@ def test_re_t42_re_t42_i(save_xml):
         instance="msData/regex/reT42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t41_re_t41_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#xFF19;',
@@ -8030,11 +8544,12 @@ def test_re_t41_re_t41_i(save_xml):
         instance="msData/regex/reT41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t40_re_t40_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1819;',
@@ -8046,11 +8561,12 @@ def test_re_t40_re_t40_i(save_xml):
         instance="msData/regex/reT40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t39_re_t39_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x17E9;',
@@ -8062,11 +8578,12 @@ def test_re_t39_re_t39_i(save_xml):
         instance="msData/regex/reT39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t38_re_t38_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1371;',
@@ -8078,11 +8595,12 @@ def test_re_t38_re_t38_i(save_xml):
         instance="msData/regex/reT38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t37_re_t37_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1049;',
@@ -8094,11 +8612,12 @@ def test_re_t37_re_t37_i(save_xml):
         instance="msData/regex/reT37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t36_re_t36_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0F29;',
@@ -8110,11 +8629,12 @@ def test_re_t36_re_t36_i(save_xml):
         instance="msData/regex/reT36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t35_re_t35_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0ED9;',
@@ -8126,11 +8646,12 @@ def test_re_t35_re_t35_i(save_xml):
         instance="msData/regex/reT35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t34_re_t34_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0E59;',
@@ -8142,11 +8663,12 @@ def test_re_t34_re_t34_i(save_xml):
         instance="msData/regex/reT34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t33_re_t33_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0D6F;',
@@ -8158,11 +8680,12 @@ def test_re_t33_re_t33_i(save_xml):
         instance="msData/regex/reT33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t32_re_t32_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0CEF;',
@@ -8174,11 +8697,12 @@ def test_re_t32_re_t32_i(save_xml):
         instance="msData/regex/reT32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t31_re_t31_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0C6F;',
@@ -8190,11 +8714,12 @@ def test_re_t31_re_t31_i(save_xml):
         instance="msData/regex/reT31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t30_re_t30_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0BEF;',
@@ -8206,11 +8731,12 @@ def test_re_t30_re_t30_i(save_xml):
         instance="msData/regex/reT30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t29_re_t29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0B6F;',
@@ -8222,11 +8748,12 @@ def test_re_t29_re_t29_i(save_xml):
         instance="msData/regex/reT29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t28_re_t28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0AEF;',
@@ -8238,11 +8765,12 @@ def test_re_t28_re_t28_i(save_xml):
         instance="msData/regex/reT28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t27_re_t27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0A6F;',
@@ -8254,11 +8782,12 @@ def test_re_t27_re_t27_i(save_xml):
         instance="msData/regex/reT27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t26_re_t26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x09EF;',
@@ -8270,11 +8799,12 @@ def test_re_t26_re_t26_i(save_xml):
         instance="msData/regex/reT26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t25_re_t25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x096F;',
@@ -8286,11 +8816,12 @@ def test_re_t25_re_t25_i(save_xml):
         instance="msData/regex/reT25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t24_re_t24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x06F9;',
@@ -8302,11 +8833,12 @@ def test_re_t24_re_t24_i(save_xml):
         instance="msData/regex/reT24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t23_re_t23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0669;',
@@ -8318,11 +8850,12 @@ def test_re_t23_re_t23_i(save_xml):
         instance="msData/regex/reT23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t22_re_t22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0039;',
@@ -8334,11 +8867,12 @@ def test_re_t22_re_t22_i(save_xml):
         instance="msData/regex/reT22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t21_re_t21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1D7CE;',
@@ -8350,11 +8884,12 @@ def test_re_t21_re_t21_i(save_xml):
         instance="msData/regex/reT21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t20_re_t20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#xFF10;',
@@ -8366,11 +8901,12 @@ def test_re_t20_re_t20_i(save_xml):
         instance="msData/regex/reT20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t19_re_t19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1810;',
@@ -8382,11 +8918,12 @@ def test_re_t19_re_t19_i(save_xml):
         instance="msData/regex/reT19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t18_re_t18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x17E0;',
@@ -8398,11 +8935,12 @@ def test_re_t18_re_t18_i(save_xml):
         instance="msData/regex/reT18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t17_re_t17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1369;',
@@ -8414,11 +8952,12 @@ def test_re_t17_re_t17_i(save_xml):
         instance="msData/regex/reT17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t16_re_t16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x1040;',
@@ -8430,11 +8969,12 @@ def test_re_t16_re_t16_i(save_xml):
         instance="msData/regex/reT16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t15_re_t15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0F20;',
@@ -8446,11 +8986,12 @@ def test_re_t15_re_t15_i(save_xml):
         instance="msData/regex/reT15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t14_re_t14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0ED0;',
@@ -8462,11 +9003,12 @@ def test_re_t14_re_t14_i(save_xml):
         instance="msData/regex/reT14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t13_re_t13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0E50;',
@@ -8478,11 +9020,12 @@ def test_re_t13_re_t13_i(save_xml):
         instance="msData/regex/reT13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t12_re_t12_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0D66;',
@@ -8494,11 +9037,12 @@ def test_re_t12_re_t12_i(save_xml):
         instance="msData/regex/reT12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t11_re_t11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0CE6;',
@@ -8510,11 +9054,12 @@ def test_re_t11_re_t11_i(save_xml):
         instance="msData/regex/reT11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t10_re_t10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0C66;',
@@ -8526,11 +9071,12 @@ def test_re_t10_re_t10_i(save_xml):
         instance="msData/regex/reT10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t9_re_t9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0BE7;',
@@ -8542,11 +9088,12 @@ def test_re_t9_re_t9_i(save_xml):
         instance="msData/regex/reT9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t7_re_t7_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0AE6;',
@@ -8558,11 +9105,12 @@ def test_re_t7_re_t7_i(save_xml):
         instance="msData/regex/reT7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t5_re_t5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x09E6;',
@@ -8574,11 +9122,12 @@ def test_re_t5_re_t5_i(save_xml):
         instance="msData/regex/reT5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t4_re_t4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0966;',
@@ -8590,11 +9139,12 @@ def test_re_t4_re_t4_i(save_xml):
         instance="msData/regex/reT4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t3_re_t3_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x06F0;',
@@ -8606,11 +9156,12 @@ def test_re_t3_re_t3_i(save_xml):
         instance="msData/regex/reT3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t2_re_t2_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0660;',
@@ -8622,11 +9173,12 @@ def test_re_t2_re_t2_i(save_xml):
         instance="msData/regex/reT2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_t1_re_t1_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\D', value='#x0030;',
@@ -8638,11 +9190,12 @@ def test_re_t1_re_t1_i(save_xml):
         instance="msData/regex/reT1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s84_re_s84_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1D800;',
@@ -8654,11 +9207,12 @@ def test_re_s84_re_s84_i(save_xml):
         instance="msData/regex/reS84.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s83_re_s83_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#xFF1A;',
@@ -8670,11 +9224,12 @@ def test_re_s83_re_s83_i(save_xml):
         instance="msData/regex/reS83.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s82_re_s82_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x181A;',
@@ -8686,11 +9241,12 @@ def test_re_s82_re_s82_i(save_xml):
         instance="msData/regex/reS82.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s81_re_s81_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x17EA;',
@@ -8702,11 +9258,12 @@ def test_re_s81_re_s81_i(save_xml):
         instance="msData/regex/reS81.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s80_re_s80_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1372;',
@@ -8718,11 +9275,12 @@ def test_re_s80_re_s80_i(save_xml):
         instance="msData/regex/reS80.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s79_re_s79_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x104A;',
@@ -8734,11 +9292,12 @@ def test_re_s79_re_s79_i(save_xml):
         instance="msData/regex/reS79.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s78_re_s78_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0F2A;',
@@ -8750,11 +9309,12 @@ def test_re_s78_re_s78_i(save_xml):
         instance="msData/regex/reS78.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s77_re_s77_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0EDA;',
@@ -8766,11 +9326,12 @@ def test_re_s77_re_s77_i(save_xml):
         instance="msData/regex/reS77.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s76_re_s76_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0E5A;',
@@ -8782,11 +9343,12 @@ def test_re_s76_re_s76_i(save_xml):
         instance="msData/regex/reS76.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s75_re_s75_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0D70;',
@@ -8798,11 +9360,12 @@ def test_re_s75_re_s75_i(save_xml):
         instance="msData/regex/reS75.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s74_re_s74_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0CF0;',
@@ -8814,11 +9377,12 @@ def test_re_s74_re_s74_i(save_xml):
         instance="msData/regex/reS74.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s73_re_s73_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0C70;',
@@ -8830,11 +9394,12 @@ def test_re_s73_re_s73_i(save_xml):
         instance="msData/regex/reS73.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s72_re_s72_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0BF0;',
@@ -8846,11 +9411,12 @@ def test_re_s72_re_s72_i(save_xml):
         instance="msData/regex/reS72.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s71_re_s71_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0B70;',
@@ -8862,11 +9428,12 @@ def test_re_s71_re_s71_i(save_xml):
         instance="msData/regex/reS71.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s70_re_s70_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0AF0;',
@@ -8878,11 +9445,12 @@ def test_re_s70_re_s70_i(save_xml):
         instance="msData/regex/reS70.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s69_re_s69_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0A79;',
@@ -8894,11 +9462,12 @@ def test_re_s69_re_s69_i(save_xml):
         instance="msData/regex/reS69.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s68_re_s68_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x09F0;',
@@ -8910,11 +9479,12 @@ def test_re_s68_re_s68_i(save_xml):
         instance="msData/regex/reS68.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s67_re_s67_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0970;',
@@ -8926,11 +9496,12 @@ def test_re_s67_re_s67_i(save_xml):
         instance="msData/regex/reS67.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s66_re_s66_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x06FA;',
@@ -8942,11 +9513,12 @@ def test_re_s66_re_s66_i(save_xml):
         instance="msData/regex/reS66.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s65_re_s65_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x066A;',
@@ -8958,11 +9530,12 @@ def test_re_s65_re_s65_i(save_xml):
         instance="msData/regex/reS65.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s64_re_s64_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x003A;',
@@ -8974,11 +9547,12 @@ def test_re_s64_re_s64_i(save_xml):
         instance="msData/regex/reS64.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s63_re_s63_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1D7CD;',
@@ -8990,11 +9564,12 @@ def test_re_s63_re_s63_i(save_xml):
         instance="msData/regex/reS63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s62_re_s62_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#xFF09;',
@@ -9006,11 +9581,12 @@ def test_re_s62_re_s62_i(save_xml):
         instance="msData/regex/reS62.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s61_re_s61_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1809;',
@@ -9022,11 +9598,12 @@ def test_re_s61_re_s61_i(save_xml):
         instance="msData/regex/reS61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s60_re_s60_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x17DF;',
@@ -9038,11 +9615,12 @@ def test_re_s60_re_s60_i(save_xml):
         instance="msData/regex/reS60.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s59_re_s59_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1368;',
@@ -9054,11 +9632,12 @@ def test_re_s59_re_s59_i(save_xml):
         instance="msData/regex/reS59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s58_re_s58_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1039;',
@@ -9070,11 +9649,12 @@ def test_re_s58_re_s58_i(save_xml):
         instance="msData/regex/reS58.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s57_re_s57_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0F19;',
@@ -9086,11 +9666,12 @@ def test_re_s57_re_s57_i(save_xml):
         instance="msData/regex/reS57.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s56_re_s56_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0ECF;',
@@ -9102,11 +9683,12 @@ def test_re_s56_re_s56_i(save_xml):
         instance="msData/regex/reS56.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s55_re_s55_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0E49;',
@@ -9118,11 +9700,12 @@ def test_re_s55_re_s55_i(save_xml):
         instance="msData/regex/reS55.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s54_re_s54_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0D65;',
@@ -9134,11 +9717,12 @@ def test_re_s54_re_s54_i(save_xml):
         instance="msData/regex/reS54.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s53_re_s53_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0CE5;',
@@ -9150,11 +9734,12 @@ def test_re_s53_re_s53_i(save_xml):
         instance="msData/regex/reS53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s52_re_s52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0C65;',
@@ -9166,11 +9751,12 @@ def test_re_s52_re_s52_i(save_xml):
         instance="msData/regex/reS52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s51_re_s51_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0BE6;',
@@ -9182,11 +9768,12 @@ def test_re_s51_re_s51_i(save_xml):
         instance="msData/regex/reS51.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s50_re_s50_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0B65;',
@@ -9198,11 +9785,12 @@ def test_re_s50_re_s50_i(save_xml):
         instance="msData/regex/reS50.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s49_re_s49_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0AE5;',
@@ -9214,11 +9802,12 @@ def test_re_s49_re_s49_i(save_xml):
         instance="msData/regex/reS49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s48_re_s48_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0A65;',
@@ -9230,11 +9819,12 @@ def test_re_s48_re_s48_i(save_xml):
         instance="msData/regex/reS48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s47_re_s47_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x09E5;',
@@ -9246,11 +9836,12 @@ def test_re_s47_re_s47_i(save_xml):
         instance="msData/regex/reS47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s46_re_s46_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0965;',
@@ -9262,11 +9853,12 @@ def test_re_s46_re_s46_i(save_xml):
         instance="msData/regex/reS46.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s45_re_s45_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x06EE;',
@@ -9278,11 +9870,12 @@ def test_re_s45_re_s45_i(save_xml):
         instance="msData/regex/reS45.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s44_re_s44_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0659;',
@@ -9294,11 +9887,12 @@ def test_re_s44_re_s44_i(save_xml):
         instance="msData/regex/reS44.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s43_re_s43_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0029;',
@@ -9310,11 +9904,12 @@ def test_re_s43_re_s43_i(save_xml):
         instance="msData/regex/reS43.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s42_re_s42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1D7FF;',
@@ -9326,11 +9921,12 @@ def test_re_s42_re_s42_i(save_xml):
         instance="msData/regex/reS42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s41_re_s41_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#xFF19;',
@@ -9342,11 +9938,12 @@ def test_re_s41_re_s41_v(save_xml):
         instance="msData/regex/reS41.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s40_re_s40_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1819;',
@@ -9358,11 +9955,12 @@ def test_re_s40_re_s40_v(save_xml):
         instance="msData/regex/reS40.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s39_re_s39_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x17E9;',
@@ -9374,11 +9972,12 @@ def test_re_s39_re_s39_v(save_xml):
         instance="msData/regex/reS39.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s38_re_s38_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1371;',
@@ -9390,11 +9989,12 @@ def test_re_s38_re_s38_v(save_xml):
         instance="msData/regex/reS38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s37_re_s37_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1049;',
@@ -9406,11 +10006,12 @@ def test_re_s37_re_s37_v(save_xml):
         instance="msData/regex/reS37.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s36_re_s36_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0F29;',
@@ -9422,11 +10023,12 @@ def test_re_s36_re_s36_v(save_xml):
         instance="msData/regex/reS36.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s35_re_s35_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0ED9;',
@@ -9438,11 +10040,12 @@ def test_re_s35_re_s35_v(save_xml):
         instance="msData/regex/reS35.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s34_re_s34_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0E59;',
@@ -9454,11 +10057,12 @@ def test_re_s34_re_s34_v(save_xml):
         instance="msData/regex/reS34.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s33_re_s33_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0D6F;',
@@ -9470,11 +10074,12 @@ def test_re_s33_re_s33_v(save_xml):
         instance="msData/regex/reS33.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s32_re_s32_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0CEF;',
@@ -9486,11 +10091,12 @@ def test_re_s32_re_s32_v(save_xml):
         instance="msData/regex/reS32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s31_re_s31_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0C6F;',
@@ -9502,11 +10108,12 @@ def test_re_s31_re_s31_v(save_xml):
         instance="msData/regex/reS31.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s30_re_s30_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0BEF;',
@@ -9518,11 +10125,12 @@ def test_re_s30_re_s30_v(save_xml):
         instance="msData/regex/reS30.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s29_re_s29_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0B6F;',
@@ -9534,11 +10142,12 @@ def test_re_s29_re_s29_v(save_xml):
         instance="msData/regex/reS29.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s28_re_s28_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0AEF;',
@@ -9550,11 +10159,12 @@ def test_re_s28_re_s28_v(save_xml):
         instance="msData/regex/reS28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s27_re_s27_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0A6F;',
@@ -9566,11 +10176,12 @@ def test_re_s27_re_s27_v(save_xml):
         instance="msData/regex/reS27.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s26_re_s26_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x09EF;',
@@ -9582,11 +10193,12 @@ def test_re_s26_re_s26_v(save_xml):
         instance="msData/regex/reS26.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s25_re_s25_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x096F;',
@@ -9598,11 +10210,12 @@ def test_re_s25_re_s25_v(save_xml):
         instance="msData/regex/reS25.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s24_re_s24_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x06F9;',
@@ -9614,11 +10227,12 @@ def test_re_s24_re_s24_v(save_xml):
         instance="msData/regex/reS24.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s23_re_s23_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0669;',
@@ -9630,11 +10244,12 @@ def test_re_s23_re_s23_v(save_xml):
         instance="msData/regex/reS23.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s22_re_s22_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0039;',
@@ -9646,11 +10261,12 @@ def test_re_s22_re_s22_v(save_xml):
         instance="msData/regex/reS22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s21_re_s21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1D7CE;',
@@ -9662,11 +10278,12 @@ def test_re_s21_re_s21_i(save_xml):
         instance="msData/regex/reS21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s20_re_s20_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#xFF10;',
@@ -9678,11 +10295,12 @@ def test_re_s20_re_s20_v(save_xml):
         instance="msData/regex/reS20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s19_re_s19_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1810;',
@@ -9694,11 +10312,12 @@ def test_re_s19_re_s19_v(save_xml):
         instance="msData/regex/reS19.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s18_re_s18_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x17E0;',
@@ -9710,11 +10329,12 @@ def test_re_s18_re_s18_v(save_xml):
         instance="msData/regex/reS18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s17_re_s17_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1369;',
@@ -9726,11 +10346,12 @@ def test_re_s17_re_s17_v(save_xml):
         instance="msData/regex/reS17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s16_re_s16_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x1040;',
@@ -9742,11 +10363,12 @@ def test_re_s16_re_s16_v(save_xml):
         instance="msData/regex/reS16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s15_re_s15_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0F20;',
@@ -9758,11 +10380,12 @@ def test_re_s15_re_s15_v(save_xml):
         instance="msData/regex/reS15.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s14_re_s14_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0ED0;',
@@ -9774,11 +10397,12 @@ def test_re_s14_re_s14_v(save_xml):
         instance="msData/regex/reS14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s13_re_s13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0E50;',
@@ -9790,11 +10414,12 @@ def test_re_s13_re_s13_v(save_xml):
         instance="msData/regex/reS13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s12_re_s12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0D66;',
@@ -9806,11 +10431,12 @@ def test_re_s12_re_s12_v(save_xml):
         instance="msData/regex/reS12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s11_re_s11_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0CE6;',
@@ -9822,11 +10448,12 @@ def test_re_s11_re_s11_v(save_xml):
         instance="msData/regex/reS11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s10_re_s10_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0C66;',
@@ -9838,11 +10465,12 @@ def test_re_s10_re_s10_v(save_xml):
         instance="msData/regex/reS10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s9_re_s9_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0BE7;',
@@ -9854,11 +10482,12 @@ def test_re_s9_re_s9_v(save_xml):
         instance="msData/regex/reS9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s8_re_s8_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0B66;',
@@ -9870,11 +10499,12 @@ def test_re_s8_re_s8_v(save_xml):
         instance="msData/regex/reS8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s7_re_s7_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0AE6;',
@@ -9886,11 +10516,12 @@ def test_re_s7_re_s7_v(save_xml):
         instance="msData/regex/reS7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s6_re_s6_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0A66;',
@@ -9902,11 +10533,12 @@ def test_re_s6_re_s6_v(save_xml):
         instance="msData/regex/reS6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s5_re_s5_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x09E6;',
@@ -9918,11 +10550,12 @@ def test_re_s5_re_s5_v(save_xml):
         instance="msData/regex/reS5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s3_re_s3_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x06F0;',
@@ -9934,11 +10567,12 @@ def test_re_s3_re_s3_v(save_xml):
         instance="msData/regex/reS3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_s1_re_s1_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\d', value='#x0030;',
@@ -9950,11 +10584,12 @@ def test_re_s1_re_s1_v(save_xml):
         instance="msData/regex/reS1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r29_re_r29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*',
@@ -9966,11 +10601,12 @@ def test_re_r29_re_r29_i(save_xml):
         instance="msData/regex/reR29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r28_re_r28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*',
@@ -9982,11 +10618,12 @@ def test_re_r28_re_r28_i(save_xml):
         instance="msData/regex/reR28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r27_re_r27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*',
@@ -9998,11 +10635,12 @@ def test_re_r27_re_r27_i(save_xml):
         instance="msData/regex/reR27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r26_re_r26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*',
@@ -10014,11 +10652,12 @@ def test_re_r26_re_r26_i(save_xml):
         instance="msData/regex/reR26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r25_re_r25_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*', value='aa2a',
@@ -10030,11 +10669,12 @@ def test_re_r25_re_r25_v(save_xml):
         instance="msData/regex/reR25.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r24_re_r24_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*',
@@ -10046,11 +10686,12 @@ def test_re_r24_re_r24_v(save_xml):
         instance="msData/regex/reR24.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r23_re_r23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\C?\c\C+\c\C*', value='',
@@ -10062,11 +10703,12 @@ def test_re_r23_re_r23_i(save_xml):
         instance="msData/regex/reR23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r22_re_r22_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value='#x9;',
@@ -10078,11 +10720,12 @@ def test_re_r22_re_r22_v(save_xml):
         instance="msData/regex/reR22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r21_re_r21_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value='#xD;',
@@ -10094,11 +10737,12 @@ def test_re_r21_re_r21_v(save_xml):
         instance="msData/regex/reR21.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r20_re_r20_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value='#xA;',
@@ -10110,11 +10754,12 @@ def test_re_r20_re_r20_v(save_xml):
         instance="msData/regex/reR20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r19_re_r19_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value='#x20;',
@@ -10126,11 +10771,12 @@ def test_re_r19_re_r19_v(save_xml):
         instance="msData/regex/reR19.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r18_re_r18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value='a', type='invalid',
@@ -10142,11 +10788,12 @@ def test_re_r18_re_r18_i(save_xml):
         instance="msData/regex/reR18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r17_re_r17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value=':', type='invalid',
@@ -10158,11 +10805,12 @@ def test_re_r17_re_r17_i(save_xml):
         instance="msData/regex/reR17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r16_re_r16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\C', value='_', type='invalid',
@@ -10174,11 +10822,12 @@ def test_re_r16_re_r16_i(save_xml):
         instance="msData/regex/reR16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r15_re_r15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\c+\c*', value='',
@@ -10190,11 +10839,12 @@ def test_re_r15_re_r15_i(save_xml):
         instance="msData/regex/reR15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r14_re_r14_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\c+\c*',
@@ -10206,11 +10856,12 @@ def test_re_r14_re_r14_v(save_xml):
         instance="msData/regex/reR14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r13_re_r13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\c+\c*', value='aa',
@@ -10222,11 +10873,12 @@ def test_re_r13_re_r13_v(save_xml):
         instance="msData/regex/reR13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r12_re_r12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\c+\c*', value='a',
@@ -10238,11 +10890,12 @@ def test_re_r12_re_r12_v(save_xml):
         instance="msData/regex/reR12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r11_re_r11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\?\d\s\c+', value='a?2#xa;',
@@ -10254,11 +10907,12 @@ def test_re_r11_re_r11_i(save_xml):
         instance="msData/regex/reR11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r10_re_r10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\?\d\s\c+', value='aa?3 c',
@@ -10270,11 +10924,12 @@ def test_re_r10_re_r10_i(save_xml):
         instance="msData/regex/reR10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r9_re_r9_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\?\d\s\c+',
@@ -10286,11 +10941,12 @@ def test_re_r9_re_r9_v(save_xml):
         instance="msData/regex/reR9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r8_re_r8_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c?\?\d\s\c+', value='c?1 abc',
@@ -10302,11 +10958,12 @@ def test_re_r8_re_r8_v(save_xml):
         instance="msData/regex/reR8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r7_re_r7_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value='#x9;',
@@ -10318,11 +10975,12 @@ def test_re_r7_re_r7_i(save_xml):
         instance="msData/regex/reR7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r6_re_r6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value='#xD;',
@@ -10334,11 +10992,12 @@ def test_re_r6_re_r6_i(save_xml):
         instance="msData/regex/reR6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r5_re_r5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value='#xA;',
@@ -10350,11 +11009,12 @@ def test_re_r5_re_r5_i(save_xml):
         instance="msData/regex/reR5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r4_re_r4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value='#x20;',
@@ -10366,11 +11026,12 @@ def test_re_r4_re_r4_i(save_xml):
         instance="msData/regex/reR4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r3_re_r3_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value='a', type='valid',
@@ -10382,11 +11043,12 @@ def test_re_r3_re_r3_v(save_xml):
         instance="msData/regex/reR3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r2_re_r2_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value=':', type='valid',
@@ -10398,11 +11060,12 @@ def test_re_r2_re_r2_v(save_xml):
         instance="msData/regex/reR2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_r1_re_r1_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c', value='_', type='valid',
@@ -10414,11 +11077,12 @@ def test_re_r1_re_r1_v(save_xml):
         instance="msData/regex/reR1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q24_re_q24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\I+\c', value='a123 123cc',
@@ -10430,11 +11094,12 @@ def test_re_q24_re_q24_i(save_xml):
         instance="msData/regex/reQ24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q23_re_q23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\I+\c', value='b123c',
@@ -10446,11 +11111,12 @@ def test_re_q23_re_q23_i(save_xml):
         instance="msData/regex/reQ23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q22_re_q22_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\I+\c', value='a 123c',
@@ -10462,11 +11128,12 @@ def test_re_q22_re_q22_v(save_xml):
         instance="msData/regex/reQ22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q21_re_q21_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I*', value='1234',
@@ -10478,11 +11145,12 @@ def test_re_q21_re_q21_v(save_xml):
         instance="msData/regex/reQ21.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q20_re_q20_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value='#x9;',
@@ -10494,11 +11162,12 @@ def test_re_q20_re_q20_v(save_xml):
         instance="msData/regex/reQ20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q19_re_q19_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value='#xD;',
@@ -10510,11 +11179,12 @@ def test_re_q19_re_q19_v(save_xml):
         instance="msData/regex/reQ19.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q18_re_q18_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value='#xA;',
@@ -10526,11 +11196,12 @@ def test_re_q18_re_q18_v(save_xml):
         instance="msData/regex/reQ18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q17_re_q17_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value='#x20;',
@@ -10542,11 +11213,12 @@ def test_re_q17_re_q17_v(save_xml):
         instance="msData/regex/reQ17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q16_re_q16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value='a', type='invalid',
@@ -10558,11 +11230,12 @@ def test_re_q16_re_q16_i(save_xml):
         instance="msData/regex/reQ16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q15_re_q15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value=':', type='invalid',
@@ -10574,11 +11247,12 @@ def test_re_q15_re_q15_i(save_xml):
         instance="msData/regex/reQ15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q14_re_q14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\I', value='_', type='invalid',
@@ -10590,11 +11264,12 @@ def test_re_q14_re_q14_i(save_xml):
         instance="msData/regex/reQ14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q13_re_q13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\s\i]*', value='1',
@@ -10606,11 +11281,12 @@ def test_re_q13_re_q13_i(save_xml):
         instance="msData/regex/reQ13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q12_re_q12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\s\i]*', value='a b c Z :_
@@ -10622,11 +11298,12 @@ def test_re_q12_re_q12_v(save_xml):
         instance="msData/regex/reQ12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q11_re_q11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\i*a', value='ab',
@@ -10638,11 +11315,12 @@ def test_re_q11_re_q11_i(save_xml):
         instance="msData/regex/reQ11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q10_re_q10_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c\i*a', value='zabcsdea',
@@ -10654,11 +11332,12 @@ def test_re_q10_re_q10_v(save_xml):
         instance="msData/regex/reQ10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q9_re_q9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i+', value='a b',
@@ -10670,11 +11349,12 @@ def test_re_q9_re_q9_i(save_xml):
         instance="msData/regex/reQ9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q8_re_q8_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i*',
@@ -10686,11 +11366,12 @@ def test_re_q8_re_q8_v(save_xml):
         instance="msData/regex/reQ8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q7_re_q7_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value='#x9;',
@@ -10702,11 +11383,12 @@ def test_re_q7_re_q7_i(save_xml):
         instance="msData/regex/reQ7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q6_re_q6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value='#xD;',
@@ -10718,11 +11400,12 @@ def test_re_q6_re_q6_i(save_xml):
         instance="msData/regex/reQ6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q5_re_q5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value='#xA;',
@@ -10734,11 +11417,12 @@ def test_re_q5_re_q5_i(save_xml):
         instance="msData/regex/reQ5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q4_re_q4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value='#x20;',
@@ -10750,11 +11434,12 @@ def test_re_q4_re_q4_i(save_xml):
         instance="msData/regex/reQ4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q3_re_q3_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value='a', type='valid',
@@ -10766,11 +11451,12 @@ def test_re_q3_re_q3_v(save_xml):
         instance="msData/regex/reQ3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q2_re_q2_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value=':', type='valid',
@@ -10782,11 +11468,12 @@ def test_re_q2_re_q2_v(save_xml):
         instance="msData/regex/reQ2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_q1_re_q1_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\i', value='_', type='valid',
@@ -10798,11 +11485,12 @@ def test_re_q1_re_q1_v(save_xml):
         instance="msData/regex/reQ1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p30_re_p30_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S?\s?\S?\s+', value='ab',
@@ -10814,11 +11502,12 @@ def test_re_p30_re_p30_i(save_xml):
         instance="msData/regex/reP30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p29_re_p29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S?\s?\S?\s+', value=' a b',
@@ -10830,11 +11519,12 @@ def test_re_p29_re_p29_i(save_xml):
         instance="msData/regex/reP29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p28_re_p28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S?\s?\S?\s+', value='a b',
@@ -10846,11 +11536,12 @@ def test_re_p28_re_p28_i(save_xml):
         instance="msData/regex/reP28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p27_re_p27_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S?\s?\S?\s+', value=' a #xD;',
@@ -10862,11 +11553,12 @@ def test_re_p27_re_p27_v(save_xml):
         instance="msData/regex/reP27.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p26_re_p26_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S?\s?\S?\s+', value='a b#x9;',
@@ -10878,11 +11570,12 @@ def test_re_p26_re_p26_v(save_xml):
         instance="msData/regex/reP26.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p25_re_p25_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S*', value='', type='valid',
@@ -10894,11 +11587,12 @@ def test_re_p25_re_p25_v(save_xml):
         instance="msData/regex/reP25.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p24_re_p24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S+', value='a#x20;b',
@@ -10910,11 +11604,12 @@ def test_re_p24_re_p24_i(save_xml):
         instance="msData/regex/reP24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p23_re_p23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S', value='aa',
@@ -10926,11 +11621,12 @@ def test_re_p23_re_p23_i(save_xml):
         instance="msData/regex/reP23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p22_re_p22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S', value='#x9;',
@@ -10942,11 +11638,12 @@ def test_re_p22_re_p22_i(save_xml):
         instance="msData/regex/reP22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p21_re_p21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S', value='#xD;',
@@ -10958,11 +11655,12 @@ def test_re_p21_re_p21_i(save_xml):
         instance="msData/regex/reP21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p20_re_p20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S', value='#xA;',
@@ -10974,11 +11672,12 @@ def test_re_p20_re_p20_i(save_xml):
         instance="msData/regex/reP20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p19_re_p19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S', value='#x20;',
@@ -10990,11 +11689,12 @@ def test_re_p19_re_p19_i(save_xml):
         instance="msData/regex/reP19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p18_re_p18_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\S', value='a', type='valid',
@@ -11006,11 +11706,12 @@ def test_re_p18_re_p18_v(save_xml):
         instance="msData/regex/reP18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p17_re_p17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value='#x20;#xA;',
@@ -11022,11 +11723,12 @@ def test_re_p17_re_p17_i(save_xml):
         instance="msData/regex/reP17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p16_re_p16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value=' ', type='invalid',
@@ -11038,11 +11740,12 @@ def test_re_p16_re_p16_i(save_xml):
         instance="msData/regex/reP16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p15_re_p15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\s{0,3}a', value='aa a',
@@ -11054,11 +11757,12 @@ def test_re_p15_re_p15_i(save_xml):
         instance="msData/regex/reP15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p14_re_p14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\s{0,3}a', value='a a',
@@ -11070,11 +11774,12 @@ def test_re_p14_re_p14_i(save_xml):
         instance="msData/regex/reP14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p13_re_p13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\s{0,3}a', value='a a',
@@ -11086,11 +11791,12 @@ def test_re_p13_re_p13_v(save_xml):
         instance="msData/regex/reP13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p12_re_p12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\s{0,3}a', value='a a',
@@ -11102,11 +11808,12 @@ def test_re_p12_re_p12_v(save_xml):
         instance="msData/regex/reP12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p11_re_p11_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\s{0,3}a', value='aa',
@@ -11118,11 +11825,12 @@ def test_re_p11_re_p11_v(save_xml):
         instance="msData/regex/reP11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p10_re_p10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s*\c\s?\c\s+\c\s*', value=' a
@@ -11134,11 +11842,12 @@ def test_re_p10_re_p10_i(save_xml):
         instance="msData/regex/reP10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p9_re_p9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s*\c\s?\c\s+\c\s*',
@@ -11150,11 +11859,12 @@ def test_re_p9_re_p9_i(save_xml):
         instance="msData/regex/reP9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p8_re_p8_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s*\c\s?\c\s+\c\s*', value=' a
@@ -11166,11 +11876,12 @@ def test_re_p8_re_p8_i(save_xml):
         instance="msData/regex/reP8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p7_re_p7_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s*\c\s?\c\s+\c\s*', value='aa
@@ -11182,11 +11893,12 @@ def test_re_p7_re_p7_v(save_xml):
         instance="msData/regex/reP7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p6_re_p6_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s*\c\s?\c\s+\c\s*', value='
@@ -11199,11 +11911,12 @@ def test_re_p6_re_p6_v(save_xml):
         instance="msData/regex/reP6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p5_re_p5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value='a', type='invalid',
@@ -11215,11 +11928,12 @@ def test_re_p5_re_p5_i(save_xml):
         instance="msData/regex/reP5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p4_re_p4_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value='#x9;',
@@ -11231,11 +11945,12 @@ def test_re_p4_re_p4_v(save_xml):
         instance="msData/regex/reP4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p3_re_p3_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value='#xD;',
@@ -11247,11 +11962,12 @@ def test_re_p3_re_p3_v(save_xml):
         instance="msData/regex/reP3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p2_re_p2_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value='#xA;',
@@ -11263,11 +11979,12 @@ def test_re_p2_re_p2_v(save_xml):
         instance="msData/regex/reP2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_p1_re_p1_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\s', value='#x20;',
@@ -11279,11 +11996,12 @@ def test_re_p1_re_p1_v(save_xml):
         instance="msData/regex/reP1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_o4_re_o4_i(save_xml):
     """
     TEST :branch : base='string', pattern='.', value='', type='invalid',
@@ -11295,11 +12013,12 @@ def test_re_o4_re_o4_i(save_xml):
         instance="msData/regex/reO4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_o3_re_o3_i(save_xml):
     """
     TEST :branch : base='string', pattern='.', value='aa', type='invalid',
@@ -11311,11 +12030,12 @@ def test_re_o3_re_o3_i(save_xml):
         instance="msData/regex/reO3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_o2_re_o2_v(save_xml):
     """
     TEST :branch : base='string', pattern='.', value='#x20;',
@@ -11327,11 +12047,12 @@ def test_re_o2_re_o2_v(save_xml):
         instance="msData/regex/reO2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_o1_re_o1_v(save_xml):
     """
     TEST :branch : base='string', pattern='.', value='a', type='valid',
@@ -11343,11 +12064,12 @@ def test_re_o1_re_o1_v(save_xml):
         instance="msData/regex/reO1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n99_re_n99_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}',
@@ -11359,11 +12081,12 @@ def test_re_n99_re_n99_i(save_xml):
         instance="msData/regex/reN99.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n98_re_n98_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}',
@@ -11375,11 +12098,12 @@ def test_re_n98_re_n98_i(save_xml):
         instance="msData/regex/reN98.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n97_re_n97_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTags}', value='#x2FA1F;',
@@ -11391,11 +12115,12 @@ def test_re_n97_re_n97_i(save_xml):
         instance="msData/regex/reN97.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n96_re_n96_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11408,11 +12133,12 @@ def test_re_n96_re_n96_i(save_xml):
         instance="msData/regex/reN96.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n95_re_n95_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11425,11 +12151,12 @@ def test_re_n95_re_n95_i(save_xml):
         instance="msData/regex/reN95.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n94_re_n94_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11442,11 +12169,12 @@ def test_re_n94_re_n94_i(save_xml):
         instance="msData/regex/reN94.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n93_re_n93_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMusicalSymbols}',
@@ -11458,11 +12186,12 @@ def test_re_n93_re_n93_i(save_xml):
         instance="msData/regex/reN93.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n92_re_n92_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsByzantineMusicalSymbols}',
@@ -11474,11 +12203,12 @@ def test_re_n92_re_n92_i(save_xml):
         instance="msData/regex/reN92.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n91_re_n91_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDeseret}',
@@ -11490,11 +12220,12 @@ def test_re_n91_re_n91_i(save_xml):
         instance="msData/regex/reN91.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n90_re_n90_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGothic}',
@@ -11506,11 +12237,12 @@ def test_re_n90_re_n90_i(save_xml):
         instance="msData/regex/reN90.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n89_re_n89_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOldItalic}',
@@ -11522,11 +12254,12 @@ def test_re_n89_re_n89_i(save_xml):
         instance="msData/regex/reN89.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n88_re_n88_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpecials}',
@@ -11538,11 +12271,12 @@ def test_re_n88_re_n88_i(save_xml):
         instance="msData/regex/reN88.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n87_re_n87_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11555,11 +12289,12 @@ def test_re_n87_re_n87_i(save_xml):
         instance="msData/regex/reN87.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n86_re_n86_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpecials}',
@@ -11571,11 +12306,12 @@ def test_re_n86_re_n86_i(save_xml):
         instance="msData/regex/reN86.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n85_re_n85_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11588,11 +12324,12 @@ def test_re_n85_re_n85_i(save_xml):
         instance="msData/regex/reN85.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n84_re_n84_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSmallFormVariants}',
@@ -11604,11 +12341,12 @@ def test_re_n84_re_n84_i(save_xml):
         instance="msData/regex/reN84.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n83_re_n83_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKCompatibilityForms}',
@@ -11620,11 +12358,12 @@ def test_re_n83_re_n83_i(save_xml):
         instance="msData/regex/reN83.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n82_re_n82_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCombiningHalfMarks}',
@@ -11636,11 +12375,12 @@ def test_re_n82_re_n82_i(save_xml):
         instance="msData/regex/reN82.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n81_re_n81_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11653,11 +12393,12 @@ def test_re_n81_re_n81_i(save_xml):
         instance="msData/regex/reN81.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n80_re_n80_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11670,11 +12411,12 @@ def test_re_n80_re_n80_i(save_xml):
         instance="msData/regex/reN80.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n79_re_n79_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11687,11 +12429,12 @@ def test_re_n79_re_n79_i(save_xml):
         instance="msData/regex/reN79.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n75_re_n75_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHighSurrogates}',
@@ -11703,11 +12446,12 @@ def test_re_n75_re_n75_i(save_xml):
         instance="msData/regex/reN75.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n74_re_n74_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHangulSyllables}',
@@ -11719,11 +12463,12 @@ def test_re_n74_re_n74_i(save_xml):
         instance="msData/regex/reN74.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n73_re_n73_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsYiRadicals}',
@@ -11735,11 +12480,12 @@ def test_re_n73_re_n73_i(save_xml):
         instance="msData/regex/reN73.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n72_re_n72_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsYiSyllables}',
@@ -11751,11 +12497,12 @@ def test_re_n72_re_n72_i(save_xml):
         instance="msData/regex/reN72.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n71_re_n71_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKUnifiedIdeographs}',
@@ -11767,11 +12514,12 @@ def test_re_n71_re_n71_i(save_xml):
         instance="msData/regex/reN71.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n70_re_n70_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11784,11 +12532,12 @@ def test_re_n70_re_n70_i(save_xml):
         instance="msData/regex/reN70.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n69_re_n69_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKCompatibility}',
@@ -11800,11 +12549,12 @@ def test_re_n69_re_n69_i(save_xml):
         instance="msData/regex/reN69.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n68_re_n68_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11817,11 +12567,12 @@ def test_re_n68_re_n68_i(save_xml):
         instance="msData/regex/reN68.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n67_re_n67_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBopomofoExtended}',
@@ -11833,11 +12584,12 @@ def test_re_n67_re_n67_i(save_xml):
         instance="msData/regex/reN67.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n66_re_n66_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKanbun}', value='#x318F;',
@@ -11849,11 +12601,12 @@ def test_re_n66_re_n66_i(save_xml):
         instance="msData/regex/reN66.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n65_re_n65_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHangulCompatibilityJamo}',
@@ -11865,11 +12618,12 @@ def test_re_n65_re_n65_i(save_xml):
         instance="msData/regex/reN65.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n64_re_n64_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBopomofo}',
@@ -11881,11 +12635,12 @@ def test_re_n64_re_n64_i(save_xml):
         instance="msData/regex/reN64.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n63_re_n63_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKatakana}',
@@ -11897,11 +12652,12 @@ def test_re_n63_re_n63_i(save_xml):
         instance="msData/regex/reN63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n62_re_n62_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHiragana}',
@@ -11913,11 +12669,12 @@ def test_re_n62_re_n62_i(save_xml):
         instance="msData/regex/reN62.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n61_re_n61_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11930,11 +12687,12 @@ def test_re_n61_re_n61_i(save_xml):
         instance="msData/regex/reN61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n60_re_n60_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -11947,11 +12705,12 @@ def test_re_n60_re_n60_i(save_xml):
         instance="msData/regex/reN60.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n59_re_n59_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKangxiRadicals}',
@@ -11963,11 +12722,12 @@ def test_re_n59_re_n59_i(save_xml):
         instance="msData/regex/reN59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n58_re_n58_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKRadicalsSupplement}',
@@ -11979,11 +12739,12 @@ def test_re_n58_re_n58_i(save_xml):
         instance="msData/regex/reN58.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n57_re_n57_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBraillePatterns}',
@@ -11995,11 +12756,12 @@ def test_re_n57_re_n57_i(save_xml):
         instance="msData/regex/reN57.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n56_re_n56_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDingbats}',
@@ -12011,11 +12773,12 @@ def test_re_n56_re_n56_i(save_xml):
         instance="msData/regex/reN56.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n55_re_n55_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMiscellaneousSymbols}',
@@ -12027,11 +12790,12 @@ def test_re_n55_re_n55_i(save_xml):
         instance="msData/regex/reN55.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n54_re_n54_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeometricShapes}',
@@ -12043,11 +12807,12 @@ def test_re_n54_re_n54_i(save_xml):
         instance="msData/regex/reN54.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n53_re_n53_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBlockElements}',
@@ -12059,11 +12824,12 @@ def test_re_n53_re_n53_i(save_xml):
         instance="msData/regex/reN53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n52_re_n52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBoxDrawing}',
@@ -12075,11 +12841,12 @@ def test_re_n52_re_n52_i(save_xml):
         instance="msData/regex/reN52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n51_re_n51_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsEnclosedAlphanumerics}',
@@ -12091,11 +12858,12 @@ def test_re_n51_re_n51_i(save_xml):
         instance="msData/regex/reN51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n50_re_n50_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12108,11 +12876,12 @@ def test_re_n50_re_n50_i(save_xml):
         instance="msData/regex/reN50.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n49_re_n49_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsControlPictures}',
@@ -12124,11 +12893,12 @@ def test_re_n49_re_n49_i(save_xml):
         instance="msData/regex/reN49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n48_re_n48_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMiscellaneousTechnical}',
@@ -12140,11 +12910,12 @@ def test_re_n48_re_n48_i(save_xml):
         instance="msData/regex/reN48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n47_re_n47_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMathematicalOperators}',
@@ -12156,11 +12927,12 @@ def test_re_n47_re_n47_i(save_xml):
         instance="msData/regex/reN47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n46_re_n46_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArrows}', value='#x218F;',
@@ -12172,11 +12944,12 @@ def test_re_n46_re_n46_i(save_xml):
         instance="msData/regex/reN46.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n45_re_n45_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsNumberForms}',
@@ -12188,11 +12961,12 @@ def test_re_n45_re_n45_i(save_xml):
         instance="msData/regex/reN45.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n44_re_n44_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLetterlikeSymbols}',
@@ -12204,11 +12978,12 @@ def test_re_n44_re_n44_i(save_xml):
         instance="msData/regex/reN44.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n43_re_n43_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12221,11 +12996,12 @@ def test_re_n43_re_n43_i(save_xml):
         instance="msData/regex/reN43.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n42_re_n42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCurrencySymbols}',
@@ -12237,11 +13013,12 @@ def test_re_n42_re_n42_i(save_xml):
         instance="msData/regex/reN42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n41_re_n41_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12254,11 +13031,12 @@ def test_re_n41_re_n41_i(save_xml):
         instance="msData/regex/reN41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n40_re_n40_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeneralPunctuation}',
@@ -12270,11 +13048,12 @@ def test_re_n40_re_n40_i(save_xml):
         instance="msData/regex/reN40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n39_re_n39_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGreekExtended}',
@@ -12286,11 +13065,12 @@ def test_re_n39_re_n39_i(save_xml):
         instance="msData/regex/reN39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n38_re_n38_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtendedAdditional}',
@@ -12302,11 +13082,12 @@ def test_re_n38_re_n38_i(save_xml):
         instance="msData/regex/reN38.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n37_re_n37_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMongolian}',
@@ -12318,11 +13099,12 @@ def test_re_n37_re_n37_i(save_xml):
         instance="msData/regex/reN37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n36_re_n36_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKhmer}', value='#x16FF;',
@@ -12334,11 +13116,12 @@ def test_re_n36_re_n36_i(save_xml):
         instance="msData/regex/reN36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n35_re_n35_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsRunic}', value='#x169F;',
@@ -12350,11 +13133,12 @@ def test_re_n35_re_n35_i(save_xml):
         instance="msData/regex/reN35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n34_re_n34_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOgham}', value='#x167F;',
@@ -12366,11 +13150,12 @@ def test_re_n34_re_n34_i(save_xml):
         instance="msData/regex/reN34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n33_re_n33_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12383,11 +13168,12 @@ def test_re_n33_re_n33_i(save_xml):
         instance="msData/regex/reN33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n32_re_n32_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCherokee}',
@@ -12399,11 +13185,12 @@ def test_re_n32_re_n32_i(save_xml):
         instance="msData/regex/reN32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n31_re_n31_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsEthiopic}',
@@ -12415,11 +13202,12 @@ def test_re_n31_re_n31_i(save_xml):
         instance="msData/regex/reN31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n30_re_n30_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHangulJamo}',
@@ -12431,11 +13219,12 @@ def test_re_n30_re_n30_i(save_xml):
         instance="msData/regex/reN30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n29_re_n29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeorgian}',
@@ -12447,11 +13236,12 @@ def test_re_n29_re_n29_i(save_xml):
         instance="msData/regex/reN29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n28_re_n28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMyanmar}',
@@ -12463,11 +13253,12 @@ def test_re_n28_re_n28_i(save_xml):
         instance="msData/regex/reN28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n27_re_n27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTibetan}',
@@ -12479,11 +13270,12 @@ def test_re_n27_re_n27_i(save_xml):
         instance="msData/regex/reN27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n26_re_n26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLao}', value='#x0E7F;',
@@ -12495,11 +13287,12 @@ def test_re_n26_re_n26_i(save_xml):
         instance="msData/regex/reN26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n25_re_n25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsThai}', value='#x0DFF;',
@@ -12511,11 +13304,12 @@ def test_re_n25_re_n25_i(save_xml):
         instance="msData/regex/reN25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n24_re_n24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSinhala}',
@@ -12527,11 +13321,12 @@ def test_re_n24_re_n24_i(save_xml):
         instance="msData/regex/reN24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n23_re_n23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMalayalam}',
@@ -12543,11 +13338,12 @@ def test_re_n23_re_n23_i(save_xml):
         instance="msData/regex/reN23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n22_re_n22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKannada}',
@@ -12559,11 +13355,12 @@ def test_re_n22_re_n22_i(save_xml):
         instance="msData/regex/reN22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n21_re_n21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTelugu}', value='#x0BFF;',
@@ -12575,11 +13372,12 @@ def test_re_n21_re_n21_i(save_xml):
         instance="msData/regex/reN21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n20_re_n20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTamil}', value='#x0B7F;',
@@ -12591,11 +13389,12 @@ def test_re_n20_re_n20_i(save_xml):
         instance="msData/regex/reN20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n19_re_n19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOriya}', value='#x0AFF;',
@@ -12607,11 +13406,12 @@ def test_re_n19_re_n19_i(save_xml):
         instance="msData/regex/reN19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n18_re_n18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGujarati}',
@@ -12623,11 +13423,12 @@ def test_re_n18_re_n18_i(save_xml):
         instance="msData/regex/reN18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n17_re_n17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGurmukhi}',
@@ -12639,11 +13440,12 @@ def test_re_n17_re_n17_i(save_xml):
         instance="msData/regex/reN17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n16_re_n16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBengali}',
@@ -12655,11 +13457,12 @@ def test_re_n16_re_n16_i(save_xml):
         instance="msData/regex/reN16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n15_re_n15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDevanagari}',
@@ -12671,11 +13474,12 @@ def test_re_n15_re_n15_i(save_xml):
         instance="msData/regex/reN15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n14_re_n14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsThaana}', value='#x074F;',
@@ -12687,11 +13491,12 @@ def test_re_n14_re_n14_i(save_xml):
         instance="msData/regex/reN14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n13_re_n13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSyriac}', value='#x06FF;',
@@ -12703,11 +13508,12 @@ def test_re_n13_re_n13_i(save_xml):
         instance="msData/regex/reN13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n12_re_n12_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArabic}', value='#x05FF;',
@@ -12719,11 +13525,12 @@ def test_re_n12_re_n12_i(save_xml):
         instance="msData/regex/reN12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n11_re_n11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHebrew}', value='#x058F;',
@@ -12735,11 +13542,12 @@ def test_re_n11_re_n11_i(save_xml):
         instance="msData/regex/reN11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n10_re_n10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArmenian}',
@@ -12751,11 +13559,12 @@ def test_re_n10_re_n10_i(save_xml):
         instance="msData/regex/reN10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n9_re_n9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCyrillic}',
@@ -12767,11 +13576,12 @@ def test_re_n9_re_n9_i(save_xml):
         instance="msData/regex/reN9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n8_re_n8_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGreek}', value='#x036F;',
@@ -12783,11 +13593,12 @@ def test_re_n8_re_n8_i(save_xml):
         instance="msData/regex/reN8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n6_re_n6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpacingModifierLetters}',
@@ -12799,11 +13610,12 @@ def test_re_n6_re_n6_i(save_xml):
         instance="msData/regex/reN6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n5_re_n5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsIPAExtensions}',
@@ -12815,11 +13627,12 @@ def test_re_n5_re_n5_i(save_xml):
         instance="msData/regex/reN5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n4_re_n4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtended-B}',
@@ -12831,11 +13644,12 @@ def test_re_n4_re_n4_i(save_xml):
         instance="msData/regex/reN4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n3_re_n3_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtended-A}',
@@ -12847,11 +13661,12 @@ def test_re_n3_re_n3_i(save_xml):
         instance="msData/regex/reN3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n2_re_n2_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatin-1Supplement}',
@@ -12863,11 +13678,12 @@ def test_re_n2_re_n2_i(save_xml):
         instance="msData/regex/reN2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_n1_re_n1_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBasicLatin}',
@@ -12879,11 +13695,12 @@ def test_re_n1_re_n1_i(save_xml):
         instance="msData/regex/reN1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m99_re_m99_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}?',
@@ -12895,11 +13712,12 @@ def test_re_m99_re_m99_i(save_xml):
         instance="msData/regex/reM99.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m98_re_m98_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}?',
@@ -12911,11 +13729,12 @@ def test_re_m98_re_m98_i(save_xml):
         instance="msData/regex/reM98.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m97_re_m97_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTags}?', value='#xF0000;',
@@ -12927,11 +13746,12 @@ def test_re_m97_re_m97_i(save_xml):
         instance="msData/regex/reM97.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m96_re_m96_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12944,11 +13764,12 @@ def test_re_m96_re_m96_i(save_xml):
         instance="msData/regex/reM96.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m95_re_m95_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12961,11 +13782,12 @@ def test_re_m95_re_m95_i(save_xml):
         instance="msData/regex/reM95.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m94_re_m94_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -12978,11 +13800,12 @@ def test_re_m94_re_m94_i(save_xml):
         instance="msData/regex/reM94.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m93_re_m93_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMusicalSymbols}?',
@@ -12994,11 +13817,12 @@ def test_re_m93_re_m93_i(save_xml):
         instance="msData/regex/reM93.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m92_re_m92_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13011,11 +13835,12 @@ def test_re_m92_re_m92_i(save_xml):
         instance="msData/regex/reM92.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m91_re_m91_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDeseret}?',
@@ -13027,11 +13852,12 @@ def test_re_m91_re_m91_i(save_xml):
         instance="msData/regex/reM91.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m90_re_m90_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGothic}?',
@@ -13043,11 +13869,12 @@ def test_re_m90_re_m90_i(save_xml):
         instance="msData/regex/reM90.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m89_re_m89_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOldItalic}?',
@@ -13059,11 +13886,12 @@ def test_re_m89_re_m89_i(save_xml):
         instance="msData/regex/reM89.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m88_re_m88_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpecials}?',
@@ -13075,11 +13903,12 @@ def test_re_m88_re_m88_i(save_xml):
         instance="msData/regex/reM88.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m87_re_m87_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13092,11 +13921,12 @@ def test_re_m87_re_m87_i(save_xml):
         instance="msData/regex/reM87.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m86_re_m86_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpecials}?',
@@ -13108,11 +13938,12 @@ def test_re_m86_re_m86_i(save_xml):
         instance="msData/regex/reM86.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m84_re_m84_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSmallFormVariants}?',
@@ -13124,11 +13955,12 @@ def test_re_m84_re_m84_i(save_xml):
         instance="msData/regex/reM84.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m83_re_m83_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKCompatibilityForms}?',
@@ -13140,11 +13972,12 @@ def test_re_m83_re_m83_i(save_xml):
         instance="msData/regex/reM83.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m82_re_m82_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCombiningHalfMarks}?',
@@ -13156,11 +13989,12 @@ def test_re_m82_re_m82_i(save_xml):
         instance="msData/regex/reM82.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m81_re_m81_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13173,11 +14007,12 @@ def test_re_m81_re_m81_i(save_xml):
         instance="msData/regex/reM81.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m80_re_m80_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13190,11 +14025,12 @@ def test_re_m80_re_m80_i(save_xml):
         instance="msData/regex/reM80.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m79_re_m79_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13207,11 +14043,12 @@ def test_re_m79_re_m79_i(save_xml):
         instance="msData/regex/reM79.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m78_re_m78_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}?',
@@ -13223,11 +14060,12 @@ def test_re_m78_re_m78_i(save_xml):
         instance="msData/regex/reM78.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m77_re_m77_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLowSurrogates}?',
@@ -13239,11 +14077,12 @@ def test_re_m77_re_m77_i(save_xml):
         instance="msData/regex/reM77.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m73_re_m73_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsYiRadicals}?',
@@ -13255,11 +14094,12 @@ def test_re_m73_re_m73_i(save_xml):
         instance="msData/regex/reM73.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m72_re_m72_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsYiSyllables}?',
@@ -13271,11 +14111,12 @@ def test_re_m72_re_m72_i(save_xml):
         instance="msData/regex/reM72.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m71_re_m71_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKUnifiedIdeographs}?',
@@ -13287,11 +14128,12 @@ def test_re_m71_re_m71_i(save_xml):
         instance="msData/regex/reM71.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m70_re_m70_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13304,11 +14146,12 @@ def test_re_m70_re_m70_i(save_xml):
         instance="msData/regex/reM70.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m69_re_m69_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKCompatibility}?',
@@ -13320,11 +14163,12 @@ def test_re_m69_re_m69_i(save_xml):
         instance="msData/regex/reM69.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m68_re_m68_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13337,11 +14181,12 @@ def test_re_m68_re_m68_i(save_xml):
         instance="msData/regex/reM68.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m67_re_m67_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBopomofoExtended}?',
@@ -13353,11 +14198,12 @@ def test_re_m67_re_m67_i(save_xml):
         instance="msData/regex/reM67.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m66_re_m66_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKanbun}?',
@@ -13369,11 +14215,12 @@ def test_re_m66_re_m66_i(save_xml):
         instance="msData/regex/reM66.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m65_re_m65_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13386,11 +14233,12 @@ def test_re_m65_re_m65_i(save_xml):
         instance="msData/regex/reM65.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m64_re_m64_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBopomofo}?',
@@ -13402,11 +14250,12 @@ def test_re_m64_re_m64_i(save_xml):
         instance="msData/regex/reM64.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m63_re_m63_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKatakana}?',
@@ -13418,11 +14267,12 @@ def test_re_m63_re_m63_i(save_xml):
         instance="msData/regex/reM63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m62_re_m62_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHiragana}?',
@@ -13434,11 +14284,12 @@ def test_re_m62_re_m62_i(save_xml):
         instance="msData/regex/reM62.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m61_re_m61_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13451,11 +14302,12 @@ def test_re_m61_re_m61_i(save_xml):
         instance="msData/regex/reM61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m60_re_m60_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13468,11 +14320,12 @@ def test_re_m60_re_m60_i(save_xml):
         instance="msData/regex/reM60.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m59_re_m59_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKangxiRadicals}?',
@@ -13484,11 +14337,12 @@ def test_re_m59_re_m59_i(save_xml):
         instance="msData/regex/reM59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m58_re_m58_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKRadicalsSupplement}?',
@@ -13500,11 +14354,12 @@ def test_re_m58_re_m58_i(save_xml):
         instance="msData/regex/reM58.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m57_re_m57_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBraillePatterns}?',
@@ -13516,11 +14371,12 @@ def test_re_m57_re_m57_i(save_xml):
         instance="msData/regex/reM57.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m56_re_m56_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDingbats}?',
@@ -13532,11 +14388,12 @@ def test_re_m56_re_m56_i(save_xml):
         instance="msData/regex/reM56.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m55_re_m55_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMiscellaneousSymbols}?',
@@ -13548,11 +14405,12 @@ def test_re_m55_re_m55_i(save_xml):
         instance="msData/regex/reM55.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m54_re_m54_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeometricShapes}?',
@@ -13564,11 +14422,12 @@ def test_re_m54_re_m54_i(save_xml):
         instance="msData/regex/reM54.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m53_re_m53_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBlockElements}?',
@@ -13580,11 +14439,12 @@ def test_re_m53_re_m53_i(save_xml):
         instance="msData/regex/reM53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m52_re_m52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBoxDrawing}?',
@@ -13596,11 +14456,12 @@ def test_re_m52_re_m52_i(save_xml):
         instance="msData/regex/reM52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m51_re_m51_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsEnclosedAlphanumerics}?',
@@ -13612,11 +14473,12 @@ def test_re_m51_re_m51_i(save_xml):
         instance="msData/regex/reM51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m50_re_m50_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13629,11 +14491,12 @@ def test_re_m50_re_m50_i(save_xml):
         instance="msData/regex/reM50.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m49_re_m49_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsControlPictures}?',
@@ -13645,11 +14508,12 @@ def test_re_m49_re_m49_i(save_xml):
         instance="msData/regex/reM49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m48_re_m48_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMiscellaneousTechnical}?',
@@ -13661,11 +14525,12 @@ def test_re_m48_re_m48_i(save_xml):
         instance="msData/regex/reM48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m47_re_m47_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMathematicalOperators}?',
@@ -13677,11 +14542,12 @@ def test_re_m47_re_m47_i(save_xml):
         instance="msData/regex/reM47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m46_re_m46_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArrows}?',
@@ -13693,11 +14559,12 @@ def test_re_m46_re_m46_i(save_xml):
         instance="msData/regex/reM46.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m45_re_m45_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsNumberForms}?',
@@ -13709,11 +14576,12 @@ def test_re_m45_re_m45_i(save_xml):
         instance="msData/regex/reM45.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m44_re_m44_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLetterlikeSymbols}?',
@@ -13725,11 +14593,12 @@ def test_re_m44_re_m44_i(save_xml):
         instance="msData/regex/reM44.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m43_re_m43_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13742,11 +14611,12 @@ def test_re_m43_re_m43_i(save_xml):
         instance="msData/regex/reM43.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m42_re_m42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCurrencySymbols}?',
@@ -13758,11 +14628,12 @@ def test_re_m42_re_m42_i(save_xml):
         instance="msData/regex/reM42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m41_re_m41_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13775,11 +14646,12 @@ def test_re_m41_re_m41_i(save_xml):
         instance="msData/regex/reM41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m40_re_m40_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeneralPunctuation}?',
@@ -13791,11 +14663,12 @@ def test_re_m40_re_m40_i(save_xml):
         instance="msData/regex/reM40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m39_re_m39_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGreekExtended}?',
@@ -13807,11 +14680,12 @@ def test_re_m39_re_m39_i(save_xml):
         instance="msData/regex/reM39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m38_re_m38_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13824,11 +14698,12 @@ def test_re_m38_re_m38_i(save_xml):
         instance="msData/regex/reM38.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m37_re_m37_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMongolian}?',
@@ -13840,11 +14715,12 @@ def test_re_m37_re_m37_i(save_xml):
         instance="msData/regex/reM37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m36_re_m36_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKhmer}?', value='#x1800;',
@@ -13856,11 +14732,12 @@ def test_re_m36_re_m36_i(save_xml):
         instance="msData/regex/reM36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m35_re_m35_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsRunic}?', value='#x1780;',
@@ -13872,11 +14749,12 @@ def test_re_m35_re_m35_i(save_xml):
         instance="msData/regex/reM35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m34_re_m34_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOgham}?', value='#x16A0;',
@@ -13888,11 +14766,12 @@ def test_re_m34_re_m34_i(save_xml):
         instance="msData/regex/reM34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m33_re_m33_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -13905,11 +14784,12 @@ def test_re_m33_re_m33_i(save_xml):
         instance="msData/regex/reM33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m32_re_m32_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCherokee}?',
@@ -13921,11 +14801,12 @@ def test_re_m32_re_m32_i(save_xml):
         instance="msData/regex/reM32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m31_re_m31_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsEthiopic}?',
@@ -13937,11 +14818,12 @@ def test_re_m31_re_m31_i(save_xml):
         instance="msData/regex/reM31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m30_re_m30_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHangulJamo}?',
@@ -13953,11 +14835,12 @@ def test_re_m30_re_m30_i(save_xml):
         instance="msData/regex/reM30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m29_re_m29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeorgian}?',
@@ -13969,11 +14852,12 @@ def test_re_m29_re_m29_i(save_xml):
         instance="msData/regex/reM29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m28_re_m28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMyanmar}?',
@@ -13985,11 +14869,12 @@ def test_re_m28_re_m28_i(save_xml):
         instance="msData/regex/reM28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m27_re_m27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTibetan}?',
@@ -14001,11 +14886,12 @@ def test_re_m27_re_m27_i(save_xml):
         instance="msData/regex/reM27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m26_re_m26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLao}?', value='#x0F00;',
@@ -14017,11 +14903,12 @@ def test_re_m26_re_m26_i(save_xml):
         instance="msData/regex/reM26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m25_re_m25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsThai}?', value='#x0E80;',
@@ -14033,11 +14920,12 @@ def test_re_m25_re_m25_i(save_xml):
         instance="msData/regex/reM25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m24_re_m24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSinhala}?',
@@ -14049,11 +14937,12 @@ def test_re_m24_re_m24_i(save_xml):
         instance="msData/regex/reM24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m23_re_m23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMalayalam}?',
@@ -14065,11 +14954,12 @@ def test_re_m23_re_m23_i(save_xml):
         instance="msData/regex/reM23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m22_re_m22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKannada}?',
@@ -14081,11 +14971,12 @@ def test_re_m22_re_m22_i(save_xml):
         instance="msData/regex/reM22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m21_re_m21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTelugu}?',
@@ -14097,11 +14988,12 @@ def test_re_m21_re_m21_i(save_xml):
         instance="msData/regex/reM21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m20_re_m20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTamil}?', value='#x0C00;',
@@ -14113,11 +15005,12 @@ def test_re_m20_re_m20_i(save_xml):
         instance="msData/regex/reM20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m19_re_m19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOriya}?', value='#x0B80;',
@@ -14129,11 +15022,12 @@ def test_re_m19_re_m19_i(save_xml):
         instance="msData/regex/reM19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m18_re_m18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGujarati}?',
@@ -14145,11 +15039,12 @@ def test_re_m18_re_m18_i(save_xml):
         instance="msData/regex/reM18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m17_re_m17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGurmukhi}?',
@@ -14161,11 +15056,12 @@ def test_re_m17_re_m17_i(save_xml):
         instance="msData/regex/reM17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m16_re_m16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBengali}?',
@@ -14177,11 +15073,12 @@ def test_re_m16_re_m16_i(save_xml):
         instance="msData/regex/reM16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m15_re_m15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDevanagari}?',
@@ -14193,11 +15090,12 @@ def test_re_m15_re_m15_i(save_xml):
         instance="msData/regex/reM15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m14_re_m14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsThaana}?',
@@ -14209,11 +15107,12 @@ def test_re_m14_re_m14_i(save_xml):
         instance="msData/regex/reM14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m13_re_m13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSyriac}?',
@@ -14225,11 +15124,12 @@ def test_re_m13_re_m13_i(save_xml):
         instance="msData/regex/reM13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m12_re_m12_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArabic}?',
@@ -14241,11 +15141,12 @@ def test_re_m12_re_m12_i(save_xml):
         instance="msData/regex/reM12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m11_re_m11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHebrew}?',
@@ -14257,11 +15158,12 @@ def test_re_m11_re_m11_i(save_xml):
         instance="msData/regex/reM11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m10_re_m10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArmenian}?',
@@ -14273,11 +15175,12 @@ def test_re_m10_re_m10_i(save_xml):
         instance="msData/regex/reM10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m9_re_m9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCyrillic}?',
@@ -14289,11 +15192,12 @@ def test_re_m9_re_m9_i(save_xml):
         instance="msData/regex/reM9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m6_re_m6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpacingModifierLetters}?',
@@ -14305,11 +15209,12 @@ def test_re_m6_re_m6_i(save_xml):
         instance="msData/regex/reM6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m5_re_m5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsIPAExtensions}?',
@@ -14321,11 +15226,12 @@ def test_re_m5_re_m5_i(save_xml):
         instance="msData/regex/reM5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m4_re_m4_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtended-B}?',
@@ -14337,11 +15243,12 @@ def test_re_m4_re_m4_i(save_xml):
         instance="msData/regex/reM4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m3_re_m3_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtended-A}?',
@@ -14353,11 +15260,12 @@ def test_re_m3_re_m3_i(save_xml):
         instance="msData/regex/reM3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m2_re_m2_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatin-1Supplement}?',
@@ -14369,11 +15277,12 @@ def test_re_m2_re_m2_i(save_xml):
         instance="msData/regex/reM2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_m1_re_m1_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBasicLatin}?',
@@ -14385,11 +15294,12 @@ def test_re_m1_re_m1_i(save_xml):
         instance="msData/regex/reM1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l99_re_l99_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}+',
@@ -14401,11 +15311,12 @@ def test_re_l99_re_l99_i(save_xml):
         instance="msData/regex/reL99.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l98_re_l98_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}+',
@@ -14417,11 +15328,12 @@ def test_re_l98_re_l98_i(save_xml):
         instance="msData/regex/reL98.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l88_re_l88_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpecials}+',
@@ -14433,11 +15345,12 @@ def test_re_l88_re_l88_v(save_xml):
         instance="msData/regex/reL88.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l87_re_l87_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14450,11 +15363,12 @@ def test_re_l87_re_l87_v(save_xml):
         instance="msData/regex/reL87.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l85_re_l85_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14467,11 +15381,12 @@ def test_re_l85_re_l85_v(save_xml):
         instance="msData/regex/reL85.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l84_re_l84_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSmallFormVariants}+',
@@ -14483,11 +15398,12 @@ def test_re_l84_re_l84_v(save_xml):
         instance="msData/regex/reL84.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l83_re_l83_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKCompatibilityForms}+',
@@ -14499,11 +15415,12 @@ def test_re_l83_re_l83_v(save_xml):
         instance="msData/regex/reL83.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l82_re_l82_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCombiningHalfMarks}+',
@@ -14515,11 +15432,12 @@ def test_re_l82_re_l82_v(save_xml):
         instance="msData/regex/reL82.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l81_re_l81_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14532,11 +15450,12 @@ def test_re_l81_re_l81_v(save_xml):
         instance="msData/regex/reL81.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l80_re_l80_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14549,11 +15468,12 @@ def test_re_l80_re_l80_v(save_xml):
         instance="msData/regex/reL80.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l79_re_l79_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14566,11 +15486,12 @@ def test_re_l79_re_l79_v(save_xml):
         instance="msData/regex/reL79.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l78_re_l78_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsPrivateUse}+',
@@ -14582,11 +15503,12 @@ def test_re_l78_re_l78_v(save_xml):
         instance="msData/regex/reL78.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l74_re_l74_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHangulSyllables}+',
@@ -14598,11 +15520,12 @@ def test_re_l74_re_l74_v(save_xml):
         instance="msData/regex/reL74.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l73_re_l73_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsYiRadicals}+',
@@ -14614,11 +15537,12 @@ def test_re_l73_re_l73_v(save_xml):
         instance="msData/regex/reL73.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l72_re_l72_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsYiSyllables}+',
@@ -14630,11 +15554,12 @@ def test_re_l72_re_l72_v(save_xml):
         instance="msData/regex/reL72.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l71_re_l71_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKUnifiedIdeographs}+',
@@ -14646,11 +15571,12 @@ def test_re_l71_re_l71_v(save_xml):
         instance="msData/regex/reL71.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l70_re_l70_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14663,11 +15589,12 @@ def test_re_l70_re_l70_v(save_xml):
         instance="msData/regex/reL70.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l69_re_l69_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKCompatibility}+',
@@ -14679,11 +15606,12 @@ def test_re_l69_re_l69_v(save_xml):
         instance="msData/regex/reL69.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l68_re_l68_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14696,11 +15624,12 @@ def test_re_l68_re_l68_v(save_xml):
         instance="msData/regex/reL68.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l67_re_l67_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBopomofoExtended}+',
@@ -14712,11 +15641,12 @@ def test_re_l67_re_l67_v(save_xml):
         instance="msData/regex/reL67.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l66_re_l66_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKanbun}+',
@@ -14728,11 +15658,12 @@ def test_re_l66_re_l66_v(save_xml):
         instance="msData/regex/reL66.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l65_re_l65_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14745,11 +15676,12 @@ def test_re_l65_re_l65_v(save_xml):
         instance="msData/regex/reL65.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l64_re_l64_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBopomofo}+',
@@ -14761,11 +15693,12 @@ def test_re_l64_re_l64_v(save_xml):
         instance="msData/regex/reL64.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l63_re_l63_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKatakana}+',
@@ -14777,11 +15710,12 @@ def test_re_l63_re_l63_v(save_xml):
         instance="msData/regex/reL63.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l62_re_l62_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHiragana}+',
@@ -14793,11 +15727,12 @@ def test_re_l62_re_l62_v(save_xml):
         instance="msData/regex/reL62.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l61_re_l61_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14810,11 +15745,12 @@ def test_re_l61_re_l61_v(save_xml):
         instance="msData/regex/reL61.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l60_re_l60_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14827,11 +15763,12 @@ def test_re_l60_re_l60_v(save_xml):
         instance="msData/regex/reL60.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l59_re_l59_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKangxiRadicals}+',
@@ -14843,11 +15780,12 @@ def test_re_l59_re_l59_v(save_xml):
         instance="msData/regex/reL59.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l58_re_l58_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCJKRadicalsSupplement}+',
@@ -14859,11 +15797,12 @@ def test_re_l58_re_l58_v(save_xml):
         instance="msData/regex/reL58.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l57_re_l57_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBraillePatterns}+',
@@ -14875,11 +15814,12 @@ def test_re_l57_re_l57_v(save_xml):
         instance="msData/regex/reL57.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l56_re_l56_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDingbats}+',
@@ -14891,11 +15831,12 @@ def test_re_l56_re_l56_v(save_xml):
         instance="msData/regex/reL56.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l55_re_l55_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMiscellaneousSymbols}+',
@@ -14907,11 +15848,12 @@ def test_re_l55_re_l55_v(save_xml):
         instance="msData/regex/reL55.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l54_re_l54_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeometricShapes}+',
@@ -14923,11 +15865,12 @@ def test_re_l54_re_l54_v(save_xml):
         instance="msData/regex/reL54.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l53_re_l53_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBlockElements}+',
@@ -14939,11 +15882,12 @@ def test_re_l53_re_l53_v(save_xml):
         instance="msData/regex/reL53.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l52_re_l52_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBoxDrawing}+',
@@ -14955,11 +15899,12 @@ def test_re_l52_re_l52_v(save_xml):
         instance="msData/regex/reL52.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l51_re_l51_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsEnclosedAlphanumerics}+',
@@ -14971,11 +15916,12 @@ def test_re_l51_re_l51_v(save_xml):
         instance="msData/regex/reL51.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l50_re_l50_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -14988,11 +15934,12 @@ def test_re_l50_re_l50_v(save_xml):
         instance="msData/regex/reL50.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l49_re_l49_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsControlPictures}+',
@@ -15004,11 +15951,12 @@ def test_re_l49_re_l49_v(save_xml):
         instance="msData/regex/reL49.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l48_re_l48_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMiscellaneousTechnical}+',
@@ -15020,11 +15968,12 @@ def test_re_l48_re_l48_v(save_xml):
         instance="msData/regex/reL48.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l47_re_l47_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMathematicalOperators}+',
@@ -15036,11 +15985,12 @@ def test_re_l47_re_l47_v(save_xml):
         instance="msData/regex/reL47.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l46_re_l46_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArrows}+',
@@ -15052,11 +16002,12 @@ def test_re_l46_re_l46_v(save_xml):
         instance="msData/regex/reL46.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l45_re_l45_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsNumberForms}+',
@@ -15068,11 +16019,12 @@ def test_re_l45_re_l45_v(save_xml):
         instance="msData/regex/reL45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l44_re_l44_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLetterlikeSymbols}+',
@@ -15084,11 +16036,12 @@ def test_re_l44_re_l44_v(save_xml):
         instance="msData/regex/reL44.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l43_re_l43_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -15101,11 +16054,12 @@ def test_re_l43_re_l43_v(save_xml):
         instance="msData/regex/reL43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l42_re_l42_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCurrencySymbols}+',
@@ -15117,11 +16071,12 @@ def test_re_l42_re_l42_v(save_xml):
         instance="msData/regex/reL42.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l41_re_l41_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -15134,11 +16089,12 @@ def test_re_l41_re_l41_v(save_xml):
         instance="msData/regex/reL41.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l40_re_l40_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeneralPunctuation}+',
@@ -15150,11 +16106,12 @@ def test_re_l40_re_l40_v(save_xml):
         instance="msData/regex/reL40.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l39_re_l39_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGreekExtended}+',
@@ -15166,11 +16123,12 @@ def test_re_l39_re_l39_v(save_xml):
         instance="msData/regex/reL39.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l38_re_l38_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -15183,11 +16141,12 @@ def test_re_l38_re_l38_v(save_xml):
         instance="msData/regex/reL38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l37_re_l37_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMongolian}+',
@@ -15199,11 +16158,12 @@ def test_re_l37_re_l37_v(save_xml):
         instance="msData/regex/reL37.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l36_re_l36_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKhmer}+',
@@ -15215,11 +16175,12 @@ def test_re_l36_re_l36_v(save_xml):
         instance="msData/regex/reL36.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l35_re_l35_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsRunic}+',
@@ -15231,11 +16192,12 @@ def test_re_l35_re_l35_v(save_xml):
         instance="msData/regex/reL35.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l34_re_l34_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOgham}+',
@@ -15247,11 +16209,12 @@ def test_re_l34_re_l34_v(save_xml):
         instance="msData/regex/reL34.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l33_re_l33_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -15264,11 +16227,12 @@ def test_re_l33_re_l33_v(save_xml):
         instance="msData/regex/reL33.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l32_re_l32_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsCherokee}+',
@@ -15280,11 +16244,12 @@ def test_re_l32_re_l32_v(save_xml):
         instance="msData/regex/reL32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l31_re_l31_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsEthiopic}+',
@@ -15296,11 +16261,12 @@ def test_re_l31_re_l31_v(save_xml):
         instance="msData/regex/reL31.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l30_re_l30_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHangulJamo}+',
@@ -15312,11 +16278,12 @@ def test_re_l30_re_l30_v(save_xml):
         instance="msData/regex/reL30.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l29_re_l29_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGeorgian}+',
@@ -15328,11 +16295,12 @@ def test_re_l29_re_l29_v(save_xml):
         instance="msData/regex/reL29.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l28_re_l28_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMyanmar}+',
@@ -15344,11 +16312,12 @@ def test_re_l28_re_l28_v(save_xml):
         instance="msData/regex/reL28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l27_re_l27_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTibetan}+',
@@ -15360,11 +16329,12 @@ def test_re_l27_re_l27_v(save_xml):
         instance="msData/regex/reL27.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l26_re_l26_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLao}+',
@@ -15376,11 +16346,12 @@ def test_re_l26_re_l26_v(save_xml):
         instance="msData/regex/reL26.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l25_re_l25_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsThai}+',
@@ -15392,11 +16363,12 @@ def test_re_l25_re_l25_v(save_xml):
         instance="msData/regex/reL25.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l24_re_l24_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSinhala}+',
@@ -15408,11 +16380,12 @@ def test_re_l24_re_l24_v(save_xml):
         instance="msData/regex/reL24.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l23_re_l23_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsMalayalam}+',
@@ -15424,11 +16397,12 @@ def test_re_l23_re_l23_v(save_xml):
         instance="msData/regex/reL23.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l22_re_l22_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsKannada}+',
@@ -15440,11 +16414,12 @@ def test_re_l22_re_l22_v(save_xml):
         instance="msData/regex/reL22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l21_re_l21_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTelugu}+',
@@ -15456,11 +16431,12 @@ def test_re_l21_re_l21_v(save_xml):
         instance="msData/regex/reL21.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l20_re_l20_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsTamil}+',
@@ -15472,11 +16448,12 @@ def test_re_l20_re_l20_v(save_xml):
         instance="msData/regex/reL20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l19_re_l19_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsOriya}+',
@@ -15488,11 +16465,12 @@ def test_re_l19_re_l19_v(save_xml):
         instance="msData/regex/reL19.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l18_re_l18_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGujarati}+',
@@ -15504,11 +16482,12 @@ def test_re_l18_re_l18_v(save_xml):
         instance="msData/regex/reL18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l17_re_l17_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsGurmukhi}+',
@@ -15520,11 +16499,12 @@ def test_re_l17_re_l17_v(save_xml):
         instance="msData/regex/reL17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l16_re_l16_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBengali}+',
@@ -15536,11 +16516,12 @@ def test_re_l16_re_l16_v(save_xml):
         instance="msData/regex/reL16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l15_re_l15_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsDevanagari}+',
@@ -15552,11 +16533,12 @@ def test_re_l15_re_l15_v(save_xml):
         instance="msData/regex/reL15.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l14_re_l14_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsThaana}+',
@@ -15568,11 +16550,12 @@ def test_re_l14_re_l14_v(save_xml):
         instance="msData/regex/reL14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l13_re_l13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSyriac}+',
@@ -15584,11 +16567,12 @@ def test_re_l13_re_l13_v(save_xml):
         instance="msData/regex/reL13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l12_re_l12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArabic}+',
@@ -15600,11 +16584,12 @@ def test_re_l12_re_l12_v(save_xml):
         instance="msData/regex/reL12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l11_re_l11_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsHebrew}+',
@@ -15616,11 +16601,12 @@ def test_re_l11_re_l11_v(save_xml):
         instance="msData/regex/reL11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l10_re_l10_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsArmenian}+',
@@ -15632,11 +16618,12 @@ def test_re_l10_re_l10_v(save_xml):
         instance="msData/regex/reL10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l6_re_l6_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsSpacingModifierLetters}+',
@@ -15648,11 +16635,12 @@ def test_re_l6_re_l6_v(save_xml):
         instance="msData/regex/reL6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l5_re_l5_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsIPAExtensions}+',
@@ -15664,11 +16652,12 @@ def test_re_l5_re_l5_v(save_xml):
         instance="msData/regex/reL5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l4_re_l4_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtended-B}+',
@@ -15680,11 +16669,12 @@ def test_re_l4_re_l4_v(save_xml):
         instance="msData/regex/reL4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l3_re_l3_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatinExtended-A}+',
@@ -15696,11 +16686,12 @@ def test_re_l3_re_l3_v(save_xml):
         instance="msData/regex/reL3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l2_re_l2_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsLatin-1Supplement}+',
@@ -15712,11 +16703,12 @@ def test_re_l2_re_l2_v(save_xml):
         instance="msData/regex/reL2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_l1_re_l1_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{IsBasicLatin}+',
@@ -15728,7 +16720,7 @@ def test_re_l1_re_l1_v(save_xml):
         instance="msData/regex/reL1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -15750,6 +16742,7 @@ def test_re_k88_re_k88_v(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_re_k85_re_k85_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\\p{L}*', value='a',
@@ -15761,11 +16754,12 @@ def test_re_k85_re_k85_i(save_xml):
         instance="msData/regex/reK85.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k84_re_k84_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\\p{L}*', value='\a',
@@ -15777,11 +16771,12 @@ def test_re_k84_re_k84_v(save_xml):
         instance="msData/regex/reK84.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k78_re_k78_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Co}*', value='#x2044;',
@@ -15793,11 +16788,12 @@ def test_re_k78_re_k78_v(save_xml):
         instance="msData/regex/reK78.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k77_re_k77_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Co}*',
@@ -15810,11 +16806,12 @@ def test_re_k77_re_k77_i(save_xml):
         instance="msData/regex/reK77.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k76_re_k76_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Cf}*', value='#xE000;',
@@ -15826,11 +16823,12 @@ def test_re_k76_re_k76_v(save_xml):
         instance="msData/regex/reK76.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k75_re_k75_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Cf}*',
@@ -15842,11 +16840,12 @@ def test_re_k75_re_k75_i(save_xml):
         instance="msData/regex/reK75.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k74_re_k74_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Cc}*', value='#x070F;',
@@ -15858,6 +16857,6 @@ def test_re_k74_re_k74_v(save_xml):
         instance="msData/regex/reK74.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_ms_meta_4755.py
+++ b/tests/test_ms_meta_4755.py
@@ -9705,7 +9705,6 @@ def test_st_e092_st_e092_v(save_xml):
     )
 
 
-@pytest.mark.xfail
 def test_st_e091_st_e091_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed

--- a/tests/test_ms_meta_4755.py
+++ b/tests/test_ms_meta_4755.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_re_k73_re_k73_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Cc}*', value='#x9;',
@@ -14,11 +15,12 @@ def test_re_k73_re_k73_i(save_xml):
         instance="msData/regex/reK73.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k72_re_k72_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{C}*', value='#x20A0;',
@@ -30,11 +32,12 @@ def test_re_k72_re_k72_v(save_xml):
         instance="msData/regex/reK72.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k71_re_k71_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{C}*', value='#x9;#x070F;#x70
@@ -47,11 +50,12 @@ def test_re_k71_re_k71_i(save_xml):
         instance="msData/regex/reK71.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k70_re_k70_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{So}*', value='#x9;',
@@ -63,11 +67,12 @@ def test_re_k70_re_k70_v(save_xml):
         instance="msData/regex/reK70.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k69_re_k69_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{So}*',
@@ -79,11 +84,12 @@ def test_re_k69_re_k69_i(save_xml):
         instance="msData/regex/reK69.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k68_re_k68_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Sk}*', value='#x3190;',
@@ -95,11 +101,12 @@ def test_re_k68_re_k68_v(save_xml):
         instance="msData/regex/reK68.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k67_re_k67_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Sk}*',
@@ -111,11 +118,12 @@ def test_re_k67_re_k67_i(save_xml):
         instance="msData/regex/reK67.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k66_re_k66_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Sc}*', value='#x309B;',
@@ -127,11 +135,12 @@ def test_re_k66_re_k66_v(save_xml):
         instance="msData/regex/reK66.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k65_re_k65_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Sc}*',
@@ -143,11 +152,12 @@ def test_re_k65_re_k65_i(save_xml):
         instance="msData/regex/reK65.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k64_re_k64_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Sm}*', value='#x20A0;',
@@ -159,11 +169,12 @@ def test_re_k64_re_k64_v(save_xml):
         instance="msData/regex/reK64.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k63_re_k63_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Sm}*',
@@ -175,11 +186,12 @@ def test_re_k63_re_k63_i(save_xml):
         instance="msData/regex/reK63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k62_re_k62_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{S}*', value='#x1680;',
@@ -191,11 +203,12 @@ def test_re_k62_re_k62_v(save_xml):
         instance="msData/regex/reK62.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k61_re_k61_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{S}*', value='#x2044;#xFFE2;#
@@ -208,11 +221,12 @@ def test_re_k61_re_k61_i(save_xml):
         instance="msData/regex/reK61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k60_re_k60_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Zp}*', value='#x2044;',
@@ -224,11 +238,12 @@ def test_re_k60_re_k60_v(save_xml):
         instance="msData/regex/reK60.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k59_re_k59_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Zp}*', value='#x2029;',
@@ -240,11 +255,12 @@ def test_re_k59_re_k59_i(save_xml):
         instance="msData/regex/reK59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k58_re_k58_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Zl}*', value='#x2029;',
@@ -256,11 +272,12 @@ def test_re_k58_re_k58_v(save_xml):
         instance="msData/regex/reK58.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k57_re_k57_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Zl}*', value='#x2028;',
@@ -272,11 +289,12 @@ def test_re_k57_re_k57_i(save_xml):
         instance="msData/regex/reK57.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k56_re_k56_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Zs}*', value='#x2028;',
@@ -288,11 +306,12 @@ def test_re_k56_re_k56_v(save_xml):
         instance="msData/regex/reK56.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k55_re_k55_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Zs}*',
@@ -304,11 +323,12 @@ def test_re_k55_re_k55_i(save_xml):
         instance="msData/regex/reK55.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k54_re_k54_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Z}*', value='#xBF;',
@@ -320,11 +340,12 @@ def test_re_k54_re_k54_v(save_xml):
         instance="msData/regex/reK54.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k53_re_k53_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Z}*',
@@ -337,11 +358,12 @@ def test_re_k53_re_k53_i(save_xml):
         instance="msData/regex/reK53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k52_re_k52_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Po}*', value='#x1680;',
@@ -353,11 +375,12 @@ def test_re_k52_re_k52_v(save_xml):
         instance="msData/regex/reK52.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k51_re_k51_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Po}*', value='#xBF;#xFF64;',
@@ -369,11 +392,12 @@ def test_re_k51_re_k51_i(save_xml):
         instance="msData/regex/reK51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k50_re_k50_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pf}*', value='#xBF;',
@@ -385,11 +409,12 @@ def test_re_k50_re_k50_v(save_xml):
         instance="msData/regex/reK50.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k49_re_k49_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pf}*', value='#xBB;#x203A;',
@@ -401,11 +426,12 @@ def test_re_k49_re_k49_i(save_xml):
         instance="msData/regex/reK49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k48_re_k48_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pi}*', value='#xBB;',
@@ -417,11 +443,12 @@ def test_re_k48_re_k48_v(save_xml):
         instance="msData/regex/reK48.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k47_re_k47_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pi}*', value='#xAB;#x2039;',
@@ -433,11 +460,12 @@ def test_re_k47_re_k47_i(save_xml):
         instance="msData/regex/reK47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k46_re_k46_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pe}*', value='#xAB;',
@@ -449,11 +477,12 @@ def test_re_k46_re_k46_v(save_xml):
         instance="msData/regex/reK46.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k45_re_k45_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pe}*',
@@ -465,11 +494,12 @@ def test_re_k45_re_k45_i(save_xml):
         instance="msData/regex/reK45.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k44_re_k44_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Ps}*', value='#x301E;',
@@ -481,11 +511,12 @@ def test_re_k44_re_k44_v(save_xml):
         instance="msData/regex/reK44.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k43_re_k43_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Ps}*',
@@ -497,11 +528,12 @@ def test_re_k43_re_k43_i(save_xml):
         instance="msData/regex/reK43.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k42_re_k42_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pd}*', value='#x301D;',
@@ -513,11 +545,12 @@ def test_re_k42_re_k42_v(save_xml):
         instance="msData/regex/reK42.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k41_re_k41_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pd}*',
@@ -529,11 +562,12 @@ def test_re_k41_re_k41_i(save_xml):
         instance="msData/regex/reK41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k40_re_k40_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pc}*', value='#x301C;',
@@ -545,11 +579,12 @@ def test_re_k40_re_k40_v(save_xml):
         instance="msData/regex/reK40.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k39_re_k39_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Pc}*',
@@ -561,11 +596,12 @@ def test_re_k39_re_k39_i(save_xml):
         instance="msData/regex/reK39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k38_re_k38_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{P}*', value='#xB2;',
@@ -577,11 +613,12 @@ def test_re_k38_re_k38_v(save_xml):
         instance="msData/regex/reK38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k37_re_k37_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{P}*', value='#x203F;#xFF65;#
@@ -595,11 +632,12 @@ def test_re_k37_re_k37_i(save_xml):
         instance="msData/regex/reK37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k36_re_k36_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{No}*', value='#x203F;',
@@ -611,11 +649,12 @@ def test_re_k36_re_k36_v(save_xml):
         instance="msData/regex/reK36.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k35_re_k35_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{No}*',
@@ -627,11 +666,12 @@ def test_re_k35_re_k35_i(save_xml):
         instance="msData/regex/reK35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k34_re_k34_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Nl}*', value='#xB2;',
@@ -643,11 +683,12 @@ def test_re_k34_re_k34_v(save_xml):
         instance="msData/regex/reK34.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k33_re_k33_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Nl}*',
@@ -659,11 +700,12 @@ def test_re_k33_re_k33_i(save_xml):
         instance="msData/regex/reK33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k32_re_k32_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Nd}*', value='#x1034A;',
@@ -675,11 +717,12 @@ def test_re_k32_re_k32_v(save_xml):
         instance="msData/regex/reK32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k31_re_k31_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Nd}*',
@@ -691,11 +734,12 @@ def test_re_k31_re_k31_i(save_xml):
         instance="msData/regex/reK31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k30_re_k30_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{N}*', value='#x903;',
@@ -707,11 +751,12 @@ def test_re_k30_re_k30_v(save_xml):
         instance="msData/regex/reK30.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k29_re_k29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{N}*',
@@ -724,11 +769,12 @@ def test_re_k29_re_k29_i(save_xml):
         instance="msData/regex/reK29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k28_re_k28_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Me}*', value='#xFF10;',
@@ -740,11 +786,12 @@ def test_re_k28_re_k28_v(save_xml):
         instance="msData/regex/reK28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k27_re_k27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Me}*',
@@ -756,11 +803,12 @@ def test_re_k27_re_k27_i(save_xml):
         instance="msData/regex/reK27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k26_re_k26_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Mc}*', value='#x20DD;',
@@ -772,11 +820,12 @@ def test_re_k26_re_k26_v(save_xml):
         instance="msData/regex/reK26.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k25_re_k25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Mc}*',
@@ -788,11 +837,12 @@ def test_re_k25_re_k25_i(save_xml):
         instance="msData/regex/reK25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k24_re_k24_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Mn}*',
@@ -804,11 +854,12 @@ def test_re_k24_re_k24_v(save_xml):
         instance="msData/regex/reK24.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k23_re_k23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Mn}*',
@@ -820,11 +871,12 @@ def test_re_k23_re_k23_i(save_xml):
         instance="msData/regex/reK23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k22_re_k22_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{M}*', value='#x1C5;',
@@ -836,11 +888,12 @@ def test_re_k22_re_k22_v(save_xml):
         instance="msData/regex/reK22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k21_re_k21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{M}*', value='#x64B;#x1D1AD;#
@@ -853,11 +906,12 @@ def test_re_k21_re_k21_i(save_xml):
         instance="msData/regex/reK21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k20_re_k20_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lo}*', value='#x64B;',
@@ -869,11 +923,12 @@ def test_re_k20_re_k20_v(save_xml):
         instance="msData/regex/reK20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k19_re_k19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lo}*',
@@ -885,11 +940,12 @@ def test_re_k19_re_k19_i(save_xml):
         instance="msData/regex/reK19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k18_re_k18_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lm}*', value='#x5D0;',
@@ -901,11 +957,12 @@ def test_re_k18_re_k18_v(save_xml):
         instance="msData/regex/reK18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k17_re_k17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lm}*',
@@ -917,11 +974,12 @@ def test_re_k17_re_k17_i(save_xml):
         instance="msData/regex/reK17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k16_re_k16_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lt}*', value='#x2B0;',
@@ -933,11 +991,12 @@ def test_re_k16_re_k16_v(save_xml):
         instance="msData/regex/reK16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k15_re_k15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lt}*',
@@ -949,11 +1008,12 @@ def test_re_k15_re_k15_i(save_xml):
         instance="msData/regex/reK15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k14_re_k14_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Ll}*', value='#x1C5;',
@@ -965,11 +1025,12 @@ def test_re_k14_re_k14_v(save_xml):
         instance="msData/regex/reK14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k13_re_k13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Ll}*',
@@ -981,11 +1042,12 @@ def test_re_k13_re_k13_i(save_xml):
         instance="msData/regex/reK13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k12_re_k12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lu}*', value='#x61;',
@@ -997,11 +1059,12 @@ def test_re_k12_re_k12_v(save_xml):
         instance="msData/regex/reK12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k11_re_k11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{Lu}*',
@@ -1013,11 +1076,12 @@ def test_re_k11_re_k11_i(save_xml):
         instance="msData/regex/reK11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k10_re_k10_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{L}*', value='#x20DD;',
@@ -1029,11 +1093,12 @@ def test_re_k10_re_k10_v(save_xml):
         instance="msData/regex/reK10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k9_re_k9_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{L}*', value='#x41;#x1D7A8;#x
@@ -1046,11 +1111,12 @@ def test_re_k9_re_k9_i(save_xml):
         instance="msData/regex/reK9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k6_re_k6_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\P{L}*]{0,2}', value='A',
@@ -1062,11 +1128,12 @@ def test_re_k6_re_k6_i(save_xml):
         instance="msData/regex/reK6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k5_re_k5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\P{L}*]{0,2}', value='!$#',
@@ -1078,11 +1145,12 @@ def test_re_k5_re_k5_i(save_xml):
         instance="msData/regex/reK5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k4_re_k4_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\P{L}*]{0,2}', value='#$',
@@ -1094,11 +1162,12 @@ def test_re_k4_re_k4_v(save_xml):
         instance="msData/regex/reK4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k3_re_k3_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\P{L}*]{0,2}', value='',
@@ -1110,11 +1179,12 @@ def test_re_k3_re_k3_v(save_xml):
         instance="msData/regex/reK3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k2_re_k2_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{L}*', value='_',
@@ -1126,11 +1196,12 @@ def test_re_k2_re_k2_v(save_xml):
         instance="msData/regex/reK2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_k1_re_k1_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\P{L}*', value='aAbB',
@@ -1142,11 +1213,12 @@ def test_re_k1_re_k1_i(save_xml):
         instance="msData/regex/reK1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j80_re_j80_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Cn}*', value='#x9;',
@@ -1158,11 +1230,12 @@ def test_re_j80_re_j80_i(save_xml):
         instance="msData/regex/reJ80.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j78_re_j78_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Co}*', value='#x2044;',
@@ -1174,11 +1247,12 @@ def test_re_j78_re_j78_i(save_xml):
         instance="msData/regex/reJ78.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j77_re_j77_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Co}*',
@@ -1191,11 +1265,12 @@ def test_re_j77_re_j77_i(save_xml):
         instance="msData/regex/reJ77.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j76_re_j76_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Cf}*', value='#xE000;',
@@ -1207,11 +1282,12 @@ def test_re_j76_re_j76_i(save_xml):
         instance="msData/regex/reJ76.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j75_re_j75_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Cf}*',
@@ -1223,11 +1299,12 @@ def test_re_j75_re_j75_i(save_xml):
         instance="msData/regex/reJ75.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j74_re_j74_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Cc}*', value='#x070F;',
@@ -1239,11 +1316,12 @@ def test_re_j74_re_j74_i(save_xml):
         instance="msData/regex/reJ74.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j73_re_j73_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Cc}*', value='#x9;',
@@ -1255,11 +1333,12 @@ def test_re_j73_re_j73_v(save_xml):
         instance="msData/regex/reJ73.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j72_re_j72_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{C}*', value='#x20A0;',
@@ -1271,11 +1350,12 @@ def test_re_j72_re_j72_i(save_xml):
         instance="msData/regex/reJ72.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j70_re_j70_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{So}*', value='#x9;',
@@ -1287,11 +1367,12 @@ def test_re_j70_re_j70_i(save_xml):
         instance="msData/regex/reJ70.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j69_re_j69_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{So}*',
@@ -1303,11 +1384,12 @@ def test_re_j69_re_j69_i(save_xml):
         instance="msData/regex/reJ69.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j68_re_j68_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Sk}*', value='#x3190;',
@@ -1319,11 +1401,12 @@ def test_re_j68_re_j68_i(save_xml):
         instance="msData/regex/reJ68.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j67_re_j67_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Sk}*',
@@ -1335,11 +1418,12 @@ def test_re_j67_re_j67_v(save_xml):
         instance="msData/regex/reJ67.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j66_re_j66_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Sc}*', value='#x309B;',
@@ -1351,11 +1435,12 @@ def test_re_j66_re_j66_i(save_xml):
         instance="msData/regex/reJ66.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j65_re_j65_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Sc}*',
@@ -1367,11 +1452,12 @@ def test_re_j65_re_j65_v(save_xml):
         instance="msData/regex/reJ65.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j64_re_j64_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Sm}*', value='#x20A0;',
@@ -1383,11 +1469,12 @@ def test_re_j64_re_j64_i(save_xml):
         instance="msData/regex/reJ64.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j63_re_j63_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Sm}*',
@@ -1399,11 +1486,12 @@ def test_re_j63_re_j63_v(save_xml):
         instance="msData/regex/reJ63.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j62_re_j62_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{S}*', value='#x1680;',
@@ -1415,11 +1503,12 @@ def test_re_j62_re_j62_i(save_xml):
         instance="msData/regex/reJ62.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j61_re_j61_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{S}*', value='#x2044;#xFFE2;#
@@ -1432,11 +1521,12 @@ def test_re_j61_re_j61_i(save_xml):
         instance="msData/regex/reJ61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j60_re_j60_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Zp}*', value='#x2044;',
@@ -1448,11 +1538,12 @@ def test_re_j60_re_j60_i(save_xml):
         instance="msData/regex/reJ60.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j59_re_j59_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Zp}*', value='#x2029;',
@@ -1464,11 +1555,12 @@ def test_re_j59_re_j59_v(save_xml):
         instance="msData/regex/reJ59.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j58_re_j58_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Zl}*', value='#x2029;',
@@ -1480,11 +1572,12 @@ def test_re_j58_re_j58_i(save_xml):
         instance="msData/regex/reJ58.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j57_re_j57_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Zl}*', value='#x2028;',
@@ -1496,11 +1589,12 @@ def test_re_j57_re_j57_v(save_xml):
         instance="msData/regex/reJ57.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j56_re_j56_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Zs}*', value='#x2028;',
@@ -1512,11 +1606,12 @@ def test_re_j56_re_j56_i(save_xml):
         instance="msData/regex/reJ56.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j55_re_j55_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Zs}*',
@@ -1528,11 +1623,12 @@ def test_re_j55_re_j55_v(save_xml):
         instance="msData/regex/reJ55.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j54_re_j54_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Z}*', value='#xBF;',
@@ -1544,11 +1640,12 @@ def test_re_j54_re_j54_i(save_xml):
         instance="msData/regex/reJ54.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j53_re_j53_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Z}*',
@@ -1561,11 +1658,12 @@ def test_re_j53_re_j53_v(save_xml):
         instance="msData/regex/reJ53.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j52_re_j52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Po}*', value='#x1680;',
@@ -1577,11 +1675,12 @@ def test_re_j52_re_j52_i(save_xml):
         instance="msData/regex/reJ52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j51_re_j51_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Po}*', value='#xBF;#xFF64;',
@@ -1593,11 +1692,12 @@ def test_re_j51_re_j51_v(save_xml):
         instance="msData/regex/reJ51.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j50_re_j50_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pf}*', value='#xBF;',
@@ -1609,11 +1709,12 @@ def test_re_j50_re_j50_i(save_xml):
         instance="msData/regex/reJ50.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j49_re_j49_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pf}*', value='#xBB;#x203A;',
@@ -1625,11 +1726,12 @@ def test_re_j49_re_j49_v(save_xml):
         instance="msData/regex/reJ49.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j48_re_j48_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pi}*', value='#xBB;',
@@ -1641,11 +1743,12 @@ def test_re_j48_re_j48_i(save_xml):
         instance="msData/regex/reJ48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j47_re_j47_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pi}*', value='#xAB;#x2039;',
@@ -1657,11 +1760,12 @@ def test_re_j47_re_j47_v(save_xml):
         instance="msData/regex/reJ47.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j46_re_j46_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pe}*', value='#xAB;',
@@ -1673,11 +1777,12 @@ def test_re_j46_re_j46_i(save_xml):
         instance="msData/regex/reJ46.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j45_re_j45_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pe}*',
@@ -1689,11 +1794,12 @@ def test_re_j45_re_j45_v(save_xml):
         instance="msData/regex/reJ45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j44_re_j44_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Ps}*', value='#x301E;',
@@ -1705,11 +1811,12 @@ def test_re_j44_re_j44_i(save_xml):
         instance="msData/regex/reJ44.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j43_re_j43_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Ps}*',
@@ -1721,11 +1828,12 @@ def test_re_j43_re_j43_v(save_xml):
         instance="msData/regex/reJ43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j42_re_j42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pd}*', value='#x301D;',
@@ -1737,11 +1845,12 @@ def test_re_j42_re_j42_i(save_xml):
         instance="msData/regex/reJ42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j41_re_j41_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pd}*',
@@ -1753,11 +1862,12 @@ def test_re_j41_re_j41_v(save_xml):
         instance="msData/regex/reJ41.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j40_re_j40_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Pc}*', value='#x301C;',
@@ -1769,11 +1879,12 @@ def test_re_j40_re_j40_i(save_xml):
         instance="msData/regex/reJ40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j38_re_j38_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{P}*', value='#xB2;',
@@ -1785,11 +1896,12 @@ def test_re_j38_re_j38_i(save_xml):
         instance="msData/regex/reJ38.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j37_re_j37_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{P}*', value='#x203F;#xFF65;#
@@ -1803,11 +1915,12 @@ def test_re_j37_re_j37_v(save_xml):
         instance="msData/regex/reJ37.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j36_re_j36_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{No}*', value='#x203F;',
@@ -1819,11 +1932,12 @@ def test_re_j36_re_j36_i(save_xml):
         instance="msData/regex/reJ36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j35_re_j35_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{No}*',
@@ -1835,11 +1949,12 @@ def test_re_j35_re_j35_i(save_xml):
         instance="msData/regex/reJ35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j34_re_j34_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Nl}*', value='#xB2;',
@@ -1851,11 +1966,12 @@ def test_re_j34_re_j34_i(save_xml):
         instance="msData/regex/reJ34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j33_re_j33_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Nl}*',
@@ -1867,11 +1983,12 @@ def test_re_j33_re_j33_i(save_xml):
         instance="msData/regex/reJ33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j32_re_j32_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Nd}*', value='#x1034A;',
@@ -1883,11 +2000,12 @@ def test_re_j32_re_j32_i(save_xml):
         instance="msData/regex/reJ32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j31_re_j31_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Nd}*',
@@ -1899,11 +2017,12 @@ def test_re_j31_re_j31_i(save_xml):
         instance="msData/regex/reJ31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j30_re_j30_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{N}*', value='#x903;',
@@ -1915,11 +2034,12 @@ def test_re_j30_re_j30_i(save_xml):
         instance="msData/regex/reJ30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j29_re_j29_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{N}*',
@@ -1932,11 +2052,12 @@ def test_re_j29_re_j29_i(save_xml):
         instance="msData/regex/reJ29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j28_re_j28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Me}*', value='#xFF10;',
@@ -1948,11 +2069,12 @@ def test_re_j28_re_j28_i(save_xml):
         instance="msData/regex/reJ28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j27_re_j27_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Me}*',
@@ -1964,11 +2086,12 @@ def test_re_j27_re_j27_v(save_xml):
         instance="msData/regex/reJ27.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j26_re_j26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Mc}*', value='#x20DD;',
@@ -1980,11 +2103,12 @@ def test_re_j26_re_j26_i(save_xml):
         instance="msData/regex/reJ26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j25_re_j25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Mc}*',
@@ -1996,11 +2120,12 @@ def test_re_j25_re_j25_i(save_xml):
         instance="msData/regex/reJ25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j24_re_j24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Mn}*', value='#x903;',
@@ -2012,11 +2137,12 @@ def test_re_j24_re_j24_i(save_xml):
         instance="msData/regex/reJ24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j23_re_j23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Mn}*',
@@ -2028,11 +2154,12 @@ def test_re_j23_re_j23_i(save_xml):
         instance="msData/regex/reJ23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j22_re_j22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{M}*', value='#x1C5;',
@@ -2044,11 +2171,12 @@ def test_re_j22_re_j22_i(save_xml):
         instance="msData/regex/reJ22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j21_re_j21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{M}*', value='#x64B;#x1D1AD;#
@@ -2061,11 +2189,12 @@ def test_re_j21_re_j21_i(save_xml):
         instance="msData/regex/reJ21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j20_re_j20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lo}*', value='#x64B;',
@@ -2077,11 +2206,12 @@ def test_re_j20_re_j20_i(save_xml):
         instance="msData/regex/reJ20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j19_re_j19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lo}*',
@@ -2093,11 +2223,12 @@ def test_re_j19_re_j19_i(save_xml):
         instance="msData/regex/reJ19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j18_re_j18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lm}*', value='#x5D0;',
@@ -2109,11 +2240,12 @@ def test_re_j18_re_j18_i(save_xml):
         instance="msData/regex/reJ18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j17_re_j17_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lm}*',
@@ -2125,11 +2257,12 @@ def test_re_j17_re_j17_v(save_xml):
         instance="msData/regex/reJ17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j16_re_j16_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lt}*', value='#x2B0;',
@@ -2141,11 +2274,12 @@ def test_re_j16_re_j16_i(save_xml):
         instance="msData/regex/reJ16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j15_re_j15_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lt}*',
@@ -2157,11 +2291,12 @@ def test_re_j15_re_j15_v(save_xml):
         instance="msData/regex/reJ15.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j14_re_j14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Ll}*', value='#x1C5;',
@@ -2173,11 +2308,12 @@ def test_re_j14_re_j14_i(save_xml):
         instance="msData/regex/reJ14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j13_re_j13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Ll}*',
@@ -2189,11 +2325,12 @@ def test_re_j13_re_j13_i(save_xml):
         instance="msData/regex/reJ13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j12_re_j12_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lu}*', value='#x61;',
@@ -2205,11 +2342,12 @@ def test_re_j12_re_j12_i(save_xml):
         instance="msData/regex/reJ12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j11_re_j11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{Lu}*',
@@ -2221,11 +2359,12 @@ def test_re_j11_re_j11_i(save_xml):
         instance="msData/regex/reJ11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j10_re_j10_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\p{L}*', value='#x20DD;',
@@ -2237,11 +2376,12 @@ def test_re_j10_re_j10_i(save_xml):
         instance="msData/regex/reJ10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j8_re_j8_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(\p{Ll}\p{Cc}\p{Nd})*',
@@ -2253,11 +2393,12 @@ def test_re_j8_re_j8_i(save_xml):
         instance="msData/regex/reJ8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j5_re_j5_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\p{L}*]{0,2}', value='aBC',
@@ -2269,11 +2410,12 @@ def test_re_j5_re_j5_i(save_xml):
         instance="msData/regex/reJ5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_j4_re_j4_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\p{L}*]{0,2}', value='aX',
@@ -2285,11 +2427,12 @@ def test_re_j4_re_j4_v(save_xml):
         instance="msData/regex/reJ4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i83_re_i83_v(save_xml):
     r"""
     TEST :branch : base='string',pattern="\\.*,\\s*,\\S*,\\i*,\\I?,\\c+,\\
@@ -2302,11 +2445,12 @@ def test_re_i83_re_i83_v(save_xml):
         instance="msData/regex/reI83.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i82_re_i82_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2319,11 +2463,12 @@ def test_re_i82_re_i82_v(save_xml):
         instance="msData/regex/reI82.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i81_re_i81_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\c', value='\\', type='valid',
@@ -2335,11 +2480,12 @@ def test_re_i81_re_i81_i(save_xml):
         instance="msData/regex/reI81.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i80_re_i80_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\c', value='\\c',
@@ -2351,11 +2497,12 @@ def test_re_i80_re_i80_i(save_xml):
         instance="msData/regex/reI80.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i79_re_i79_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\c', value='\p{_xmlC}',
@@ -2367,11 +2514,12 @@ def test_re_i79_re_i79_i(save_xml):
         instance="msData/regex/reI79.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i78_re_i78_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\c', value='\c', type='valid',
@@ -2383,11 +2531,12 @@ def test_re_i78_re_i78_v(save_xml):
         instance="msData/regex/reI78.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i77_re_i77_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2400,11 +2549,12 @@ def test_re_i77_re_i77_v(save_xml):
         instance="msData/regex/reI77.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i76_re_i76_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2417,11 +2567,12 @@ def test_re_i76_re_i76_i(save_xml):
         instance="msData/regex/reI76.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i75_re_i75_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2434,11 +2585,12 @@ def test_re_i75_re_i75_i(save_xml):
         instance="msData/regex/reI75.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i74_re_i74_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2451,11 +2603,12 @@ def test_re_i74_re_i74_v(save_xml):
         instance="msData/regex/reI74.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i73_re_i73_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2468,11 +2621,12 @@ def test_re_i73_re_i73_v(save_xml):
         instance="msData/regex/reI73.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i72_re_i72_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2485,11 +2639,12 @@ def test_re_i72_re_i72_v(save_xml):
         instance="msData/regex/reI72.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i71_re_i71_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\na\nb\nc\n', value=' a b c ',
@@ -2501,11 +2656,12 @@ def test_re_i71_re_i71_v(save_xml):
         instance="msData/regex/reI71.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i69_re_i69_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\ta\tb\tc\t', value=' a b c ',
@@ -2517,11 +2673,12 @@ def test_re_i69_re_i69_v(save_xml):
         instance="msData/regex/reI69.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i67_re_i67_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\n\ra\n\rb', value=' a b',
@@ -2533,11 +2690,12 @@ def test_re_i67_re_i67_v(save_xml):
         instance="msData/regex/reI67.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i65_re_i65_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='a\r\nb', value='a b',
@@ -2549,11 +2707,12 @@ def test_re_i65_re_i65_v(save_xml):
         instance="msData/regex/reI65.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i64_re_i64_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\t\ta\t\tb\t\t', value=' a b ',
@@ -2565,11 +2724,12 @@ def test_re_i64_re_i64_i(save_xml):
         instance="msData/regex/reI64.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i63_re_i63_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\t\ta\t\tb\t\t', value=' a ',
@@ -2581,11 +2741,12 @@ def test_re_i63_re_i63_i(save_xml):
         instance="msData/regex/reI63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i62_re_i62_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\t\ta\t\tb\t\t', value=' a b ',
@@ -2597,11 +2758,12 @@ def test_re_i62_re_i62_i(save_xml):
         instance="msData/regex/reI62.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i61_re_i61_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\t\ta\t\tb\t\t', value=' a b ',
@@ -2613,11 +2775,12 @@ def test_re_i61_re_i61_i(save_xml):
         instance="msData/regex/reI61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i59_re_i59_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\r\ra\r\rb\r\r', value=' a b ',
@@ -2629,11 +2792,12 @@ def test_re_i59_re_i59_i(save_xml):
         instance="msData/regex/reI59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i58_re_i58_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\r\ra\r\rb\r\r', value=' a ',
@@ -2645,11 +2809,12 @@ def test_re_i58_re_i58_i(save_xml):
         instance="msData/regex/reI58.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i57_re_i57_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\r\ra\r\rb\r\r', value=' a b ',
@@ -2661,11 +2826,12 @@ def test_re_i57_re_i57_i(save_xml):
         instance="msData/regex/reI57.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i56_re_i56_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\r\ra\r\rb\r\r', value=' a b ',
@@ -2677,11 +2843,12 @@ def test_re_i56_re_i56_i(save_xml):
         instance="msData/regex/reI56.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i55_re_i55_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\r\ra\r\rb\r\r', value=' a b ',
@@ -2693,11 +2860,12 @@ def test_re_i55_re_i55_v(save_xml):
         instance="msData/regex/reI55.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i54_re_i54_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\n\na\n\nb\n\n', value=' a b ',
@@ -2709,11 +2877,12 @@ def test_re_i54_re_i54_i(save_xml):
         instance="msData/regex/reI54.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i53_re_i53_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\n\na\n\nb\n\n', value=' a ',
@@ -2725,11 +2894,12 @@ def test_re_i53_re_i53_i(save_xml):
         instance="msData/regex/reI53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i52_re_i52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\n\na\n\nb\n\n', value=' a b ',
@@ -2741,11 +2911,12 @@ def test_re_i52_re_i52_i(save_xml):
         instance="msData/regex/reI52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i51_re_i51_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\n\na\n\nb\n\n', value=' a b ',
@@ -2757,11 +2928,12 @@ def test_re_i51_re_i51_i(save_xml):
         instance="msData/regex/reI51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i49_re_i49_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2774,11 +2946,12 @@ def test_re_i49_re_i49_i(save_xml):
         instance="msData/regex/reI49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i48_re_i48_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2791,11 +2964,12 @@ def test_re_i48_re_i48_i(save_xml):
         instance="msData/regex/reI48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i47_re_i47_i(save_xml):
     r"""
     TEST :branch : base='string',
@@ -2808,11 +2982,12 @@ def test_re_i47_re_i47_i(save_xml):
         instance="msData/regex/reI47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i45_re_i45_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\]', value=']', type='valid',
@@ -2824,11 +2999,12 @@ def test_re_i45_re_i45_v(save_xml):
         instance="msData/regex/reI45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i44_re_i44_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\[', value='[', type='valid',
@@ -2840,11 +3016,12 @@ def test_re_i44_re_i44_v(save_xml):
         instance="msData/regex/reI44.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i43_re_i43_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\)', value=')', type='valid',
@@ -2856,11 +3033,12 @@ def test_re_i43_re_i43_v(save_xml):
         instance="msData/regex/reI43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i42_re_i42_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\(', value='(', type='valid',
@@ -2872,11 +3050,12 @@ def test_re_i42_re_i42_v(save_xml):
         instance="msData/regex/reI42.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i41_re_i41_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\}', value='}', type='valid',
@@ -2888,11 +3067,12 @@ def test_re_i41_re_i41_v(save_xml):
         instance="msData/regex/reI41.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i40_re_i40_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\{', value='{', type='valid',
@@ -2904,11 +3084,12 @@ def test_re_i40_re_i40_v(save_xml):
         instance="msData/regex/reI40.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i39_re_i39_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\+', value='+', type='valid',
@@ -2920,11 +3101,12 @@ def test_re_i39_re_i39_v(save_xml):
         instance="msData/regex/reI39.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i38_re_i38_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\*', value='*', type='valid',
@@ -2936,11 +3118,12 @@ def test_re_i38_re_i38_v(save_xml):
         instance="msData/regex/reI38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i37_re_i37_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\?', value='?', type='valid',
@@ -2952,11 +3135,12 @@ def test_re_i37_re_i37_v(save_xml):
         instance="msData/regex/reI37.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i36_re_i36_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\^', value='^', type='valid',
@@ -2968,11 +3152,12 @@ def test_re_i36_re_i36_v(save_xml):
         instance="msData/regex/reI36.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i35_re_i35_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\-', value='-', type='valid',
@@ -2984,11 +3169,12 @@ def test_re_i35_re_i35_v(save_xml):
         instance="msData/regex/reI35.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i34_re_i34_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\.', value='.', type='valid',
@@ -3000,11 +3186,12 @@ def test_re_i34_re_i34_v(save_xml):
         instance="msData/regex/reI34.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i33_re_i33_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\|', value='|', type='valid',
@@ -3016,11 +3203,12 @@ def test_re_i33_re_i33_v(save_xml):
         instance="msData/regex/reI33.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i32_re_i32_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\', value='\', type='valid',
@@ -3032,11 +3220,12 @@ def test_re_i32_re_i32_v(save_xml):
         instance="msData/regex/reI32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i31_re_i31_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\t', value='#x9;',
@@ -3048,11 +3237,12 @@ def test_re_i31_re_i31_v(save_xml):
         instance="msData/regex/reI31.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i29_re_i29_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\n', value='#xA;',
@@ -3064,11 +3254,12 @@ def test_re_i29_re_i29_v(save_xml):
         instance="msData/regex/reI29.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i28_re_i28_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\r', value='#xD;',
@@ -3080,11 +3271,12 @@ def test_re_i28_re_i28_i(save_xml):
         instance="msData/regex/reI28.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i27_re_i27_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\r', value='\\r',
@@ -3096,11 +3288,12 @@ def test_re_i27_re_i27_i(save_xml):
         instance="msData/regex/reI27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i26_re_i26_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\r', value='r',
@@ -3112,11 +3305,12 @@ def test_re_i26_re_i26_i(save_xml):
         instance="msData/regex/reI26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i25_re_i25_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\r', value='\r', type='valid',
@@ -3128,11 +3322,12 @@ def test_re_i25_re_i25_v(save_xml):
         instance="msData/regex/reI25.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i24_re_i24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\n', value='#xA;',
@@ -3144,11 +3339,12 @@ def test_re_i24_re_i24_i(save_xml):
         instance="msData/regex/reI24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i23_re_i23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\n', value='\\n',
@@ -3160,11 +3356,12 @@ def test_re_i23_re_i23_i(save_xml):
         instance="msData/regex/reI23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i22_re_i22_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\n', value='n',
@@ -3176,11 +3373,12 @@ def test_re_i22_re_i22_i(save_xml):
         instance="msData/regex/reI22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i21_re_i21_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\n', value='\n', type='valid',
@@ -3192,11 +3390,12 @@ def test_re_i21_re_i21_v(save_xml):
         instance="msData/regex/reI21.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i20_re_i20_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\t', value='#x9;',
@@ -3208,11 +3407,12 @@ def test_re_i20_re_i20_i(save_xml):
         instance="msData/regex/reI20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i19_re_i19_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\t', value='\\t',
@@ -3224,11 +3424,12 @@ def test_re_i19_re_i19_i(save_xml):
         instance="msData/regex/reI19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i18_re_i18_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\t', value='t',
@@ -3240,11 +3441,12 @@ def test_re_i18_re_i18_i(save_xml):
         instance="msData/regex/reI18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i17_re_i17_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\\t', value='\t', type='valid',
@@ -3256,11 +3458,12 @@ def test_re_i17_re_i17_v(save_xml):
         instance="msData/regex/reI17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i16_re_i16_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[(a\?)?]+', value='aa?',
@@ -3272,11 +3475,12 @@ def test_re_i16_re_i16_v(save_xml):
         instance="msData/regex/reI16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i15_re_i15_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[(a\?)?]+', value='a??',
@@ -3288,11 +3492,12 @@ def test_re_i15_re_i15_v(save_xml):
         instance="msData/regex/reI15.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i14_re_i14_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[(a\?)?]+', value='a',
@@ -3304,11 +3509,12 @@ def test_re_i14_re_i14_v(save_xml):
         instance="msData/regex/reI14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i13_re_i13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[(a\?)?]+', value='a?a?a?',
@@ -3320,11 +3526,12 @@ def test_re_i13_re_i13_v(save_xml):
         instance="msData/regex/reI13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i12_re_i12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[(a\?)?]+', value='a?',
@@ -3336,11 +3543,12 @@ def test_re_i12_re_i12_v(save_xml):
         instance="msData/regex/reI12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i11_re_i11_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[(a\?)?]+', value='',
@@ -3352,11 +3560,12 @@ def test_re_i11_re_i11_i(save_xml):
         instance="msData/regex/reI11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i10_re_i10_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[a\*]*', value='a',
@@ -3368,11 +3577,12 @@ def test_re_i10_re_i10_v(save_xml):
         instance="msData/regex/reI10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i9_re_i9_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[a\*]*', value='aa*',
@@ -3384,11 +3594,12 @@ def test_re_i9_re_i9_v(save_xml):
         instance="msData/regex/reI9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i8_re_i8_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[a\*]*', value='a**',
@@ -3400,11 +3611,12 @@ def test_re_i8_re_i8_v(save_xml):
         instance="msData/regex/reI8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_i1_re_i1_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -3418,11 +3630,12 @@ def test_re_i1_re_i1_v(save_xml):
         instance="msData/regex/reI1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h21_re_h21_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-a-x-x]+', value='a-b',
@@ -3434,11 +3647,12 @@ def test_re_h21_re_h21_i(save_xml):
         instance="msData/regex/reH21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h20_re_h20_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-a-x-x]+', value='j',
@@ -3450,11 +3664,12 @@ def test_re_h20_re_h20_i(save_xml):
         instance="msData/regex/reH20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h19_re_h19_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-a-x-x]+', value='a-x',
@@ -3466,11 +3681,12 @@ def test_re_h19_re_h19_v(save_xml):
         instance="msData/regex/reH19.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h18_re_h18_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-]*', value='a--aa---',
@@ -3482,11 +3698,12 @@ def test_re_h18_re_h18_v(save_xml):
         instance="msData/regex/reH18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h17_re_h17_v(save_xml):
     """
     TEST :branch : base='string', pattern='[-a]+', value='a--aa---',
@@ -3498,11 +3715,12 @@ def test_re_h17_re_h17_v(save_xml):
         instance="msData/regex/reH17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h16_re_h16_v(save_xml):
     """
     TEST :branch : base='string', pattern='[-]', value='-', type='valid',
@@ -3514,11 +3732,12 @@ def test_re_h16_re_h16_v(save_xml):
         instance="msData/regex/reH16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h15_re_h15_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='[][]',
@@ -3530,11 +3749,12 @@ def test_re_h15_re_h15_i(save_xml):
         instance="msData/regex/reH15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h14_re_h14_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='\]\]',
@@ -3546,11 +3766,12 @@ def test_re_h14_re_h14_i(save_xml):
         instance="msData/regex/reH14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h13_re_h13_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='\[][',
@@ -3562,11 +3783,12 @@ def test_re_h13_re_h13_i(save_xml):
         instance="msData/regex/reH13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h12_re_h12_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='[][',
@@ -3578,11 +3800,12 @@ def test_re_h12_re_h12_v(save_xml):
         instance="msData/regex/reH12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h11_re_h11_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='\]\',
@@ -3594,11 +3817,12 @@ def test_re_h11_re_h11_v(save_xml):
         instance="msData/regex/reH11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h10_re_h10_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='[\\',
@@ -3610,11 +3834,12 @@ def test_re_h10_re_h10_v(save_xml):
         instance="msData/regex/reH10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h9_re_h9_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='[]',
@@ -3626,11 +3851,12 @@ def test_re_h9_re_h9_v(save_xml):
         instance="msData/regex/reH9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h8_re_h8_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='\[]',
@@ -3642,11 +3868,12 @@ def test_re_h8_re_h8_v(save_xml):
         instance="msData/regex/reH8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h7_re_h7_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='\[',
@@ -3658,11 +3885,12 @@ def test_re_h7_re_h7_v(save_xml):
         instance="msData/regex/reH7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h6_re_h6_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value=']',
@@ -3674,11 +3902,12 @@ def test_re_h6_re_h6_v(save_xml):
         instance="msData/regex/reH6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h5_re_h5_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='[',
@@ -3690,11 +3919,12 @@ def test_re_h5_re_h5_v(save_xml):
         instance="msData/regex/reH5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_h4_re_h4_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\\[\]]{0,3}', value='\',
@@ -3706,11 +3936,12 @@ def test_re_h4_re_h4_v(save_xml):
         instance="msData/regex/reH4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g51_re_g51_i(save_xml):
     """
     TEST :branch : base='string', pattern='[#x10000;]', value='#x10001;',
@@ -3722,11 +3953,12 @@ def test_re_g51_re_g51_i(save_xml):
         instance="msData/regex/reG51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g50_re_g50_i(save_xml):
     """
     TEST :branch : base='string', pattern='[#x10000;]', value='#x10000;',
@@ -3739,11 +3971,12 @@ def test_re_g50_re_g50_i(save_xml):
         instance="msData/regex/reG50.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g49_re_g49_v(save_xml):
     """
     TEST :branch : base='string', pattern='[?]', value='#x0FFF;',
@@ -3755,11 +3988,12 @@ def test_re_g49_re_g49_v(save_xml):
         instance="msData/regex/reG49.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g48_re_g48_i(save_xml):
     """
     TEST :branch : base='string', pattern='[@]', value='a',
@@ -3771,11 +4005,12 @@ def test_re_g48_re_g48_i(save_xml):
         instance="msData/regex/reG48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g47_re_g47_v(save_xml):
     """
     TEST :branch : base='string', pattern='[@]', value='@', type='valid',
@@ -3787,11 +4022,12 @@ def test_re_g47_re_g47_v(save_xml):
         instance="msData/regex/reG47.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g45_re_g45_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[=->]', value='\?',
@@ -3803,11 +4039,12 @@ def test_re_g45_re_g45_i(save_xml):
         instance="msData/regex/reG45.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g44_re_g44_v(save_xml):
     """
     TEST :branch : base='string', pattern='[=->]', value='>',
@@ -3819,11 +4056,12 @@ def test_re_g44_re_g44_v(save_xml):
         instance="msData/regex/reG44.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g43_re_g43_v(save_xml):
     """
     TEST :branch : base='string', pattern='[=->]', value='=',
@@ -3835,11 +4073,12 @@ def test_re_g43_re_g43_v(save_xml):
         instance="msData/regex/reG43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g40_re_g40_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[1-\]]+', value='^',
@@ -3851,11 +4090,12 @@ def test_re_g40_re_g40_i(save_xml):
         instance="msData/regex/reG40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g39_re_g39_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[1-\]]+', value='0',
@@ -3867,11 +4107,12 @@ def test_re_g39_re_g39_i(save_xml):
         instance="msData/regex/reG39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g38_re_g38_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[1-\]]+', value='1]',
@@ -3883,11 +4124,12 @@ def test_re_g38_re_g38_v(save_xml):
         instance="msData/regex/reG38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g36_re_g36_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\*a]*', value='a*a****aaaaa*',
@@ -3899,11 +4141,12 @@ def test_re_g36_re_g36_v(save_xml):
         instance="msData/regex/reG36.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g33_re_g33_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -3915,11 +4158,12 @@ def test_re_g33_re_g33_v(save_xml):
         instance="msData/regex/reG33.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g32_re_g32_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -3931,11 +4175,12 @@ def test_re_g32_re_g32_v(save_xml):
         instance="msData/regex/reG32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g31_re_g31_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -3947,11 +4192,12 @@ def test_re_g31_re_g31_v(save_xml):
         instance="msData/regex/reG31.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g30_re_g30_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -3963,11 +4209,12 @@ def test_re_g30_re_g30_v(save_xml):
         instance="msData/regex/reG30.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g29_re_g29_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -3979,11 +4226,12 @@ def test_re_g29_re_g29_v(save_xml):
         instance="msData/regex/reG29.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g28_re_g28_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -3995,11 +4243,12 @@ def test_re_g28_re_g28_v(save_xml):
         instance="msData/regex/reG28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g27_re_g27_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*',
@@ -4011,11 +4260,12 @@ def test_re_g27_re_g27_v(save_xml):
         instance="msData/regex/reG27.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g26_re_g26_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-1-4x-z-7-9]*', value='',
@@ -4027,11 +4277,12 @@ def test_re_g26_re_g26_v(save_xml):
         instance="msData/regex/reG26.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g25_re_g25_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+',
@@ -4043,11 +4294,12 @@ def test_re_g25_re_g25_i(save_xml):
         instance="msData/regex/reG25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g24_re_g24_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='? ?',
@@ -4059,11 +4311,12 @@ def test_re_g24_re_g24_i(save_xml):
         instance="msData/regex/reG24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g23_re_g23_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='?1?',
@@ -4075,11 +4328,12 @@ def test_re_g23_re_g23_i(save_xml):
         instance="msData/regex/reG23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g22_re_g22_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='?',
@@ -4091,11 +4345,12 @@ def test_re_g22_re_g22_v(save_xml):
         instance="msData/regex/reG22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g21_re_g21_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='?d?',
@@ -4107,11 +4362,12 @@ def test_re_g21_re_g21_i(save_xml):
         instance="msData/regex/reG21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g20_re_g20_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='?c?',
@@ -4123,11 +4379,12 @@ def test_re_g20_re_g20_v(save_xml):
         instance="msData/regex/reG20.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g19_re_g19_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='?b?',
@@ -4139,11 +4396,12 @@ def test_re_g19_re_g19_v(save_xml):
         instance="msData/regex/reG19.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g18_re_g18_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\S\D\?a-c\?]+', value='?a?',
@@ -4155,11 +4413,12 @@ def test_re_g18_re_g18_v(save_xml):
         instance="msData/regex/reG18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g17_re_g17_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\\-\{^]', value='',
@@ -4171,11 +4430,12 @@ def test_re_g17_re_g17_i(save_xml):
         instance="msData/regex/reG17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g16_re_g16_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^a-z^]', value='',
@@ -4187,11 +4447,12 @@ def test_re_g16_re_g16_i(save_xml):
         instance="msData/regex/reG16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g14_re_g14_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -4204,11 +4465,12 @@ def test_re_g14_re_g14_v(save_xml):
         instance="msData/regex/reG14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g13_re_g13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\t]', value='#x9;',
@@ -4220,11 +4482,12 @@ def test_re_g13_re_g13_v(save_xml):
         instance="msData/regex/reG13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g11_re_g11_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[\n]', value='#xA;',
@@ -4236,11 +4499,12 @@ def test_re_g11_re_g11_v(save_xml):
         instance="msData/regex/reG11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g10_re_g10_i(save_xml):
     """
     TEST :branch : base='string', pattern='[0-z]*', value='/',
@@ -4252,11 +4516,12 @@ def test_re_g10_re_g10_i(save_xml):
         instance="msData/regex/reG10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g9_re_g9_i(save_xml):
     """
     TEST :branch : base='string', pattern='[0-z]*', value='{',
@@ -4268,11 +4533,12 @@ def test_re_g9_re_g9_i(save_xml):
         instance="msData/regex/reG9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g8_re_g8_v(save_xml):
     """
     TEST :branch : base='string', pattern='[0-z]*',
@@ -4284,11 +4550,12 @@ def test_re_g8_re_g8_v(save_xml):
         instance="msData/regex/reG8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g7_re_g7_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-a]', value='b',
@@ -4300,11 +4567,12 @@ def test_re_g7_re_g7_i(save_xml):
         instance="msData/regex/reG7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g6_re_g6_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-a]', value='a',
@@ -4316,11 +4584,12 @@ def test_re_g6_re_g6_v(save_xml):
         instance="msData/regex/reG6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g4_re_g4_v(save_xml):
     """
     TEST :branch : base='string', pattern='[1-3]{1,4}', value='123',
@@ -4332,11 +4601,12 @@ def test_re_g4_re_g4_v(save_xml):
         instance="msData/regex/reG4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g3_re_g3_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a]', value='', type='invalid',
@@ -4348,11 +4618,12 @@ def test_re_g3_re_g3_i(save_xml):
         instance="msData/regex/reG3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_g2_re_g2_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a]', value='b',
@@ -4364,11 +4635,12 @@ def test_re_g2_re_g2_i(save_xml):
         instance="msData/regex/reG2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f55_re_f55_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[a-\}-]', value='}-',
@@ -4380,11 +4652,12 @@ def test_re_f55_re_f55_v(save_xml):
         instance="msData/regex/reF55.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f54_re_f54_v(save_xml):
     """
     TEST :branch : base='string', pattern='[a-abc]', value='abc',
@@ -4396,11 +4669,12 @@ def test_re_f54_re_f54_v(save_xml):
         instance="msData/regex/reF54.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f53_re_f53_i(save_xml):
     """
     TEST :branch : base='string', pattern='^^a', value='^a',
@@ -4412,11 +4686,12 @@ def test_re_f53_re_f53_i(save_xml):
         instance="msData/regex/reF53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f52_re_f52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='^\^a', value='^', type='valid',
@@ -4428,11 +4703,12 @@ def test_re_f52_re_f52_i(save_xml):
         instance="msData/regex/reF52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f51_re_f51_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c^\d\c', value='a r',
@@ -4444,11 +4720,12 @@ def test_re_f51_re_f51_i(save_xml):
         instance="msData/regex/reF51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f50_re_f50_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c^\d\c', value='a c',
@@ -4460,11 +4737,12 @@ def test_re_f50_re_f50_i(save_xml):
         instance="msData/regex/reF50.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f49_re_f49_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c^\d\c', value='a z',
@@ -4476,11 +4754,12 @@ def test_re_f49_re_f49_i(save_xml):
         instance="msData/regex/reF49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f48_re_f48_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c^\d\c', value='a c',
@@ -4492,11 +4771,12 @@ def test_re_f48_re_f48_i(save_xml):
         instance="msData/regex/reF48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f47_re_f47_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c^\d\c', value='aa',
@@ -4508,11 +4788,12 @@ def test_re_f47_re_f47_i(save_xml):
         instance="msData/regex/reF47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f46_re_f46_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\c^\d\c', value='a*a',
@@ -4524,11 +4805,12 @@ def test_re_f46_re_f46_v(save_xml):
         instance="msData/regex/reF46.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f45_re_f45_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(^\?)*', value='a+*abc',
@@ -4540,11 +4822,12 @@ def test_re_f45_re_f45_v(save_xml):
         instance="msData/regex/reF45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f44_re_f44_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='^\?', value='?',
@@ -4556,11 +4839,12 @@ def test_re_f44_re_f44_i(save_xml):
         instance="msData/regex/reF44.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f43_re_f43_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='^\P{IsBasicLatin}', value='a',
@@ -4572,11 +4856,12 @@ def test_re_f43_re_f43_v(save_xml):
         instance="msData/regex/reF43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f42_re_f42_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='^\P{IsBasicLatin}',
@@ -4588,11 +4873,12 @@ def test_re_f42_re_f42_i(save_xml):
         instance="msData/regex/reF42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f41_re_f41_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='^\p{IsBasicLatin}', value='a',
@@ -4604,11 +4890,12 @@ def test_re_f41_re_f41_i(save_xml):
         instance="msData/regex/reF41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f40_re_f40_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='^\p{IsBasicLatin}',
@@ -4620,11 +4907,12 @@ def test_re_f40_re_f40_v(save_xml):
         instance="msData/regex/reF40.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f39_re_f39_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-z-[^a]]', value='b',
@@ -4636,11 +4924,12 @@ def test_re_f39_re_f39_i(save_xml):
         instance="msData/regex/reF39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f36_re_f36_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-c-[^a-c]]', value='d',
@@ -4652,11 +4941,12 @@ def test_re_f36_re_f36_i(save_xml):
         instance="msData/regex/reF36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f34_re_f34_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-b-[0-9]]+', value='a1',
@@ -4668,11 +4958,12 @@ def test_re_f34_re_f34_i(save_xml):
         instance="msData/regex/reF34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f32_re_f32_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[a-\}]+', value='abcxyz}',
@@ -4684,11 +4975,12 @@ def test_re_f32_re_f32_v(save_xml):
         instance="msData/regex/reF32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f23_re_f23_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^a-d-b-c]', value='cc',
@@ -4700,11 +4992,12 @@ def test_re_f23_re_f23_i(save_xml):
         instance="msData/regex/reF23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f22_re_f22_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^a-d-b-c]', value='ab',
@@ -4716,11 +5009,12 @@ def test_re_f22_re_f22_i(save_xml):
         instance="msData/regex/reF22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f21_re_f21_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^a-d-b-c]', value='c-c',
@@ -4732,11 +5026,12 @@ def test_re_f21_re_f21_i(save_xml):
         instance="msData/regex/reF21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f20_re_f20_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^a-d-b-c]', value='a-b',
@@ -4748,11 +5043,12 @@ def test_re_f20_re_f20_i(save_xml):
         instance="msData/regex/reF20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f18_re_f18_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-d-[b-c]]', value='c',
@@ -4764,11 +5060,12 @@ def test_re_f18_re_f18_i(save_xml):
         instance="msData/regex/reF18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f17_re_f17_i(save_xml):
     """
     TEST :branch : base='string', pattern='[a-d-[b-c]]', value='b',
@@ -4780,11 +5077,12 @@ def test_re_f17_re_f17_i(save_xml):
         instance="msData/regex/reF17.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f15_re_f15_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^-z]+', value='a-z',
@@ -4796,11 +5094,12 @@ def test_re_f15_re_f15_i(save_xml):
         instance="msData/regex/reF15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f14_re_f14_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^-z]+', value='aaz',
@@ -4812,11 +5111,12 @@ def test_re_f14_re_f14_i(save_xml):
         instance="msData/regex/reF14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f13_re_f13_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^(]{0,2}', value='@',
@@ -4828,11 +5128,12 @@ def test_re_f13_re_f13_i(save_xml):
         instance="msData/regex/reF13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f12_re_f12_v(save_xml):
     """
     TEST :branch : base='string', pattern='[^(]{0,2}', value=' a',
@@ -4844,11 +5145,12 @@ def test_re_f12_re_f12_v(save_xml):
         instance="msData/regex/reF12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f11_re_f11_v(save_xml):
     """
     TEST :branch : base='string', pattern='[^(]{0,2}', value='ab',
@@ -4860,11 +5162,12 @@ def test_re_f11_re_f11_v(save_xml):
         instance="msData/regex/reF11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f10_re_f10_v(save_xml):
     """
     TEST :branch : base='string', pattern='[^(]{0,2}', value='a',
@@ -4876,11 +5179,12 @@ def test_re_f10_re_f10_v(save_xml):
         instance="msData/regex/reF10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f9_re_f9_v(save_xml):
     """
     TEST :branch : base='string', pattern='[^(]{0,2}', value='',
@@ -4892,11 +5196,12 @@ def test_re_f9_re_f9_v(save_xml):
         instance="msData/regex/reF9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f8_re_f8_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='[^\s]{3}', value='a c',
@@ -4908,11 +5213,12 @@ def test_re_f8_re_f8_i(save_xml):
         instance="msData/regex/reF8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f7_re_f7_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='[^\s]{3}', value='abc',
@@ -4924,11 +5230,12 @@ def test_re_f7_re_f7_v(save_xml):
         instance="msData/regex/reF7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f6_re_f6_i(save_xml):
     """
     TEST :branch : base='string', pattern='[^2-9a-x]{2}', value='1x',
@@ -4940,11 +5247,12 @@ def test_re_f6_re_f6_i(save_xml):
         instance="msData/regex/reF6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_f4_re_f4_v(save_xml):
     """
     TEST :branch : base='string', pattern='[^2-9a-x]{2}', value='1z',
@@ -4956,11 +5264,12 @@ def test_re_f4_re_f4_v(save_xml):
         instance="msData/regex/reF4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_e14_re_e14_v(save_xml):
     r"""
     TEST :branch : base='string',
@@ -4973,11 +5282,12 @@ def test_re_e14_re_e14_v(save_xml):
         instance="msData/regex/reE14.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_e13_re_e13_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='\.\\\?\*\+\{\}\[\]\(\)\|',
@@ -4989,11 +5299,12 @@ def test_re_e13_re_e13_v(save_xml):
         instance="msData/regex/reE13.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_e10_re_e10_v(save_xml):
     """
     TEST :branch : base='string', pattern='|', value='', type='error',
@@ -5006,11 +5317,12 @@ def test_re_e10_re_e10_v(save_xml):
         instance="msData/regex/reE10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d8_re_d8_i(save_xml):
     """
     TEST :branch : base='string',
@@ -5023,11 +5335,12 @@ def test_re_d8_re_d8_i(save_xml):
         instance="msData/regex/reD8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d7_re_d7_i(save_xml):
     """
     TEST :branch : base='string',
@@ -5041,11 +5354,12 @@ def test_re_d7_re_d7_i(save_xml):
         instance="msData/regex/reD7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d6_re_d6_v(save_xml):
     """
     TEST :branch : base='string',
@@ -5059,11 +5373,12 @@ def test_re_d6_re_d6_v(save_xml):
         instance="msData/regex/reD6.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d5_re_d5_v(save_xml):
     """
     TEST :branch : base='string',
@@ -5076,11 +5391,12 @@ def test_re_d5_re_d5_v(save_xml):
         instance="msData/regex/reD5.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d4_re_d4_v(save_xml):
     """
     TEST :branch : base='string',
@@ -5093,11 +5409,12 @@ def test_re_d4_re_d4_v(save_xml):
         instance="msData/regex/reD4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d3_re_d3_v(save_xml):
     """
     TEST :branch : base='string',
@@ -5110,11 +5427,12 @@ def test_re_d3_re_d3_v(save_xml):
         instance="msData/regex/reD3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d2_re_d2_v(save_xml):
     """
     TEST :branch : base='string',
@@ -5127,11 +5445,12 @@ def test_re_d2_re_d2_v(save_xml):
         instance="msData/regex/reD2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_d1_re_d1_v(save_xml):
     """
     TEST :branch : base='string',
@@ -5144,11 +5463,12 @@ def test_re_d1_re_d1_v(save_xml):
         instance="msData/regex/reD1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c84_re_c84_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5160,11 +5480,12 @@ def test_re_c84_re_c84_i(save_xml):
         instance="msData/regex/reC84.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c83_re_c83_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5176,11 +5497,12 @@ def test_re_c83_re_c83_i(save_xml):
         instance="msData/regex/reC83.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c82_re_c82_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5192,11 +5514,12 @@ def test_re_c82_re_c82_i(save_xml):
         instance="msData/regex/reC82.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c81_re_c81_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5208,11 +5531,12 @@ def test_re_c81_re_c81_i(save_xml):
         instance="msData/regex/reC81.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c80_re_c80_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5224,11 +5548,12 @@ def test_re_c80_re_c80_i(save_xml):
         instance="msData/regex/reC80.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c79_re_c79_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5240,11 +5565,12 @@ def test_re_c79_re_c79_i(save_xml):
         instance="msData/regex/reC79.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c78_re_c78_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5256,11 +5582,12 @@ def test_re_c78_re_c78_v(save_xml):
         instance="msData/regex/reC78.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c77_re_c77_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5272,11 +5599,12 @@ def test_re_c77_re_c77_v(save_xml):
         instance="msData/regex/reC77.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c76_re_c76_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5288,11 +5616,12 @@ def test_re_c76_re_c76_v(save_xml):
         instance="msData/regex/reC76.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c75_re_c75_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5304,11 +5633,12 @@ def test_re_c75_re_c75_v(save_xml):
         instance="msData/regex/reC75.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c74_re_c74_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5320,11 +5650,12 @@ def test_re_c74_re_c74_v(save_xml):
         instance="msData/regex/reC74.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c73_re_c73_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0,1}b{1,2}c{2,3}',
@@ -5336,11 +5667,12 @@ def test_re_c73_re_c73_v(save_xml):
         instance="msData/regex/reC73.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c72_re_c72_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{0,0}', value='ab',
@@ -5352,11 +5684,12 @@ def test_re_c72_re_c72_i(save_xml):
         instance="msData/regex/reC72.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c71_re_c71_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{0,0}', value='a',
@@ -5368,11 +5701,12 @@ def test_re_c71_re_c71_i(save_xml):
         instance="msData/regex/reC71.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c70_re_c70_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab{0,0}', value='',
@@ -5384,11 +5718,12 @@ def test_re_c70_re_c70_v(save_xml):
         instance="msData/regex/reC70.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c64_re_c64_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='',
@@ -5400,11 +5735,12 @@ def test_re_c64_re_c64_i(save_xml):
         instance="msData/regex/reC64.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c63_re_c63_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='abab abab',
@@ -5416,11 +5752,12 @@ def test_re_c63_re_c63_i(save_xml):
         instance="msData/regex/reC63.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c62_re_c62_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='ababababa',
@@ -5432,11 +5769,12 @@ def test_re_c62_re_c62_i(save_xml):
         instance="msData/regex/reC62.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c61_re_c61_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='ababaa',
@@ -5448,11 +5786,12 @@ def test_re_c61_re_c61_i(save_xml):
         instance="msData/regex/reC61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c60_re_c60_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='ababa',
@@ -5464,11 +5803,12 @@ def test_re_c60_re_c60_i(save_xml):
         instance="msData/regex/reC60.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c59_re_c59_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='ab',
@@ -5480,11 +5820,12 @@ def test_re_c59_re_c59_i(save_xml):
         instance="msData/regex/reC59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c58_re_c58_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='abababababababa
@@ -5497,11 +5838,12 @@ def test_re_c58_re_c58_v(save_xml):
         instance="msData/regex/reC58.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c57_re_c57_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='ababab',
@@ -5513,11 +5855,12 @@ def test_re_c57_re_c57_v(save_xml):
         instance="msData/regex/reC57.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c56_re_c56_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2,}', value='abab',
@@ -5529,11 +5872,12 @@ def test_re_c56_re_c56_v(save_xml):
         instance="msData/regex/reC56.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c55_re_c55_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='a b',
@@ -5545,11 +5889,12 @@ def test_re_c55_re_c55_i(save_xml):
         instance="msData/regex/reC55.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c54_re_c54_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='a b a b',
@@ -5561,11 +5906,12 @@ def test_re_c54_re_c54_i(save_xml):
         instance="msData/regex/reC54.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c53_re_c53_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='ab',
@@ -5577,11 +5923,12 @@ def test_re_c53_re_c53_i(save_xml):
         instance="msData/regex/reC53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c52_re_c52_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='a ba ba
@@ -5593,11 +5940,12 @@ def test_re_c52_re_c52_i(save_xml):
         instance="msData/regex/reC52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c51_re_c51_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='a ba b',
@@ -5609,11 +5957,12 @@ def test_re_c51_re_c51_v(save_xml):
         instance="msData/regex/reC51.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c50_re_c50_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='a b',
@@ -5625,11 +5974,12 @@ def test_re_c50_re_c50_v(save_xml):
         instance="msData/regex/reC50.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c49_re_c49_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(a\sb){0,2}', value='',
@@ -5641,11 +5991,12 @@ def test_re_c49_re_c49_v(save_xml):
         instance="msData/regex/reC49.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c48_re_c48_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?',
@@ -5657,11 +6008,12 @@ def test_re_c48_re_c48_i(save_xml):
         instance="msData/regex/reC48.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c47_re_c47_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?',
@@ -5673,11 +6025,12 @@ def test_re_c47_re_c47_i(save_xml):
         instance="msData/regex/reC47.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c46_re_c46_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?',
@@ -5689,11 +6042,12 @@ def test_re_c46_re_c46_i(save_xml):
         instance="msData/regex/reC46.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c45_re_c45_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?',
@@ -5705,11 +6059,12 @@ def test_re_c45_re_c45_i(save_xml):
         instance="msData/regex/reC45.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c44_re_c44_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?', value='ac',
@@ -5721,11 +6076,12 @@ def test_re_c44_re_c44_i(save_xml):
         instance="msData/regex/reC44.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c43_re_c43_v(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?',
@@ -5737,11 +6093,12 @@ def test_re_c43_re_c43_v(save_xml):
         instance="msData/regex/reC43.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c42_re_c42_v(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?',
@@ -5753,11 +6110,12 @@ def test_re_c42_re_c42_v(save_xml):
         instance="msData/regex/reC42.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c41_re_c41_v(save_xml):
     """
     TEST :branch : base='string', pattern='((ab)(ac){0,2})?', value='ab',
@@ -5769,11 +6127,12 @@ def test_re_c41_re_c41_v(save_xml):
         instance="msData/regex/reC41.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c40_re_c40_i(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='',
@@ -5785,11 +6144,12 @@ def test_re_c40_re_c40_i(save_xml):
         instance="msData/regex/reC40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c39_re_c39_i(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='abbbbb',
@@ -5801,11 +6161,12 @@ def test_re_c39_re_c39_i(save_xml):
         instance="msData/regex/reC39.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c38_re_c38_i(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='bbc',
@@ -5817,11 +6178,12 @@ def test_re_c38_re_c38_i(save_xml):
         instance="msData/regex/reC38.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c37_re_c37_i(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='abbc',
@@ -5833,11 +6195,12 @@ def test_re_c37_re_c37_i(save_xml):
         instance="msData/regex/reC37.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c36_re_c36_i(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='ab',
@@ -5849,11 +6212,12 @@ def test_re_c36_re_c36_i(save_xml):
         instance="msData/regex/reC36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c35_re_c35_v(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='bbbb',
@@ -5865,11 +6229,12 @@ def test_re_c35_re_c35_v(save_xml):
         instance="msData/regex/reC35.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c34_re_c34_v(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='bbb',
@@ -5881,11 +6246,12 @@ def test_re_c34_re_c34_v(save_xml):
         instance="msData/regex/reC34.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c33_re_c33_v(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='bb',
@@ -5897,11 +6263,12 @@ def test_re_c33_re_c33_v(save_xml):
         instance="msData/regex/reC33.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c32_re_c32_v(save_xml):
     """
     TEST :branch : base='string', pattern='a*b{2,4}c{0}', value='aaabbb',
@@ -5913,11 +6280,12 @@ def test_re_c32_re_c32_v(save_xml):
         instance="msData/regex/reC32.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c31_re_c31_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc{2}', value='',
@@ -5929,11 +6297,12 @@ def test_re_c31_re_c31_i(save_xml):
         instance="msData/regex/reC31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c30_re_c30_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc{2}', value='abccc',
@@ -5945,11 +6314,12 @@ def test_re_c30_re_c30_i(save_xml):
         instance="msData/regex/reC30.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c29_re_c29_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc{2}', value='abc',
@@ -5961,11 +6331,12 @@ def test_re_c29_re_c29_i(save_xml):
         instance="msData/regex/reC29.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c28_re_c28_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc{2}', value='abcc',
@@ -5977,11 +6348,12 @@ def test_re_c28_re_c28_v(save_xml):
         instance="msData/regex/reC28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c27_re_c27_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2}c', value='',
@@ -5993,11 +6365,12 @@ def test_re_c27_re_c27_i(save_xml):
         instance="msData/regex/reC27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c26_re_c26_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2}c', value='a',
@@ -6009,11 +6382,12 @@ def test_re_c26_re_c26_i(save_xml):
         instance="msData/regex/reC26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c25_re_c25_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2}c', value='abbbc',
@@ -6025,11 +6399,12 @@ def test_re_c25_re_c25_i(save_xml):
         instance="msData/regex/reC25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c24_re_c24_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2}c', value='abc',
@@ -6041,11 +6416,12 @@ def test_re_c24_re_c24_i(save_xml):
         instance="msData/regex/reC24.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c23_re_c23_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2}c', value='ac',
@@ -6057,11 +6433,12 @@ def test_re_c23_re_c23_i(save_xml):
         instance="msData/regex/reC23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c22_re_c22_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab{2}c', value='abbc',
@@ -6073,11 +6450,12 @@ def test_re_c22_re_c22_v(save_xml):
         instance="msData/regex/reC22.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c21_re_c21_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})*', value='aaaaaaaaaaaaaa
@@ -6091,11 +6469,12 @@ def test_re_c21_re_c21_i(save_xml):
         instance="msData/regex/reC21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c20_re_c20_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})*', value='aaa',
@@ -6107,11 +6486,12 @@ def test_re_c20_re_c20_i(save_xml):
         instance="msData/regex/reC20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c19_re_c19_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})*', value='a',
@@ -6123,11 +6503,12 @@ def test_re_c19_re_c19_i(save_xml):
         instance="msData/regex/reC19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c18_re_c18_v(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})*', value='aaaaaaaaaaaaaa
@@ -6143,11 +6524,12 @@ def test_re_c18_re_c18_v(save_xml):
         instance="msData/regex/reC18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c17_re_c17_v(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})*', value='aa',
@@ -6159,11 +6541,12 @@ def test_re_c17_re_c17_v(save_xml):
         instance="msData/regex/reC17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c16_re_c16_v(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})*', value='',
@@ -6175,11 +6558,12 @@ def test_re_c16_re_c16_v(save_xml):
         instance="msData/regex/reC16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c15_re_c15_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+', value='aaa',
@@ -6191,11 +6575,12 @@ def test_re_c15_re_c15_i(save_xml):
         instance="msData/regex/reC15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c14_re_c14_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+', value='a2',
@@ -6207,11 +6592,12 @@ def test_re_c14_re_c14_i(save_xml):
         instance="msData/regex/reC14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c13_re_c13_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+', value='a',
@@ -6223,11 +6609,12 @@ def test_re_c13_re_c13_i(save_xml):
         instance="msData/regex/reC13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c12_re_c12_i(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+', value='',
@@ -6239,11 +6626,12 @@ def test_re_c12_re_c12_i(save_xml):
         instance="msData/regex/reC12.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c11_re_c11_v(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+',
@@ -6255,11 +6643,12 @@ def test_re_c11_re_c11_v(save_xml):
         instance="msData/regex/reC11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c10_re_c10_v(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+', value='aaaa',
@@ -6271,11 +6660,12 @@ def test_re_c10_re_c10_v(save_xml):
         instance="msData/regex/reC10.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c9_re_c9_v(save_xml):
     """
     TEST :branch : base='string', pattern='(a{2})+', value='aa',
@@ -6287,11 +6677,12 @@ def test_re_c9_re_c9_v(save_xml):
         instance="msData/regex/reC9.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c8_re_c8_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab){2})?', value='abababab',
@@ -6303,11 +6694,12 @@ def test_re_c8_re_c8_i(save_xml):
         instance="msData/regex/reC8.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c7_re_c7_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab){2})?', value='ababa',
@@ -6319,11 +6711,12 @@ def test_re_c7_re_c7_i(save_xml):
         instance="msData/regex/reC7.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c6_re_c6_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab){2})?', value='ab',
@@ -6335,11 +6728,12 @@ def test_re_c6_re_c6_i(save_xml):
         instance="msData/regex/reC6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c5_re_c5_i(save_xml):
     """
     TEST :branch : base='string', pattern='((ab){2})?', value='a',
@@ -6351,11 +6745,12 @@ def test_re_c5_re_c5_i(save_xml):
         instance="msData/regex/reC5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c4_re_c4_v(save_xml):
     """
     TEST :branch : base='string', pattern='((ab){2})?', value='',
@@ -6367,11 +6762,12 @@ def test_re_c4_re_c4_v(save_xml):
         instance="msData/regex/reC4.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c3_re_c3_v(save_xml):
     """
     TEST :branch : base='string', pattern='((ab){2})?', value='abab',
@@ -6383,11 +6779,12 @@ def test_re_c3_re_c3_v(save_xml):
         instance="msData/regex/reC3.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c2_re_c2_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0}', value='', type='valid',
@@ -6399,11 +6796,12 @@ def test_re_c2_re_c2_v(save_xml):
         instance="msData/regex/reC2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_c1_re_c1_i(save_xml):
     """
     TEST :branch : base='string', pattern='a{0}', value='a',
@@ -6415,11 +6813,12 @@ def test_re_c1_re_c1_i(save_xml):
         instance="msData/regex/reC1.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b78_re_b78_v(save_xml):
     """
     TEST :branch : base='string', pattern='a{0}', value='', type='valid',
@@ -6431,11 +6830,12 @@ def test_re_b78_re_b78_v(save_xml):
         instance="msData/regex/reB78.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b61_re_b61_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??', value='abc???',
@@ -6447,11 +6847,12 @@ def test_re_b61_re_b61_i(save_xml):
         instance="msData/regex/reB61.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b60_re_b60_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??', value='abc',
@@ -6463,11 +6864,12 @@ def test_re_b60_re_b60_i(save_xml):
         instance="msData/regex/reB60.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b59_re_b59_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??', value='bc??',
@@ -6479,11 +6881,12 @@ def test_re_b59_re_b59_i(save_xml):
         instance="msData/regex/reB59.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b58_re_b58_i(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??', value='ac??',
@@ -6495,11 +6898,12 @@ def test_re_b58_re_b58_i(save_xml):
         instance="msData/regex/reB58.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b57_re_b57_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??',
@@ -6511,11 +6915,12 @@ def test_re_b57_re_b57_v(save_xml):
         instance="msData/regex/reB57.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b56_re_b56_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??', value='abca??',
@@ -6527,11 +6932,12 @@ def test_re_b56_re_b56_v(save_xml):
         instance="msData/regex/reB56.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b55_re_b55_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??',
@@ -6543,11 +6949,12 @@ def test_re_b55_re_b55_v(save_xml):
         instance="msData/regex/reB55.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b54_re_b54_v(save_xml):
     r"""
     TEST :branch : base='string', pattern='(ab+c)a?\?\??', value='abc?',
@@ -6559,11 +6966,12 @@ def test_re_b54_re_b54_v(save_xml):
         instance="msData/regex/reB54.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b53_re_b53_i(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='',
@@ -6575,11 +6983,12 @@ def test_re_b53_re_b53_i(save_xml):
         instance="msData/regex/reB53.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b52_re_b52_i(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='ac',
@@ -6591,11 +7000,12 @@ def test_re_b52_re_b52_i(save_xml):
         instance="msData/regex/reB52.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b51_re_b51_i(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='c',
@@ -6607,11 +7017,12 @@ def test_re_b51_re_b51_i(save_xml):
         instance="msData/regex/reB51.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b50_re_b50_i(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='a',
@@ -6623,11 +7034,12 @@ def test_re_b50_re_b50_i(save_xml):
         instance="msData/regex/reB50.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b49_re_b49_i(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='aabc',
@@ -6639,11 +7051,12 @@ def test_re_b49_re_b49_i(save_xml):
         instance="msData/regex/reB49.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b48_re_b48_v(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='abbbc',
@@ -6655,11 +7068,12 @@ def test_re_b48_re_b48_v(save_xml):
         instance="msData/regex/reB48.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b47_re_b47_v(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='abc',
@@ -6671,11 +7085,12 @@ def test_re_b47_re_b47_v(save_xml):
         instance="msData/regex/reB47.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b46_re_b46_v(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='bcccccc',
@@ -6687,11 +7102,12 @@ def test_re_b46_re_b46_v(save_xml):
         instance="msData/regex/reB46.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b45_re_b45_v(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='ab',
@@ -6703,11 +7119,12 @@ def test_re_b45_re_b45_v(save_xml):
         instance="msData/regex/reB45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b44_re_b44_v(save_xml):
     """
     TEST :branch : base='string', pattern='a?b+c*', value='b',
@@ -6719,11 +7136,12 @@ def test_re_b44_re_b44_v(save_xml):
         instance="msData/regex/reB44.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b43_re_b43_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='',
@@ -6735,11 +7153,12 @@ def test_re_b43_re_b43_i(save_xml):
         instance="msData/regex/reB43.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b42_re_b42_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='abbc',
@@ -6751,11 +7170,12 @@ def test_re_b42_re_b42_i(save_xml):
         instance="msData/regex/reB42.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b41_re_b41_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='abcd',
@@ -6767,11 +7187,12 @@ def test_re_b41_re_b41_i(save_xml):
         instance="msData/regex/reB41.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b40_re_b40_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='a',
@@ -6783,11 +7204,12 @@ def test_re_b40_re_b40_i(save_xml):
         instance="msData/regex/reB40.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b39_re_b39_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='abccccccccccccccc
@@ -6802,11 +7224,12 @@ def test_re_b39_re_b39_v(save_xml):
         instance="msData/regex/reB39.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b38_re_b38_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='ab',
@@ -6818,11 +7241,12 @@ def test_re_b38_re_b38_v(save_xml):
         instance="msData/regex/reB38.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b37_re_b37_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc*', value='abc',
@@ -6834,11 +7258,12 @@ def test_re_b37_re_b37_v(save_xml):
         instance="msData/regex/reB37.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b36_re_b36_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='',
@@ -6850,11 +7275,12 @@ def test_re_b36_re_b36_i(save_xml):
         instance="msData/regex/reB36.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b35_re_b35_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='abcb',
@@ -6866,11 +7292,12 @@ def test_re_b35_re_b35_i(save_xml):
         instance="msData/regex/reB35.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b34_re_b34_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='c',
@@ -6882,11 +7309,12 @@ def test_re_b34_re_b34_i(save_xml):
         instance="msData/regex/reB34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b33_re_b33_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='bc',
@@ -6898,11 +7326,12 @@ def test_re_b33_re_b33_i(save_xml):
         instance="msData/regex/reB33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b32_re_b32_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='ab',
@@ -6914,11 +7343,12 @@ def test_re_b32_re_b32_i(save_xml):
         instance="msData/regex/reB32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b31_re_b31_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='a',
@@ -6930,11 +7360,12 @@ def test_re_b31_re_b31_i(save_xml):
         instance="msData/regex/reB31.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b30_re_b30_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='ac',
@@ -6946,11 +7377,12 @@ def test_re_b30_re_b30_v(save_xml):
         instance="msData/regex/reB30.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b29_re_b29_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='abbbbbbbc',
@@ -6962,11 +7394,12 @@ def test_re_b29_re_b29_v(save_xml):
         instance="msData/regex/reB29.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b28_re_b28_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab*c', value='abc',
@@ -6978,11 +7411,12 @@ def test_re_b28_re_b28_v(save_xml):
         instance="msData/regex/reB28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b27_re_b27_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc+', value='abcd',
@@ -6994,11 +7428,12 @@ def test_re_b27_re_b27_i(save_xml):
         instance="msData/regex/reB27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b26_re_b26_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc+', value='ab',
@@ -7010,11 +7445,12 @@ def test_re_b26_re_b26_i(save_xml):
         instance="msData/regex/reB26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b25_re_b25_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc+', value='a',
@@ -7026,11 +7462,12 @@ def test_re_b25_re_b25_i(save_xml):
         instance="msData/regex/reB25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b24_re_b24_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc+', value='abccccccccccccccc
@@ -7046,11 +7483,12 @@ def test_re_b24_re_b24_v(save_xml):
         instance="msData/regex/reB24.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b23_re_b23_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc+', value='abc',
@@ -7062,11 +7500,12 @@ def test_re_b23_re_b23_v(save_xml):
         instance="msData/regex/reB23.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b22_re_b22_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab+c', value='',
@@ -7078,11 +7517,12 @@ def test_re_b22_re_b22_i(save_xml):
         instance="msData/regex/reB22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b21_re_b21_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab+c', value='abbb',
@@ -7094,11 +7534,12 @@ def test_re_b21_re_b21_i(save_xml):
         instance="msData/regex/reB21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b20_re_b20_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab+c', value='bbbc',
@@ -7110,11 +7551,12 @@ def test_re_b20_re_b20_i(save_xml):
         instance="msData/regex/reB20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b19_re_b19_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab+c', value='ac',
@@ -7126,11 +7568,12 @@ def test_re_b19_re_b19_i(save_xml):
         instance="msData/regex/reB19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b18_re_b18_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab+c', value='abbbbbbbbbbbbbbbb
@@ -7144,11 +7587,12 @@ def test_re_b18_re_b18_v(save_xml):
         instance="msData/regex/reB18.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b17_re_b17_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab+c', value='abc',
@@ -7160,11 +7604,12 @@ def test_re_b17_re_b17_v(save_xml):
         instance="msData/regex/reB17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b16_re_b16_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc?', value='',
@@ -7176,11 +7621,12 @@ def test_re_b16_re_b16_i(save_xml):
         instance="msData/regex/reB16.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b15_re_b15_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc?', value='abcc',
@@ -7192,11 +7638,12 @@ def test_re_b15_re_b15_i(save_xml):
         instance="msData/regex/reB15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b14_re_b14_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc?', value='bc',
@@ -7208,11 +7655,12 @@ def test_re_b14_re_b14_i(save_xml):
         instance="msData/regex/reB14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b13_re_b13_i(save_xml):
     """
     TEST :branch : base='string', pattern='abc?', value='a',
@@ -7224,11 +7672,12 @@ def test_re_b13_re_b13_i(save_xml):
         instance="msData/regex/reB13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b12_re_b12_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc?', value='abc',
@@ -7240,11 +7689,12 @@ def test_re_b12_re_b12_v(save_xml):
         instance="msData/regex/reB12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b11_re_b11_v(save_xml):
     """
     TEST :branch : base='string', pattern='abc?', value='ab',
@@ -7256,11 +7706,12 @@ def test_re_b11_re_b11_v(save_xml):
         instance="msData/regex/reB11.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b10_re_b10_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab?c', value='',
@@ -7272,11 +7723,12 @@ def test_re_b10_re_b10_i(save_xml):
         instance="msData/regex/reB10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b5_re_b5_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab?c', value='bc',
@@ -7288,11 +7740,12 @@ def test_re_b5_re_b5_i(save_xml):
         instance="msData/regex/reB5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b4_re_b4_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab?c', value='ab',
@@ -7304,11 +7757,12 @@ def test_re_b4_re_b4_i(save_xml):
         instance="msData/regex/reB4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b3_re_b3_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab?c', value='a',
@@ -7320,11 +7774,12 @@ def test_re_b3_re_b3_i(save_xml):
         instance="msData/regex/reB3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b2_re_b2_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab?c', value='abc',
@@ -7336,11 +7791,12 @@ def test_re_b2_re_b2_v(save_xml):
         instance="msData/regex/reB2.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_b1_re_b1_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab?c', value='ac',
@@ -7352,11 +7808,12 @@ def test_re_b1_re_b1_v(save_xml):
         instance="msData/regex/reB1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a45_re_a45_v(save_xml):
     """
     TEST :branch : base='string', pattern=' a|b ', value='a',
@@ -7368,11 +7825,12 @@ def test_re_a45_re_a45_v(save_xml):
         instance="msData/regex/reA45.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a34_re_a34_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='e',
@@ -7384,11 +7842,12 @@ def test_re_a34_re_a34_i(save_xml):
         instance="msData/regex/reA34.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a33_re_a33_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='ac',
@@ -7400,11 +7859,12 @@ def test_re_a33_re_a33_i(save_xml):
         instance="msData/regex/reA33.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a32_re_a32_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='aa',
@@ -7416,11 +7876,12 @@ def test_re_a32_re_a32_i(save_xml):
         instance="msData/regex/reA32.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a31_re_a31_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='d',
@@ -7432,11 +7893,12 @@ def test_re_a31_re_a31_v(save_xml):
         instance="msData/regex/reA31.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a30_re_a30_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='c',
@@ -7448,11 +7910,12 @@ def test_re_a30_re_a30_v(save_xml):
         instance="msData/regex/reA30.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a29_re_a29_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='b',
@@ -7464,11 +7927,12 @@ def test_re_a29_re_a29_v(save_xml):
         instance="msData/regex/reA29.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a28_re_a28_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|b|a|c|b|d|a', value='a',
@@ -7480,11 +7944,12 @@ def test_re_a28_re_a28_v(save_xml):
         instance="msData/regex/reA28.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a27_re_a27_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab', value='', type='invalid',
@@ -7496,11 +7961,12 @@ def test_re_a27_re_a27_i(save_xml):
         instance="msData/regex/reA27.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a26_re_a26_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab', value='bb',
@@ -7512,11 +7978,12 @@ def test_re_a26_re_a26_i(save_xml):
         instance="msData/regex/reA26.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a25_re_a25_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab', value='aa',
@@ -7528,11 +7995,12 @@ def test_re_a25_re_a25_i(save_xml):
         instance="msData/regex/reA25.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a24_re_a24_v(save_xml):
     """
     TEST :branch : base='string', pattern='ab', value='ab', type='valid',
@@ -7544,11 +8012,12 @@ def test_re_a24_re_a24_v(save_xml):
         instance="msData/regex/reA24.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a23_re_a23_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab', value='b', type='invalid',
@@ -7560,11 +8029,12 @@ def test_re_a23_re_a23_i(save_xml):
         instance="msData/regex/reA23.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a22_re_a22_i(save_xml):
     """
     TEST :branch : base='string', pattern='ab', value='a', type='invalid',
@@ -7576,11 +8046,12 @@ def test_re_a22_re_a22_i(save_xml):
         instance="msData/regex/reA22.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a21_re_a21_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b', value='', type='invalid',
@@ -7592,11 +8063,12 @@ def test_re_a21_re_a21_i(save_xml):
         instance="msData/regex/reA21.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a20_re_a20_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b', value='ab',
@@ -7608,11 +8080,12 @@ def test_re_a20_re_a20_i(save_xml):
         instance="msData/regex/reA20.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a19_re_a19_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b', value='bb',
@@ -7624,11 +8097,12 @@ def test_re_a19_re_a19_i(save_xml):
         instance="msData/regex/reA19.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a18_re_a18_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|b', value='aa',
@@ -7640,11 +8114,12 @@ def test_re_a18_re_a18_i(save_xml):
         instance="msData/regex/reA18.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a17_re_a17_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|b', value='b', type='valid',
@@ -7656,11 +8131,12 @@ def test_re_a17_re_a17_v(save_xml):
         instance="msData/regex/reA17.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a16_re_a16_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|b', value='a', type='valid',
@@ -7672,11 +8148,12 @@ def test_re_a16_re_a16_v(save_xml):
         instance="msData/regex/reA16.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a15_re_a15_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|a', value='', type='invalid',
@@ -7688,11 +8165,12 @@ def test_re_a15_re_a15_i(save_xml):
         instance="msData/regex/reA15.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a14_re_a14_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|a', value='b',
@@ -7704,11 +8182,12 @@ def test_re_a14_re_a14_i(save_xml):
         instance="msData/regex/reA14.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a13_re_a13_i(save_xml):
     """
     TEST :branch : base='string', pattern='a|a', value='aa',
@@ -7720,11 +8199,12 @@ def test_re_a13_re_a13_i(save_xml):
         instance="msData/regex/reA13.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a12_re_a12_v(save_xml):
     """
     TEST :branch : base='string', pattern='a|a', value='a', type='valid',
@@ -7736,11 +8216,12 @@ def test_re_a12_re_a12_v(save_xml):
         instance="msData/regex/reA12.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a11_re_a11_i(save_xml):
     """
     TEST :branch : base='string', pattern='a', value='', type='invalid',
@@ -7752,11 +8233,12 @@ def test_re_a11_re_a11_i(save_xml):
         instance="msData/regex/reA11.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a10_re_a10_i(save_xml):
     """
     TEST :branch : base='string', pattern='a', value='b', type='invalid',
@@ -7768,11 +8250,12 @@ def test_re_a10_re_a10_i(save_xml):
         instance="msData/regex/reA10.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a9_re_a9_i(save_xml):
     """
     TEST :branch : base='string', pattern='a', value='aa', type='invalid',
@@ -7784,11 +8267,12 @@ def test_re_a9_re_a9_i(save_xml):
         instance="msData/regex/reA9.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a8_re_a8_v(save_xml):
     """
     TEST :branch : base='string', pattern='a', value='a', type='valid',
@@ -7800,11 +8284,12 @@ def test_re_a8_re_a8_v(save_xml):
         instance="msData/regex/reA8.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a7_re_a7_v(save_xml):
     """
     TEST :branch : base='string', pattern='', value='', type='valid',
@@ -7816,11 +8301,12 @@ def test_re_a7_re_a7_v(save_xml):
         instance="msData/regex/reA7.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a6_re_a6_i(save_xml):
     """
     TEST :branch : base='string', pattern='', value='#xA;',
@@ -7832,11 +8318,12 @@ def test_re_a6_re_a6_i(save_xml):
         instance="msData/regex/reA6.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a5_re_a5_i(save_xml):
     """
     TEST :branch : base='string', pattern='', value='#x9;',
@@ -7848,11 +8335,12 @@ def test_re_a5_re_a5_i(save_xml):
         instance="msData/regex/reA5.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a4_re_a4_i(save_xml):
     """
     TEST :branch : base='string', pattern='', value='#xD;',
@@ -7864,11 +8352,12 @@ def test_re_a4_re_a4_i(save_xml):
         instance="msData/regex/reA4.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a3_re_a3_i(save_xml):
     """
     TEST :branch : base='string', pattern='', value='#x20;',
@@ -7880,11 +8369,12 @@ def test_re_a3_re_a3_i(save_xml):
         instance="msData/regex/reA3.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a2_re_a2_i(save_xml):
     """
     TEST :branch : base='string', pattern='', value='a', type='invalid',
@@ -7896,11 +8386,12 @@ def test_re_a2_re_a2_i(save_xml):
         instance="msData/regex/reA2.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_re_a1_re_a1_v(save_xml):
     """
     TEST :branch : base='string', pattern='', value='', type='valid',
@@ -7912,11 +8403,12 @@ def test_re_a1_re_a1_v(save_xml):
         instance="msData/regex/reA1.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_u5_sch_u5_i(save_xml):
     """
     TEST :schema collection and schema location : Circulcar redefines
@@ -7929,11 +8421,12 @@ def test_sch_u5_sch_u5_i(save_xml):
         instance="msData/schema/schU5.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_u4_sch_u4_i(save_xml):
     """
     TEST :schema collection and schema location : Circulcar redefines
@@ -7946,11 +8439,12 @@ def test_sch_u4_sch_u4_i(save_xml):
         instance="msData/schema/schU4.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_u3_sch_u3_i(save_xml):
     """
     TEST :schema collection and schema location : Circulcar redefines
@@ -7963,11 +8457,12 @@ def test_sch_u3_sch_u3_i(save_xml):
         instance="msData/schema/schU3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_t10_sch_t10_v(save_xml):
     """
     TEST :schema collection and schema location : redefine with an
@@ -7982,11 +8477,12 @@ def test_sch_t10_sch_t10_v(save_xml):
         instance="msData/schema/schT10.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_t9_sch_t9_v(save_xml):
     """
     TEST :schema collection and schema location : redefine with a
@@ -8002,11 +8498,12 @@ def test_sch_t9_sch_t9_v(save_xml):
         instance="msData/schema/schT9.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_t6_sch_t6_i(save_xml):
     """
     TEST :schema collection and schema location : redefine with an
@@ -8021,11 +8518,12 @@ def test_sch_t6_sch_t6_i(save_xml):
         instance="msData/schema/schT6.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_t3_sch_t3_v(save_xml):
     """
     TEST :schema collection and schema location : redefine with a
@@ -8038,11 +8536,12 @@ def test_sch_t3_sch_t3_v(save_xml):
         instance="msData/schema/schT3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_r2_sch_r2_i(save_xml):
     """
     TEST :schema collection and schema location : redefine with a group,
@@ -8055,11 +8554,12 @@ def test_sch_r2_sch_r2_i(save_xml):
         instance="msData/schema/schR2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_q3_sch_q3_v(save_xml):
     """
     TEST :schema collection and schema location : redefine with a
@@ -8071,11 +8571,12 @@ def test_sch_q3_sch_q3_v(save_xml):
         instance="msData/schema/schQ3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_q1_sch_q1_v(save_xml):
     """
     TEST :schema collection and schema location : redefine with a
@@ -8087,11 +8588,12 @@ def test_sch_q1_sch_q1_v(save_xml):
         instance="msData/schema/schQ1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_p2_sch_p2_v(save_xml):
     """
     TEST :schema collection and schema location : redefine with a
@@ -8103,11 +8605,12 @@ def test_sch_p2_sch_p2_v(save_xml):
         instance="msData/schema/schP2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g12_sch_g12_v(save_xml):
     """
     TEST :schema collection and schema location : A import B, B import C,
@@ -8120,11 +8623,12 @@ def test_sch_g12_sch_g12_v(save_xml):
         instance="msData/schema/schG12.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g8_sch_g8_v(save_xml):
     """
     TEST :schema collection and schema location : A import B and C, B is
@@ -8137,11 +8641,12 @@ def test_sch_g8_sch_g8_v(save_xml):
         instance="msData/schema/schG8.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g7_sch_g7_v(save_xml):
     """
     TEST :schema collection and schema location : A imports B and B and C,
@@ -8154,11 +8659,12 @@ def test_sch_g7_sch_g7_v(save_xml):
         instance="msData/schema/schG7.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g5_sch_g5_v(save_xml):
     """
     TEST :schema collection and schema location : A import B and C, A's
@@ -8170,11 +8676,12 @@ def test_sch_g5_sch_g5_v(save_xml):
         instance="msData/schema/schG5.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g4_sch_g4_v(save_xml):
     """
     TEST :schema collection and schema location : A import B and C, A's
@@ -8186,11 +8693,12 @@ def test_sch_g4_sch_g4_v(save_xml):
         instance="msData/schema/schG4.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g3_sch_g3_v(save_xml):
     """
     TEST :schema collection and schema location : A import B, B import C,
@@ -8202,11 +8710,12 @@ def test_sch_g3_sch_g3_v(save_xml):
         instance="msData/schema/schG3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g2_sch_g2_v(save_xml):
     """
     TEST :schema collection and schema location : A import B, B import C,
@@ -8218,11 +8727,12 @@ def test_sch_g2_sch_g2_v(save_xml):
         instance="msData/schema/schG2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_g1_sch_g1_v(save_xml):
     """
     TEST :schema collection and schema location : A import B, B import C,
@@ -8234,11 +8744,12 @@ def test_sch_g1_sch_g1_v(save_xml):
         instance="msData/schema/schG1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_f5_sch_f5_v(save_xml):
     """
     TEST :schema collection and schema location : XSD X import XSD Y, X's
@@ -8250,11 +8761,12 @@ def test_sch_f5_sch_f5_v(save_xml):
         instance="msData/schema/schF5.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_f2_sch_f2_v(save_xml):
     """
     TEST :schema collection and schema location : XSD X import XSD Y, X's
@@ -8266,11 +8778,12 @@ def test_sch_f2_sch_f2_v(save_xml):
         instance="msData/schema/schF2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_f1_sch_f1_v(save_xml):
     """
     TEST :schema collection and schema location : XSD X import XSD Y, X's
@@ -8282,11 +8795,12 @@ def test_sch_f1_sch_f1_v(save_xml):
         instance="msData/schema/schF1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_e4_sch_e4_v(save_xml):
     """
     TEST :schema collection and schema location : import namespace="foo"
@@ -8297,11 +8811,12 @@ def test_sch_e4_sch_e4_v(save_xml):
         instance="msData/schema/schE4.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_d10_sch_d10_v(save_xml):
     """
     TEST :schema collection and schema location : validate instance
@@ -8313,11 +8828,12 @@ def test_sch_d10_sch_d10_v(save_xml):
         instance="msData/schema/schD10.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_sch_d7_sch_d7_v(save_xml):
     """
@@ -8331,11 +8847,12 @@ def test_sch_d7_sch_d7_v(save_xml):
         instance="msData/schema/schD7.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_sch_d5_sch_d5_v(save_xml):
     """
@@ -8349,11 +8866,12 @@ def test_sch_d5_sch_d5_v(save_xml):
         instance="msData/schema/schD5.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_c4_sch_c4_v(save_xml):
     """
     TEST :schema collection and schema location : XSD A include XSD B, A's
@@ -8365,11 +8883,12 @@ def test_sch_c4_sch_c4_v(save_xml):
         instance="msData/schema/schC4.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_c3_sch_c3_v(save_xml):
     """
     TEST :schema collection and schema location : XSD A include XSD B, A's
@@ -8381,11 +8900,12 @@ def test_sch_c3_sch_c3_v(save_xml):
         instance="msData/schema/schC3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a8_sch_a8_i(save_xml):
     """
     TEST :schema collection and schema location : Schema
@@ -8400,11 +8920,12 @@ def test_sch_a8_sch_a8_i(save_xml):
         instance="msData/schema/schA8.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a7_sch_a7_i(save_xml):
     """
     TEST :schema collection and schema location : Schema
@@ -8418,11 +8939,12 @@ def test_sch_a7_sch_a7_i(save_xml):
         instance="msData/schema/schA7.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a5_sch_a5_i(save_xml):
     """
     TEST :schema collection and schema location : Schema
@@ -8437,11 +8959,12 @@ def test_sch_a5_sch_a5_i(save_xml):
         instance="msData/schema/schA5.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a4_sch_a4_v(save_xml):
     """
     TEST :schema collection and schema location : Schema Collection:,
@@ -8453,11 +8976,12 @@ def test_sch_a4_sch_a4_v(save_xml):
         instance="msData/schema/schA4.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a3_sch_a3_v(save_xml):
     """
     TEST :schema collection and schema location : Schema
@@ -8469,11 +8993,12 @@ def test_sch_a3_sch_a3_v(save_xml):
         instance="msData/schema/schA3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a2_sch_a2_i(save_xml):
     """
     TEST :schema collection and schema location : Schema
@@ -8488,11 +9013,12 @@ def test_sch_a2_sch_a2_i(save_xml):
         instance="msData/schema/schA2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sch_a1_sch_a1_v(save_xml):
     """
     TEST :schema collection and schema location : Schema Collection:
@@ -8504,11 +9030,12 @@ def test_sch_a1_sch_a1_v(save_xml):
         instance="msData/schema/schA1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z075_st_z075_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : XSD: xs:NOTATION
@@ -8520,11 +9047,12 @@ def test_st_z075_st_z075_v(save_xml):
         instance="msData/simpleType/stZ075.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z074_st_z074_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : chameleon lists and
@@ -8536,11 +9064,12 @@ def test_st_z074_st_z074_v(save_xml):
         instance="msData/simpleType/stZ074.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z073ba_st_z073b_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : XSD: valid xsi:type
@@ -8553,11 +9082,12 @@ def test_st_z073ba_st_z073b_i(save_xml):
         instance="msData/simpleType/stZ073.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z073b_st_z073b_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : XSD: valid xsi:type
@@ -8570,11 +9100,12 @@ def test_st_z073b_st_z073b_i(save_xml):
         instance="msData/simpleType/stZ073.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z072_st_z072_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : XSD: valid default
@@ -8586,11 +9117,12 @@ def test_st_z072_st_z072_v(save_xml):
         instance="msData/simpleType/stZ072.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z071_st_z071_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : adding chameleon
@@ -8602,11 +9134,12 @@ def test_st_z071_st_z071_v(save_xml):
         instance="msData/simpleType/test298668.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z066_st_z066_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8618,11 +9151,12 @@ def test_st_z066_st_z066_i(save_xml):
         instance="msData/simpleType/test102159_9.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z064_st_z064_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8634,11 +9168,12 @@ def test_st_z064_st_z064_i(save_xml):
         instance="msData/simpleType/test102159_7.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z063_st_z063_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8650,11 +9185,12 @@ def test_st_z063_st_z063_v(save_xml):
         instance="msData/simpleType/test102159_6.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z062_st_z062_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8666,11 +9202,12 @@ def test_st_z062_st_z062_v(save_xml):
         instance="msData/simpleType/test102159_5.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z061_st_z061_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8682,11 +9219,12 @@ def test_st_z061_st_z061_i(save_xml):
         instance="msData/simpleType/test102159_4.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z060_st_z060_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8698,11 +9236,12 @@ def test_st_z060_st_z060_i(save_xml):
         instance="msData/simpleType/test102159_3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z059_st_z059_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8714,11 +9253,12 @@ def test_st_z059_st_z059_i(save_xml):
         instance="msData/simpleType/test102159_2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z058_st_z058_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Facet and value
@@ -8730,11 +9270,12 @@ def test_st_z058_st_z058_v(save_xml):
         instance="msData/simpleType/test102159_1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z057_st_z057_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8747,11 +9288,12 @@ def test_st_z057_st_z057_v(save_xml):
         instance="msData/simpleType/test107331_10.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z056_st_z056_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8764,11 +9306,12 @@ def test_st_z056_st_z056_i(save_xml):
         instance="msData/simpleType/test107331_10.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z055_st_z055_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8781,11 +9324,12 @@ def test_st_z055_st_z055_v(save_xml):
         instance="msData/simpleType/test107331_9.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_st_z054_st_z054_v(save_xml):
     """
@@ -8799,11 +9343,12 @@ def test_st_z054_st_z054_v(save_xml):
         instance="msData/simpleType/test107331_8.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z053_st_z053_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8816,11 +9361,12 @@ def test_st_z053_st_z053_v(save_xml):
         instance="msData/simpleType/test107331_7.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z052_st_z052_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8833,11 +9379,12 @@ def test_st_z052_st_z052_v(save_xml):
         instance="msData/simpleType/test107331_6.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z051_st_z051_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8850,11 +9397,12 @@ def test_st_z051_st_z051_i(save_xml):
         instance="msData/simpleType/test107331_1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z050_st_z050_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8867,11 +9415,12 @@ def test_st_z050_st_z050_v(save_xml):
         instance="msData/simpleType/test107331_5.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z047_st_z047_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8884,11 +9433,12 @@ def test_st_z047_st_z047_v(save_xml):
         instance="msData/simpleType/test107331_4.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z046_st_z046_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8901,11 +9451,12 @@ def test_st_z046_st_z046_v(save_xml):
         instance="msData/simpleType/test107331_3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_st_z045_st_z045_v(save_xml):
     """
@@ -8919,11 +9470,12 @@ def test_st_z045_st_z045_v(save_xml):
         instance="msData/simpleType/test107331_2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z044_st_z044_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8936,11 +9488,12 @@ def test_st_z044_st_z044_i(save_xml):
         instance="msData/simpleType/test107331_1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z043_st_z043_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Need to permit
@@ -8953,11 +9506,12 @@ def test_st_z043_st_z043_v(save_xml):
         instance="msData/simpleType/test107331_1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z040_st_z040_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Using an xsd union
@@ -8969,11 +9523,12 @@ def test_st_z040_st_z040_v(save_xml):
         instance="msData/simpleType/stZ040.xml",
         instance_is_valid=True,
         class_name="Info2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z039_st_z039_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Defining a
@@ -8985,11 +9540,12 @@ def test_st_z039_st_z039_i(save_xml):
         instance="msData/simpleType/stZ039.xml",
         instance_is_valid=False,
         class_name="AlphaTestValue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z037_st_z037_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: simpleType
@@ -9002,11 +9558,12 @@ def test_st_z037_st_z037_i(save_xml):
         instance="msData/simpleType/stZ037.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z036_st_z036_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: simpleType
@@ -9019,11 +9576,12 @@ def test_st_z036_st_z036_v(save_xml):
         instance="msData/simpleType/stZ036.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z035_st_z035_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: simpleType
@@ -9036,11 +9594,12 @@ def test_st_z035_st_z035_i(save_xml):
         instance="msData/simpleType/stZ035.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z034_st_z034_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: redefine
@@ -9053,11 +9612,12 @@ def test_st_z034_st_z034_i(save_xml):
         instance="msData/simpleType/stZ034.xml",
         instance_is_valid=False,
         class_name="B1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z033_st_z033_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: redefine
@@ -9070,11 +9630,12 @@ def test_st_z033_st_z033_i(save_xml):
         instance="msData/simpleType/stZ033.xml",
         instance_is_valid=False,
         class_name="B2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z032_st_z032_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: redefine
@@ -9087,11 +9648,12 @@ def test_st_z032_st_z032_i(save_xml):
         instance="msData/simpleType/stZ032.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z031_st_z031_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: we should not
@@ -9103,11 +9665,12 @@ def test_st_z031_st_z031_v(save_xml):
         instance="msData/simpleType/stZ031.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z030_st_z030_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd: facet
@@ -9119,11 +9682,12 @@ def test_st_z030_st_z030_v(save_xml):
         instance="msData/simpleType/stZ030.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z015_st_z015_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : The value of
@@ -9136,11 +9700,12 @@ def test_st_z015_st_z015_v(save_xml):
         instance="msData/simpleType/stZ015.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z008_st_z008_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : rename a
@@ -9153,11 +9718,12 @@ def test_st_z008_st_z008_v(save_xml):
         instance="msData/simpleType/stZ008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z007_st_z007_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : rename a
@@ -9170,11 +9736,12 @@ def test_st_z007_st_z007_v(save_xml):
         instance="msData/simpleType/stZ007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_z004_st_z004_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : xsd:can not specify
@@ -9187,11 +9754,12 @@ def test_st_z004_st_z004_v(save_xml):
         instance="msData/simpleType/stZ004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h008_st_h008_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : union derived from
@@ -9204,11 +9772,12 @@ def test_st_h008_st_h008_i(save_xml):
         instance="msData/simpleType/stH008.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h007_st_h007_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : union derived from
@@ -9221,11 +9790,12 @@ def test_st_h007_st_h007_v(save_xml):
         instance="msData/simpleType/stH007.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h006_st_h006_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : union derived from
@@ -9238,11 +9808,12 @@ def test_st_h006_st_h006_i(save_xml):
         instance="msData/simpleType/stH006.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h005_st_h005_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : union derived from
@@ -9255,11 +9826,12 @@ def test_st_h005_st_h005_v(save_xml):
         instance="msData/simpleType/stH005.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h004_st_h004_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : schema defines a
@@ -9273,11 +9845,12 @@ def test_st_h004_st_h004_i(save_xml):
         instance="msData/simpleType/stH004.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h003_st_h003_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : schema defines a
@@ -9291,11 +9864,12 @@ def test_st_h003_st_h003_v(save_xml):
         instance="msData/simpleType/stH003.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h002_st_h002_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : schema defines a
@@ -9309,11 +9883,12 @@ def test_st_h002_st_h002_i(save_xml):
         instance="msData/simpleType/stH002.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_h001_st_h001_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : schema defines a
@@ -9327,11 +9902,12 @@ def test_st_h001_st_h001_v(save_xml):
         instance="msData/simpleType/stH001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g013_st_g013_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of string type
@@ -9344,11 +9920,12 @@ def test_st_g013_st_g013_i(save_xml):
         instance="msData/simpleType/stG013.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g012_st_g012_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of string type
@@ -9361,11 +9938,12 @@ def test_st_g012_st_g012_v(save_xml):
         instance="msData/simpleType/stG012.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g011_st_g011_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of NMTOKEN
@@ -9378,11 +9956,12 @@ def test_st_g011_st_g011_i(save_xml):
         instance="msData/simpleType/stG011.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g010_st_g010_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of NMTOKEN
@@ -9395,11 +9974,12 @@ def test_st_g010_st_g010_v(save_xml):
         instance="msData/simpleType/stG010.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g009_st_g009_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9411,11 +9991,12 @@ def test_st_g009_st_g009_i(save_xml):
         instance="msData/simpleType/stG009.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g008_st_g008_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9427,11 +10008,12 @@ def test_st_g008_st_g008_v(save_xml):
         instance="msData/simpleType/stG008.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g007_st_g007_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9443,11 +10025,12 @@ def test_st_g007_st_g007_i(save_xml):
         instance="msData/simpleType/stG007.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g006_st_g006_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9459,11 +10042,12 @@ def test_st_g006_st_g006_v(save_xml):
         instance="msData/simpleType/stG006.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g005_st_g005_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : schema is a list
@@ -9476,11 +10060,12 @@ def test_st_g005_st_g005_i(save_xml):
         instance="msData/simpleType/stG005.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g004_st_g004_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : schema is a list
@@ -9493,11 +10078,12 @@ def test_st_g004_st_g004_v(save_xml):
         instance="msData/simpleType/stG004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g003_st_g003_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9509,11 +10095,12 @@ def test_st_g003_st_g003_i(save_xml):
         instance="msData/simpleType/stG003.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g002_st_g002_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9525,11 +10112,12 @@ def test_st_g002_st_g002_v(save_xml):
         instance="msData/simpleType/stG002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_g001_st_g001_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : list of atomic type
@@ -9541,11 +10129,12 @@ def test_st_g001_st_g001_v(save_xml):
         instance="msData/simpleType/stG001.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ste110_ste110_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : test circular union
@@ -9556,11 +10145,12 @@ def test_ste110_ste110_i(save_xml):
         instance="msData/simpleType/ste100.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ste100_ste100_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9572,11 +10162,12 @@ def test_ste100_ste100_i(save_xml):
         instance="msData/simpleType/ste100.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ste099_ste099_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9588,11 +10179,12 @@ def test_ste099_ste099_v(save_xml):
         instance="msData/simpleType/ste099.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ste098_ste098_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9604,11 +10196,12 @@ def test_ste098_ste098_i(save_xml):
         instance="msData/simpleType/ste098.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e097_st_e097_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9620,11 +10213,12 @@ def test_st_e097_st_e097_i(save_xml):
         instance="msData/simpleType/stE097.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e096_st_e096_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9636,11 +10230,12 @@ def test_st_e096_st_e096_v(save_xml):
         instance="msData/simpleType/stE096.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e095_st_e095_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9652,11 +10247,12 @@ def test_st_e095_st_e095_i(save_xml):
         instance="msData/simpleType/stE095.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e094_st_e094_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9668,11 +10264,12 @@ def test_st_e094_st_e094_v(save_xml):
         instance="msData/simpleType/stE094.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e093_st_e093_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9684,11 +10281,12 @@ def test_st_e093_st_e093_v(save_xml):
         instance="msData/simpleType/stE093.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e092_st_e092_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9700,11 +10298,12 @@ def test_st_e092_st_e092_v(save_xml):
         instance="msData/simpleType/stE092.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e091_st_e091_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9716,11 +10315,12 @@ def test_st_e091_st_e091_v(save_xml):
         instance="msData/simpleType/stE091.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e090_st_e090_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9732,11 +10332,12 @@ def test_st_e090_st_e090_v(save_xml):
         instance="msData/simpleType/stE090.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e082_st_e082_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9748,11 +10349,12 @@ def test_st_e082_st_e082_i(save_xml):
         instance="msData/simpleType/stE082.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e081_st_e081_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9764,11 +10366,12 @@ def test_st_e081_st_e081_v(save_xml):
         instance="msData/simpleType/stE081.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e080_st_e080_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9780,11 +10383,12 @@ def test_st_e080_st_e080_v(save_xml):
         instance="msData/simpleType/stE080.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e079_st_e079_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9796,11 +10400,12 @@ def test_st_e079_st_e079_v(save_xml):
         instance="msData/simpleType/stE079.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e078_st_e078_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9812,11 +10417,12 @@ def test_st_e078_st_e078_i(save_xml):
         instance="msData/simpleType/stE078.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e077_st_e077_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9828,11 +10434,12 @@ def test_st_e077_st_e077_v(save_xml):
         instance="msData/simpleType/stE077.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e076_st_e076_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9844,11 +10451,12 @@ def test_st_e076_st_e076_i(save_xml):
         instance="msData/simpleType/stE076.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e075_st_e075_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9860,11 +10468,12 @@ def test_st_e075_st_e075_i(save_xml):
         instance="msData/simpleType/stE075.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ste074v_ste074v_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9876,11 +10485,12 @@ def test_ste074v_ste074v_v(save_xml):
         instance="msData/simpleType/ste074v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e074_st_e074_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9892,11 +10502,12 @@ def test_st_e074_st_e074_i(save_xml):
         instance="msData/simpleType/stE074.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e073v_st_e073v_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9908,11 +10519,12 @@ def test_st_e073v_st_e073v_v(save_xml):
         instance="msData/simpleType/stE073v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e073_st_e073_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9924,11 +10536,12 @@ def test_st_e073_st_e073_i(save_xml):
         instance="msData/simpleType/stE073.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e072_st_e072_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9942,11 +10555,12 @@ def test_st_e072_st_e072_v(save_xml):
         instance="msData/simpleType/stE072.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e071_st_e071_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9958,11 +10572,12 @@ def test_st_e071_st_e071_i(save_xml):
         instance="msData/simpleType/stE071.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e070_st_e070_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9974,11 +10589,12 @@ def test_st_e070_st_e070_i(save_xml):
         instance="msData/simpleType/stE070.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e069_st_e069_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -9990,11 +10606,12 @@ def test_st_e069_st_e069_v(save_xml):
         instance="msData/simpleType/stE069.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e068_st_e068_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10006,11 +10623,12 @@ def test_st_e068_st_e068_v(save_xml):
         instance="msData/simpleType/stE068.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e067_st_e067_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10022,11 +10640,12 @@ def test_st_e067_st_e067_v(save_xml):
         instance="msData/simpleType/stE067.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e066_st_e066_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10038,11 +10657,12 @@ def test_st_e066_st_e066_v(save_xml):
         instance="msData/simpleType/stE066.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e065_st_e065_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10054,11 +10674,12 @@ def test_st_e065_st_e065_v(save_xml):
         instance="msData/simpleType/stE065.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e064_st_e064_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10070,11 +10691,12 @@ def test_st_e064_st_e064_v(save_xml):
         instance="msData/simpleType/stE064.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e063_st_e063_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10086,11 +10708,12 @@ def test_st_e063_st_e063_i(save_xml):
         instance="msData/simpleType/stE063.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e062_st_e062_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10102,11 +10725,12 @@ def test_st_e062_st_e062_v(save_xml):
         instance="msData/simpleType/stE062.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e061_st_e061_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10118,11 +10742,12 @@ def test_st_e061_st_e061_v(save_xml):
         instance="msData/simpleType/stE061.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e060_st_e060_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10134,11 +10759,12 @@ def test_st_e060_st_e060_v(save_xml):
         instance="msData/simpleType/stE060.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e059_st_e059_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10150,11 +10776,12 @@ def test_st_e059_st_e059_v(save_xml):
         instance="msData/simpleType/stE059.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e058_st_e058_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10166,11 +10793,12 @@ def test_st_e058_st_e058_v(save_xml):
         instance="msData/simpleType/stE058.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e057_st_e057_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10182,11 +10810,12 @@ def test_st_e057_st_e057_v(save_xml):
         instance="msData/simpleType/stE057.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e056_st_e056_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10198,11 +10827,12 @@ def test_st_e056_st_e056_i(save_xml):
         instance="msData/simpleType/stE056.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e055_st_e055_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10214,11 +10844,12 @@ def test_st_e055_st_e055_v(save_xml):
         instance="msData/simpleType/stE055.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e054_st_e054_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10230,11 +10861,12 @@ def test_st_e054_st_e054_i(save_xml):
         instance="msData/simpleType/stE054.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e053_st_e053_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10247,11 +10879,12 @@ def test_st_e053_st_e053_i(save_xml):
         instance="msData/simpleType/stE053.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e052_st_e052_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10263,11 +10896,12 @@ def test_st_e052_st_e052_v(save_xml):
         instance="msData/simpleType/stE052.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e051_st_e051_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10279,11 +10913,12 @@ def test_st_e051_st_e051_i(save_xml):
         instance="msData/simpleType/stE051.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_e050_st_e050_v(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : Union with Fixed
@@ -10295,11 +10930,12 @@ def test_st_e050_st_e050_v(save_xml):
         instance="msData/simpleType/stE050.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_c034_st_c034_i(save_xml):
     """
     TEST :Syntax Checking for simpleType Declaration : error for duration
@@ -10311,11 +10947,12 @@ def test_st_c034_st_c034_i(save_xml):
         instance="msData/simpleType/stC034.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z013f_wild_z013f_i(save_xml):
     """
     TEST :Syntax Validation - any : 328873: Attribute Wildcard
@@ -10327,11 +10964,12 @@ def test_wild_z013f_wild_z013f_i(save_xml):
         instance="msData/wildcards/test328873f.xml",
         instance_is_valid=False,
         class_name="Sub6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z013e_wild_z013e_i(save_xml):
     """
     TEST :Syntax Validation - any : 328873: Attribute Wildcard
@@ -10343,11 +10981,12 @@ def test_wild_z013e_wild_z013e_i(save_xml):
         instance="msData/wildcards/test328873e.xml",
         instance_is_valid=False,
         class_name="Sub5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z013d_wild_z013d_i(save_xml):
     """
     TEST :Syntax Validation - any : 328873: Attribute Wildcard
@@ -10359,11 +10998,12 @@ def test_wild_z013d_wild_z013d_i(save_xml):
         instance="msData/wildcards/test328873d.xml",
         instance_is_valid=False,
         class_name="Sub4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z013c_wild_z013c_v(save_xml):
     """
     TEST :Syntax Validation - any : 328873: Attribute Wildcard
@@ -10375,11 +11015,12 @@ def test_wild_z013c_wild_z013c_v(save_xml):
         instance="msData/wildcards/test328873c.xml",
         instance_is_valid=True,
         class_name="Sub3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z013b_wild_z013b_v(save_xml):
     """
     TEST :Syntax Validation - any : 328873: Attribute Wildcard
@@ -10391,11 +11032,12 @@ def test_wild_z013b_wild_z013b_v(save_xml):
         instance="msData/wildcards/test328873b.xml",
         instance_is_valid=True,
         class_name="Sub2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z013a_wild_z013a_i(save_xml):
     """
     TEST :Syntax Validation - any : 328873: Attribute Wildcard
@@ -10407,11 +11049,12 @@ def test_wild_z013a_wild_z013a_i(save_xml):
         instance="msData/wildcards/test328873a.xml",
         instance_is_valid=False,
         class_name="Sub",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z011_wild_z011_i(save_xml):
     """
     TEST :Syntax Validation - any : XSD: process Contents for the complete
@@ -10423,11 +11066,12 @@ def test_wild_z011_wild_z011_i(save_xml):
         instance="msData/wildcards/wildZ011.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z010_wild_z010_v(save_xml):
     """
     TEST :Syntax Validation - any : xsd: namespace='' on wildcard any
@@ -10440,11 +11084,12 @@ def test_wild_z010_wild_z010_v(save_xml):
         instance="msData/wildcards/wildZ010.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z007_wild_z007_v(save_xml):
     """
     TEST :Syntax Validation - any : XSD: When processContents=lax, xsd:any
@@ -10456,11 +11101,12 @@ def test_wild_z007_wild_z007_v(save_xml):
         instance="msData/wildcards/wildZ007.xml",
         instance_is_valid=True,
         class_name="Stylesheet",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z006_wild_z006_i(save_xml):
     """
     TEST :Syntax Validation - any : any with namespace ##other should not
@@ -10472,11 +11118,12 @@ def test_wild_z006_wild_z006_i(save_xml):
         instance="msData/wildcards/wildZ006.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z005_wild_z005_i(save_xml):
     """
     TEST :Syntax Validation - any : any with namespace ##other should not
@@ -10488,11 +11135,12 @@ def test_wild_z005_wild_z005_i(save_xml):
         instance="msData/wildcards/wildZ005.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z004_wild_z004_v(save_xml):
     """
     TEST :Syntax Validation - any : xsd: un-declared element when content
@@ -10504,11 +11152,12 @@ def test_wild_z004_wild_z004_v(save_xml):
         instance="msData/wildcards/wildZ004.xml",
         instance_is_valid=True,
         class_name="RootElem",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z003_wild_z003_v(save_xml):
     """
     TEST :Syntax Validation - any : xsd: test valid instance with elements
@@ -10520,11 +11169,12 @@ def test_wild_z003_wild_z003_v(save_xml):
         instance="msData/wildcards/wildZ003.xml",
         instance_is_valid=True,
         class_name="Elt1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z002_wild_z002_v(save_xml):
     """
     TEST :Syntax Validation - any : attribute on xsd:any
@@ -10536,11 +11186,12 @@ def test_wild_z002_wild_z002_v(save_xml):
         instance="msData/wildcards/wildZ002.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_z001_wild_z001_i(save_xml):
     """
     TEST :Syntax Validation - any : validate namespace set to a valid
@@ -10552,11 +11203,12 @@ def test_wild_z001_wild_z001_i(save_xml):
         instance="msData/wildcards/wildZ001.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_p006_wild_p006_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ processContents=skip
@@ -10570,11 +11222,12 @@ def test_wild_p006_wild_p006_v(save_xml):
         instance="msData/wildcards/wildP006.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_p005_wild_p005_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ processContents=skip
@@ -10588,11 +11241,12 @@ def test_wild_p005_wild_p005_v(save_xml):
         instance="msData/wildcards/wildP005.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_p004_wild_p004_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ processContents=lax
@@ -10606,11 +11260,12 @@ def test_wild_p004_wild_p004_v(save_xml):
         instance="msData/wildcards/wildP004.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_p003_wild_p003_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ processContents=lax
@@ -10624,11 +11279,12 @@ def test_wild_p003_wild_p003_v(save_xml):
         instance="msData/wildcards/wildP003.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_p002_wild_p002_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10642,11 +11298,12 @@ def test_wild_p002_wild_p002_i(save_xml):
         instance="msData/wildcards/wildP002.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_p001_wild_p001_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10660,11 +11317,12 @@ def test_wild_p001_wild_p001_v(save_xml):
         instance="msData/wildcards/wildP001.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o040_wild_o040_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10678,11 +11336,12 @@ def test_wild_o040_wild_o040_v(save_xml):
         instance="msData/wildcards/wildO040.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o039_wild_o039_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10696,11 +11355,12 @@ def test_wild_o039_wild_o039_i(save_xml):
         instance="msData/wildcards/wildO039.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o038_wild_o038_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10714,11 +11374,12 @@ def test_wild_o038_wild_o038_v(save_xml):
         instance="msData/wildcards/wildO038.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o037_wild_o037_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -10732,11 +11393,12 @@ def test_wild_o037_wild_o037_v(save_xml):
         instance="msData/wildcards/wildO037.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o035_wild_o035_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -10750,11 +11412,12 @@ def test_wild_o035_wild_o035_i(save_xml):
         instance="msData/wildcards/wildO035.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o034_wild_o034_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -10767,11 +11430,12 @@ def test_wild_o034_wild_o034_i(save_xml):
         instance="msData/wildcards/wildO034.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o033_wild_o033_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -10784,11 +11448,12 @@ def test_wild_o033_wild_o033_v(save_xml):
         instance="msData/wildcards/wildO033.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o032_wild_o032_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=http://foobar) with
@@ -10801,11 +11466,12 @@ def test_wild_o032_wild_o032_i(save_xml):
         instance="msData/wildcards/wildO032.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o031_wild_o031_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=http://foobar) with
@@ -10818,11 +11484,12 @@ def test_wild_o031_wild_o031_v(save_xml):
         instance="msData/wildcards/wildO031.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o030_wild_o030_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) with schema
@@ -10835,11 +11502,12 @@ def test_wild_o030_wild_o030_i(save_xml):
         instance="msData/wildcards/wildO030.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o029_wild_o029_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) with schema
@@ -10852,11 +11520,12 @@ def test_wild_o029_wild_o029_v(save_xml):
         instance="msData/wildcards/wildO029.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o028_wild_o028_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -10869,11 +11538,12 @@ def test_wild_o028_wild_o028_i(save_xml):
         instance="msData/wildcards/wildO028.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o027_wild_o027_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -10886,11 +11556,12 @@ def test_wild_o027_wild_o027_v(save_xml):
         instance="msData/wildcards/wildO027.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o026_wild_o026_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) with schema
@@ -10903,11 +11574,12 @@ def test_wild_o026_wild_o026_v(save_xml):
         instance="msData/wildcards/wildO026.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o025_wild_o025_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) with schema
@@ -10920,11 +11592,12 @@ def test_wild_o025_wild_o025_i(save_xml):
         instance="msData/wildcards/wildO025.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o024_wild_o024_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10937,11 +11610,12 @@ def test_wild_o024_wild_o024_i(save_xml):
         instance="msData/wildcards/wildO024.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o023_wild_o023_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10954,11 +11628,12 @@ def test_wild_o023_wild_o023_v(save_xml):
         instance="msData/wildcards/wildO023.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o022_wild_o022_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10972,11 +11647,12 @@ def test_wild_o022_wild_o022_i(save_xml):
         instance="msData/wildcards/wildO022.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o021_wild_o021_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -10989,11 +11665,12 @@ def test_wild_o021_wild_o021_v(save_xml):
         instance="msData/wildcards/wildO021.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o020_wild_o020_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local)
@@ -11006,11 +11683,12 @@ def test_wild_o020_wild_o020_i(save_xml):
         instance="msData/wildcards/wildO020.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o019_wild_o019_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local)
@@ -11023,11 +11701,12 @@ def test_wild_o019_wild_o019_v(save_xml):
         instance="msData/wildcards/wildO019.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o018_wild_o018_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##other)
@@ -11040,11 +11719,12 @@ def test_wild_o018_wild_o018_v(save_xml):
         instance="msData/wildcards/wildO018.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o017_wild_o017_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##other)
@@ -11057,11 +11737,12 @@ def test_wild_o017_wild_o017_i(save_xml):
         instance="msData/wildcards/wildO017.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o016_wild_o016_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##any) with
@@ -11074,11 +11755,12 @@ def test_wild_o016_wild_o016_v(save_xml):
         instance="msData/wildcards/wildO016.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o015_wild_o015_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##any) with
@@ -11091,11 +11773,12 @@ def test_wild_o015_wild_o015_v(save_xml):
         instance="msData/wildcards/wildO015.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o014_wild_o014_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -11108,11 +11791,12 @@ def test_wild_o014_wild_o014_i(save_xml):
         instance="msData/wildcards/wildO014.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o013_wild_o013_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -11125,11 +11809,12 @@ def test_wild_o013_wild_o013_v(save_xml):
         instance="msData/wildcards/wildO013.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o012_wild_o012_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -11142,11 +11827,12 @@ def test_wild_o012_wild_o012_v(save_xml):
         instance="msData/wildcards/wildO012.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o011_wild_o011_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -11159,11 +11845,12 @@ def test_wild_o011_wild_o011_i(save_xml):
         instance="msData/wildcards/wildO011.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o010_wild_o010_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -11176,11 +11863,12 @@ def test_wild_o010_wild_o010_v(save_xml):
         instance="msData/wildcards/wildO010.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o009_wild_o009_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local
@@ -11193,11 +11881,12 @@ def test_wild_o009_wild_o009_i(save_xml):
         instance="msData/wildcards/wildO009.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o008_wild_o008_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -11210,11 +11899,12 @@ def test_wild_o008_wild_o008_i(save_xml):
         instance="msData/wildcards/wildO008.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o007_wild_o007_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/
@@ -11227,11 +11917,12 @@ def test_wild_o007_wild_o007_v(save_xml):
         instance="msData/wildcards/wildO007.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o006_wild_o006_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local)
@@ -11244,11 +11935,12 @@ def test_wild_o006_wild_o006_i(save_xml):
         instance="msData/wildcards/wildO006.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o005_wild_o005_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##local)
@@ -11260,11 +11952,12 @@ def test_wild_o005_wild_o005_v(save_xml):
         instance="msData/wildcards/wildO005.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o004_wild_o004_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##other)
@@ -11277,11 +11970,12 @@ def test_wild_o004_wild_o004_v(save_xml):
         instance="msData/wildcards/wildO004.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o003_wild_o003_i(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##other)
@@ -11293,11 +11987,12 @@ def test_wild_o003_wild_o003_i(save_xml):
         instance="msData/wildcards/wildO003.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o002_wild_o002_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##any) and
@@ -11309,11 +12004,12 @@ def test_wild_o002_wild_o002_v(save_xml):
         instance="msData/wildcards/wildO002.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_o001_wild_o001_v(save_xml):
     """
     TEST :Syntax Validation - any : ANYAttribute (w/ namespace=##any) and
@@ -11325,11 +12021,12 @@ def test_wild_o001_wild_o001_v(save_xml):
         instance="msData/wildcards/wildO001.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i012_wild_i012_v(save_xml):
     """
     TEST :Syntax Validation - any : multiple any in sequence with
@@ -11341,11 +12038,12 @@ def test_wild_i012_wild_i012_v(save_xml):
         instance="msData/wildcards/wildI012.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i011_wild_i011_v(save_xml):
     """
     TEST :Syntax Validation - any : multiple any in sequence with
@@ -11357,11 +12055,12 @@ def test_wild_i011_wild_i011_v(save_xml):
         instance="msData/wildcards/wildI011.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i007_wild_i007_v(save_xml):
     """
     TEST :Syntax Validation - any : multiple any in choice with namespaces
@@ -11373,11 +12072,12 @@ def test_wild_i007_wild_i007_v(save_xml):
         instance="msData/wildcards/wildI007.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i006_wild_i006_v(save_xml):
     """
     TEST :Syntax Validation - any : multiple any in choice with different
@@ -11389,11 +12089,12 @@ def test_wild_i006_wild_i006_v(save_xml):
         instance="msData/wildcards/wildI006.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i005_wild_i005_v(save_xml):
     """
     TEST :Syntax Validation - any : multiple any in sequence with
@@ -11405,11 +12106,12 @@ def test_wild_i005_wild_i005_v(save_xml):
         instance="msData/wildcards/wildI005.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i004i_wild_i004i_i(save_xml):
     """
     TEST :Syntax Validation - any : 67191 - ensuring that processContents
@@ -11421,11 +12123,12 @@ def test_wild_i004i_wild_i004i_i(save_xml):
         instance="msData/wildcards/wildI004i.xml",
         instance_is_valid=False,
         class_name="Alpha",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_i004_wild_i004_v(save_xml):
     """
     TEST :Syntax Validation - any : 67191 - ensuring that processContents
@@ -11437,11 +12140,12 @@ def test_wild_i004_wild_i004_v(save_xml):
         instance="msData/wildcards/wildI004.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h012_wild_h012_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/
@@ -11454,11 +12158,12 @@ def test_wild_h012_wild_h012_v(save_xml):
         instance="msData/wildcards/wildH012.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h011_wild_h011_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/
@@ -11471,11 +12176,12 @@ def test_wild_h011_wild_h011_v(save_xml):
         instance="msData/wildcards/wildH011.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h010_wild_h010_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/
@@ -11488,11 +12194,12 @@ def test_wild_h010_wild_h010_v(save_xml):
         instance="msData/wildcards/wildH010.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h009_wild_h009_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/
@@ -11505,11 +12212,12 @@ def test_wild_h009_wild_h009_v(save_xml):
         instance="msData/wildcards/wildH009.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h008_wild_h008_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/
@@ -11522,11 +12230,12 @@ def test_wild_h008_wild_h008_i(save_xml):
         instance="msData/wildcards/wildH008.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h007_wild_h007_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/
@@ -11539,11 +12248,12 @@ def test_wild_h007_wild_h007_v(save_xml):
         instance="msData/wildcards/wildH007.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h006_wild_h006_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ processContents=skip and
@@ -11556,11 +12266,12 @@ def test_wild_h006_wild_h006_i(save_xml):
         instance="msData/wildcards/wildH006.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h005_wild_h005_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ processContents=skip and
@@ -11573,11 +12284,12 @@ def test_wild_h005_wild_h005_v(save_xml):
         instance="msData/wildcards/wildH005.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h004_wild_h004_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ processContents=lax and
@@ -11590,11 +12302,12 @@ def test_wild_h004_wild_h004_v(save_xml):
         instance="msData/wildcards/wildH004.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h003_wild_h003_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ processContents=lax and
@@ -11607,11 +12320,12 @@ def test_wild_h003_wild_h003_v(save_xml):
         instance="msData/wildcards/wildH003.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h002_wild_h002_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ processContents=strict and
@@ -11625,11 +12339,12 @@ def test_wild_h002_wild_h002_i(save_xml):
         instance="msData/wildcards/wildH002.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_h001_wild_h001_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ processContents=strict and
@@ -11643,11 +12358,12 @@ def test_wild_h001_wild_h001_i(save_xml):
         instance="msData/wildcards/wildH001.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g040_wild_g040_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace
@@ -11661,11 +12377,12 @@ def test_wild_g040_wild_g040_v(save_xml):
         instance="msData/wildcards/wildG040.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g039_wild_g039_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace
@@ -11679,11 +12396,12 @@ def test_wild_g039_wild_g039_i(save_xml):
         instance="msData/wildcards/wildG039.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g038_wild_g038_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace
@@ -11697,11 +12415,12 @@ def test_wild_g038_wild_g038_v(save_xml):
         instance="msData/wildcards/wildG038.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g037_wild_g037_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -11715,11 +12434,12 @@ def test_wild_g037_wild_g037_v(save_xml):
         instance="msData/wildcards/wildG037.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g036_wild_g036_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -11733,11 +12453,12 @@ def test_wild_g036_wild_g036_i(save_xml):
         instance="msData/wildcards/wildG036.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g035_wild_g035_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -11751,11 +12472,12 @@ def test_wild_g035_wild_g035_v(save_xml):
         instance="msData/wildcards/wildG035.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g034_wild_g034_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -11768,11 +12490,12 @@ def test_wild_g034_wild_g034_i(save_xml):
         instance="msData/wildcards/wildG034.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g033_wild_g033_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -11785,11 +12508,12 @@ def test_wild_g033_wild_g033_v(save_xml):
         instance="msData/wildcards/wildG033.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g032_wild_g032_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=A B C D E ##local
@@ -11802,11 +12526,12 @@ def test_wild_g032_wild_g032_i(save_xml):
         instance="msData/wildcards/wildG032.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g031_wild_g031_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=A B C D E ##local
@@ -11819,11 +12544,12 @@ def test_wild_g031_wild_g031_v(save_xml):
         instance="msData/wildcards/wildG031.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g030_wild_g030_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) with schema
@@ -11836,11 +12562,12 @@ def test_wild_g030_wild_g030_i(save_xml):
         instance="msData/wildcards/wildG030.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g029_wild_g029_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) with schema
@@ -11853,11 +12580,12 @@ def test_wild_g029_wild_g029_i(save_xml):
         instance="msData/wildcards/wildG029.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g028_wild_g028_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -11870,11 +12598,12 @@ def test_wild_g028_wild_g028_i(save_xml):
         instance="msData/wildcards/wildG028.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g027_wild_g027_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -11887,11 +12616,12 @@ def test_wild_g027_wild_g027_v(save_xml):
         instance="msData/wildcards/wildG027.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g026_wild_g026_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) with schema
@@ -11904,11 +12634,12 @@ def test_wild_g026_wild_g026_v(save_xml):
         instance="msData/wildcards/wildG026.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g025_wild_g025_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) with schema
@@ -11921,11 +12652,12 @@ def test_wild_g025_wild_g025_i(save_xml):
         instance="msData/wildcards/wildG025.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g024_wild_g024_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=http://foobar) with
@@ -11938,11 +12670,12 @@ def test_wild_g024_wild_g024_i(save_xml):
         instance="msData/wildcards/wildG024.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g023_wild_g023_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=http://foobar) with
@@ -11955,11 +12688,12 @@ def test_wild_g023_wild_g023_v(save_xml):
         instance="msData/wildcards/wildG023.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g022_wild_g022_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -11972,11 +12706,12 @@ def test_wild_g022_wild_g022_i(save_xml):
         instance="msData/wildcards/wildG022.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g021_wild_g021_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -11989,11 +12724,12 @@ def test_wild_g021_wild_g021_v(save_xml):
         instance="msData/wildcards/wildG021.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g020_wild_g020_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) with schema
@@ -12006,11 +12742,12 @@ def test_wild_g020_wild_g020_i(save_xml):
         instance="msData/wildcards/wildG020.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g019_wild_g019_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) with schema
@@ -12023,11 +12760,12 @@ def test_wild_g019_wild_g019_i(save_xml):
         instance="msData/wildcards/wildG019.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g018_wild_g018_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) with schema
@@ -12040,11 +12778,12 @@ def test_wild_g018_wild_g018_v(save_xml):
         instance="msData/wildcards/wildG018.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g017_wild_g017_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) with schema
@@ -12057,11 +12796,12 @@ def test_wild_g017_wild_g017_i(save_xml):
         instance="msData/wildcards/wildG017.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g016_wild_g016_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##any) with schema
@@ -12074,11 +12814,12 @@ def test_wild_g016_wild_g016_v(save_xml):
         instance="msData/wildcards/wildG016.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g015_wild_g015_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##any) with schema
@@ -12091,11 +12832,12 @@ def test_wild_g015_wild_g015_v(save_xml):
         instance="msData/wildcards/wildG015.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g014_wild_g014_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace
@@ -12108,11 +12850,12 @@ def test_wild_g014_wild_g014_i(save_xml):
         instance="msData/wildcards/wildG014.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g013_wild_g013_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace
@@ -12125,11 +12868,12 @@ def test_wild_g013_wild_g013_v(save_xml):
         instance="msData/wildcards/wildG013.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g012_wild_g012_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace
@@ -12142,11 +12886,12 @@ def test_wild_g012_wild_g012_v(save_xml):
         instance="msData/wildcards/wildG012.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g011_wild_g011_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -12159,11 +12904,12 @@ def test_wild_g011_wild_g011_i(save_xml):
         instance="msData/wildcards/wildG011.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g010_wild_g010_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -12176,11 +12922,12 @@ def test_wild_g010_wild_g010_v(save_xml):
         instance="msData/wildcards/wildG010.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g009_wild_g009_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local
@@ -12193,11 +12940,12 @@ def test_wild_g009_wild_g009_i(save_xml):
         instance="msData/wildcards/wildG009.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g008_wild_g008_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -12210,11 +12958,12 @@ def test_wild_g008_wild_g008_i(save_xml):
         instance="msData/wildcards/wildG008.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g007_wild_g007_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##targetNamespace)
@@ -12226,11 +12975,12 @@ def test_wild_g007_wild_g007_v(save_xml):
         instance="msData/wildcards/wildG007.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g006_wild_g006_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) and
@@ -12242,11 +12992,12 @@ def test_wild_g006_wild_g006_v(save_xml):
         instance="msData/wildcards/wildG006.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g005_wild_g005_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##local) and
@@ -12258,11 +13009,12 @@ def test_wild_g005_wild_g005_i(save_xml):
         instance="msData/wildcards/wildG005.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g004_wild_g004_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) and
@@ -12274,11 +13026,12 @@ def test_wild_g004_wild_g004_v(save_xml):
         instance="msData/wildcards/wildG004.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g003_wild_g003_i(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##other) and
@@ -12290,11 +13043,12 @@ def test_wild_g003_wild_g003_i(save_xml):
         instance="msData/wildcards/wildG003.xml",
         instance_is_valid=False,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g002_wild_g002_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##any) and instance
@@ -12306,11 +13060,12 @@ def test_wild_g002_wild_g002_v(save_xml):
         instance="msData/wildcards/wildG002.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_wild_g001_wild_g001_v(save_xml):
     """
     TEST :Syntax Validation - any : ANY (w/ namespace=##any) and instance
@@ -12322,6 +13077,6 @@ def test_wild_g001_wild_g001_v(save_xml):
         instance="msData/wildcards/wildG001.xml",
         instance_is_valid=True,
         class_name="Foo",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_1000.py
+++ b/tests/test_nist_meta_1000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enumeration_5_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -11,11 +14,12 @@ def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enumeration_5_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -26,11 +30,12 @@ def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enumeration_5_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -41,11 +46,12 @@ def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enumeration_5_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -56,11 +62,12 @@ def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enumeration_5_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -71,11 +78,12 @@ def test_union_short_g_year_enumeration_9_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enumeration_4_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -86,11 +94,12 @@ def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enumeration_4_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -101,11 +110,12 @@ def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enumeration_4_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -116,11 +126,12 @@ def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enumeration_4_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -131,11 +142,12 @@ def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enumeration_4_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -146,11 +158,12 @@ def test_union_short_g_year_enumeration_8_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enumeration_3_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -161,11 +174,12 @@ def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enumeration_3_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -176,11 +190,12 @@ def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enumeration_3_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -191,11 +206,12 @@ def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enumeration_3_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -206,11 +222,12 @@ def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enumeration_3_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -221,11 +238,12 @@ def test_union_short_g_year_enumeration_7_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enumeration_2_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -236,11 +254,12 @@ def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enumeration_2_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -251,11 +270,12 @@ def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enumeration_2_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -266,11 +286,12 @@ def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enumeration_2_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -281,11 +302,12 @@ def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enumeration_2_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -296,11 +318,12 @@ def test_union_short_g_year_enumeration_6_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enumeration_1_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -311,11 +334,12 @@ def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enumeration_1_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -326,11 +350,12 @@ def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enumeration_1_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -341,11 +366,12 @@ def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enumeration_1_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -356,11 +382,12 @@ def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enumeration_1_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -371,11 +398,12 @@ def test_union_short_g_year_enumeration_5_nistxml_sv_ii_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -387,11 +415,12 @@ def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -403,11 +432,12 @@ def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -419,11 +449,12 @@ def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -435,11 +466,12 @@ def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -451,11 +483,12 @@ def test_union_short_g_year_pattern_9_nistxml_sv_ii_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -467,11 +500,12 @@ def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -483,11 +517,12 @@ def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -499,11 +534,12 @@ def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -515,11 +551,12 @@ def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -531,11 +568,12 @@ def test_union_short_g_year_pattern_8_nistxml_sv_ii_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -547,11 +585,12 @@ def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -563,11 +602,12 @@ def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -579,11 +619,12 @@ def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -595,11 +636,12 @@ def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -611,11 +653,12 @@ def test_union_short_g_year_pattern_7_nistxml_sv_ii_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -627,11 +670,12 @@ def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -643,11 +687,12 @@ def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -659,11 +704,12 @@ def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -675,11 +721,12 @@ def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -691,11 +738,12 @@ def test_union_short_g_year_pattern_6_nistxml_sv_ii_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -707,11 +755,12 @@ def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -723,11 +772,12 @@ def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -739,11 +789,12 @@ def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -755,11 +806,12 @@ def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -771,11 +823,12 @@ def test_union_short_g_year_pattern_5_nistxml_sv_ii_union_short_g_year_pattern_1
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-II-union-short-gYear-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_5_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -786,11 +839,12 @@ def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_5_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -801,11 +855,12 @@ def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_5_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -816,11 +871,12 @@ def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_5_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -831,11 +887,12 @@ def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_5_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -846,11 +903,12 @@ def test_union_g_month_day_g_year_month_enumeration_9_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_4_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -861,11 +919,12 @@ def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_4_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -876,11 +935,12 @@ def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_4_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -891,11 +951,12 @@ def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_4_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -906,11 +967,12 @@ def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_4_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -921,11 +983,12 @@ def test_union_g_month_day_g_year_month_enumeration_8_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_3_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -936,11 +999,12 @@ def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_3_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -951,11 +1015,12 @@ def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_3_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -966,11 +1031,12 @@ def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_3_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -981,11 +1047,12 @@ def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_3_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -996,11 +1063,12 @@ def test_union_g_month_day_g_year_month_enumeration_7_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_2_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1011,11 +1079,12 @@ def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_2_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1026,11 +1095,12 @@ def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_2_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1041,11 +1111,12 @@ def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_2_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1056,11 +1127,12 @@ def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_2_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1071,11 +1143,12 @@ def test_union_g_month_day_g_year_month_enumeration_6_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_1_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1086,11 +1159,12 @@ def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_1_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1101,11 +1175,12 @@ def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_1_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1116,11 +1191,12 @@ def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_1_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1131,11 +1207,12 @@ def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_month_day_g_year_month_enumeration_1_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -1146,11 +1223,12 @@ def test_union_g_month_day_g_year_month_enumeration_5_nistxml_sv_ii_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_5_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1162,11 +1240,12 @@ def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_5_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1178,11 +1257,12 @@ def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_5_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1194,11 +1274,12 @@ def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_5_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1210,11 +1291,12 @@ def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_5_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1226,11 +1308,12 @@ def test_union_g_month_day_g_year_month_pattern_9_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_4_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1242,11 +1325,12 @@ def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_4_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1258,11 +1342,12 @@ def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_4_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1274,11 +1359,12 @@ def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_4_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1290,11 +1376,12 @@ def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_4_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1306,11 +1393,12 @@ def test_union_g_month_day_g_year_month_pattern_8_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_3_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1322,11 +1410,12 @@ def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_3_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1338,11 +1427,12 @@ def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_3_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1354,11 +1444,12 @@ def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_3_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1370,11 +1461,12 @@ def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_3_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1386,11 +1478,12 @@ def test_union_g_month_day_g_year_month_pattern_7_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_2_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1402,11 +1495,12 @@ def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_2_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1418,11 +1512,12 @@ def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_2_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1434,11 +1529,12 @@ def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_2_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1450,11 +1546,12 @@ def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_2_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1466,11 +1563,12 @@ def test_union_g_month_day_g_year_month_pattern_6_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_1_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1482,11 +1580,12 @@ def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_1_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1498,11 +1597,12 @@ def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_1_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1514,11 +1614,12 @@ def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_1_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1530,11 +1631,12 @@ def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_day_g_year_month_pattern_1_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -1546,11 +1648,12 @@ def test_union_g_month_day_g_year_month_pattern_5_nistxml_sv_ii_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-II-union-gMonthDay-gYearMonth-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enumeration_5_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1561,11 +1664,12 @@ def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enumeration_5_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1576,11 +1680,12 @@ def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enumeration_5_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1591,11 +1696,12 @@ def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enumeration_5_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1606,11 +1712,12 @@ def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enumeration_5_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1621,11 +1728,12 @@ def test_union_any_uri_float_enumeration_9_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enumeration_4_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1636,11 +1744,12 @@ def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enumeration_4_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1651,11 +1760,12 @@ def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enumeration_4_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1666,11 +1776,12 @@ def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enumeration_4_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1681,11 +1792,12 @@ def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enumeration_4_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1696,11 +1808,12 @@ def test_union_any_uri_float_enumeration_8_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enumeration_3_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1711,11 +1824,12 @@ def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enumeration_3_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1726,11 +1840,12 @@ def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enumeration_3_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1741,11 +1856,12 @@ def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enumeration_3_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1756,11 +1872,12 @@ def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enumeration_3_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1771,11 +1888,12 @@ def test_union_any_uri_float_enumeration_7_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enumeration_2_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1786,11 +1904,12 @@ def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enumeration_2_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1801,11 +1920,12 @@ def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enumeration_2_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1816,11 +1936,12 @@ def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enumeration_2_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1831,11 +1952,12 @@ def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enumeration_2_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1846,11 +1968,12 @@ def test_union_any_uri_float_enumeration_6_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enumeration_1_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1861,11 +1984,12 @@ def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enumeration_1_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1876,11 +2000,12 @@ def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enumeration_1_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1891,11 +2016,12 @@ def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enumeration_1_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1906,11 +2032,12 @@ def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enumeration_1_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -1921,11 +2048,12 @@ def test_union_any_uri_float_enumeration_5_nistxml_sv_ii_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern_5_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -1937,11 +2065,12 @@ def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern_5_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -1953,11 +2082,12 @@ def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern_5_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -1969,11 +2099,12 @@ def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern_5_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -1985,11 +2116,12 @@ def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern_5_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2001,11 +2133,12 @@ def test_union_any_uri_float_pattern_9_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern_4_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2017,11 +2150,12 @@ def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern_4_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2033,11 +2167,12 @@ def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern_4_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2049,11 +2184,12 @@ def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern_4_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2065,11 +2201,12 @@ def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern_4_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2081,11 +2218,12 @@ def test_union_any_uri_float_pattern_8_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern_3_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2097,11 +2235,12 @@ def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern_3_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2113,11 +2252,12 @@ def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern_3_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2129,11 +2269,12 @@ def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern_3_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2145,11 +2286,12 @@ def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern_3_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2161,11 +2303,12 @@ def test_union_any_uri_float_pattern_7_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern_2_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2177,11 +2320,12 @@ def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern_2_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2193,11 +2337,12 @@ def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern_2_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2209,11 +2354,12 @@ def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern_2_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2225,11 +2371,12 @@ def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern_2_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2241,11 +2388,12 @@ def test_union_any_uri_float_pattern_6_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern_1_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2257,11 +2405,12 @@ def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern_1_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2273,11 +2422,12 @@ def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern_1_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2289,11 +2439,12 @@ def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern_1_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2305,11 +2456,12 @@ def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern_1_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -2321,11 +2473,12 @@ def test_union_any_uri_float_pattern_5_nistxml_sv_ii_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-II-union-anyURI-float-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decimal_enumeration_5_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2336,11 +2489,12 @@ def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decimal_enumeration_5_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2351,11 +2505,12 @@ def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decimal_enumeration_5_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2366,11 +2521,12 @@ def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decimal_enumeration_5_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2381,11 +2537,12 @@ def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decimal_enumeration_5_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2396,11 +2553,12 @@ def test_union_duration_decimal_enumeration_9_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decimal_enumeration_4_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2411,11 +2569,12 @@ def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decimal_enumeration_4_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2426,11 +2585,12 @@ def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decimal_enumeration_4_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2441,11 +2601,12 @@ def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decimal_enumeration_4_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2456,11 +2617,12 @@ def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decimal_enumeration_4_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2471,11 +2633,12 @@ def test_union_duration_decimal_enumeration_8_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decimal_enumeration_3_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2486,11 +2649,12 @@ def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decimal_enumeration_3_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2501,11 +2665,12 @@ def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decimal_enumeration_3_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2516,11 +2681,12 @@ def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decimal_enumeration_3_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2531,11 +2697,12 @@ def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decimal_enumeration_3_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2546,11 +2713,12 @@ def test_union_duration_decimal_enumeration_7_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decimal_enumeration_2_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2561,11 +2729,12 @@ def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decimal_enumeration_2_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2576,11 +2745,12 @@ def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decimal_enumeration_2_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2591,11 +2761,12 @@ def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decimal_enumeration_2_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2606,11 +2777,12 @@ def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decimal_enumeration_2_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2621,11 +2793,12 @@ def test_union_duration_decimal_enumeration_6_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decimal_enumeration_1_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2636,11 +2809,12 @@ def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decimal_enumeration_1_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2651,11 +2825,12 @@ def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decimal_enumeration_1_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2666,11 +2841,12 @@ def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decimal_enumeration_1_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2681,11 +2857,12 @@ def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decimal_enumeration_1_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -2696,11 +2873,12 @@ def test_union_duration_decimal_enumeration_5_nistxml_sv_ii_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_pattern_5_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2712,11 +2890,12 @@ def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_pattern_5_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2728,11 +2907,12 @@ def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_pattern_5_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2744,11 +2924,12 @@ def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_pattern_5_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2760,11 +2941,12 @@ def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_pattern_5_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2776,11 +2958,12 @@ def test_union_duration_decimal_pattern_9_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_pattern_4_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2792,11 +2975,12 @@ def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_pattern_4_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2808,11 +2992,12 @@ def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_pattern_4_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2824,11 +3009,12 @@ def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_pattern_4_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2840,11 +3026,12 @@ def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_pattern_4_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2856,11 +3043,12 @@ def test_union_duration_decimal_pattern_8_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_pattern_3_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2872,11 +3060,12 @@ def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_pattern_3_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2888,11 +3077,12 @@ def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_pattern_3_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2904,11 +3094,12 @@ def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_pattern_3_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2920,11 +3111,12 @@ def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_pattern_3_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2936,11 +3128,12 @@ def test_union_duration_decimal_pattern_7_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_pattern_2_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2952,11 +3145,12 @@ def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_pattern_2_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2968,11 +3162,12 @@ def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_pattern_2_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -2984,11 +3179,12 @@ def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_pattern_2_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3000,11 +3196,12 @@ def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_pattern_2_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3016,11 +3213,12 @@ def test_union_duration_decimal_pattern_6_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_pattern_1_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3032,11 +3230,12 @@ def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_pattern_1_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3048,11 +3247,12 @@ def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_pattern_1_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3064,11 +3264,12 @@ def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_pattern_1_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3080,11 +3281,12 @@ def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_pattern_1_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -3096,11 +3298,12 @@ def test_union_duration_decimal_pattern_5_nistxml_sv_ii_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-II-union-duration-decimal-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enumeration_5_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3111,11 +3314,12 @@ def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enumeration_5_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3126,11 +3330,12 @@ def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enumeration_5_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3141,11 +3346,12 @@ def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enumeration_5_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3156,11 +3362,12 @@ def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enumeration_5_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3171,11 +3378,12 @@ def test_union_short_g_year_enumeration_4_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enumeration_4_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3186,11 +3394,12 @@ def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enumeration_4_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3201,11 +3410,12 @@ def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enumeration_4_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3216,11 +3426,12 @@ def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enumeration_4_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3231,11 +3442,12 @@ def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enumeration_4_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3246,11 +3458,12 @@ def test_union_short_g_year_enumeration_3_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enumeration_3_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3261,11 +3474,12 @@ def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enumeration_3_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3276,11 +3490,12 @@ def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enumeration_3_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3291,11 +3506,12 @@ def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enumeration_3_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3306,11 +3522,12 @@ def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enumeration_3_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3321,11 +3538,12 @@ def test_union_short_g_year_enumeration_2_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enumeration_2_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3336,11 +3554,12 @@ def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enumeration_2_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3351,11 +3570,12 @@ def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enumeration_2_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3366,11 +3586,12 @@ def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enumeration_2_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3381,11 +3602,12 @@ def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enumeration_2_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3396,11 +3618,12 @@ def test_union_short_g_year_enumeration_1_nistxml_sv_iv_union_short_g_year_enume
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumeration_1_1(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3411,11 +3634,12 @@ def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumera
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumeration_1_2(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3426,11 +3650,12 @@ def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumera
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumeration_1_3(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3441,11 +3666,12 @@ def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumera
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumeration_1_4(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3456,11 +3682,12 @@ def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumera
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumeration_1_5(save_xml):
     """
     Type union/short-gYear is restricted by facet enumeration.
@@ -3471,11 +3698,12 @@ def test_union_short_g_year_enumeration_nistxml_sv_iv_union_short_g_year_enumera
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3487,11 +3715,12 @@ def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3503,11 +3732,12 @@ def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3519,11 +3749,12 @@ def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3535,11 +3766,12 @@ def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3551,11 +3783,12 @@ def test_union_short_g_year_pattern_4_nistxml_sv_iv_union_short_g_year_pattern_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3567,11 +3800,12 @@ def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3583,11 +3817,12 @@ def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3599,11 +3834,12 @@ def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3615,11 +3851,12 @@ def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3631,11 +3868,12 @@ def test_union_short_g_year_pattern_3_nistxml_sv_iv_union_short_g_year_pattern_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3647,11 +3885,12 @@ def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3663,11 +3902,12 @@ def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3679,11 +3919,12 @@ def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3695,11 +3936,12 @@ def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3711,11 +3953,12 @@ def test_union_short_g_year_pattern_2_nistxml_sv_iv_union_short_g_year_pattern_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3727,11 +3970,12 @@ def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3743,11 +3987,12 @@ def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3759,11 +4004,12 @@ def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3775,11 +4021,12 @@ def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3791,11 +4038,12 @@ def test_union_short_g_year_pattern_1_nistxml_sv_iv_union_short_g_year_pattern_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_1(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3807,11 +4055,12 @@ def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_1
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_2(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3823,11 +4072,12 @@ def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_2
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_3(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3839,11 +4089,12 @@ def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_3
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_4(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3855,11 +4106,12 @@ def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_4
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_5(save_xml):
     r"""
     Type union/short-gYear is restricted by facet pattern with value
@@ -3871,11 +4123,12 @@ def test_union_short_g_year_pattern_nistxml_sv_iv_union_short_g_year_pattern_1_5
         instance="nistData/union/short-gYear/Schema+Instance/NISTXML-SV-IV-union-short-gYear-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionShortGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_5_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3886,11 +4139,12 @@ def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_5_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3901,11 +4155,12 @@ def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_5_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3916,11 +4171,12 @@ def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_5_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3931,11 +4187,12 @@ def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_5_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3946,11 +4203,12 @@ def test_union_g_month_day_g_year_month_enumeration_4_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_4_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3961,11 +4219,12 @@ def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_4_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3976,11 +4235,12 @@ def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_4_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -3991,11 +4251,12 @@ def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_4_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4006,11 +4267,12 @@ def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_4_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4021,11 +4283,12 @@ def test_union_g_month_day_g_year_month_enumeration_3_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_3_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4036,11 +4299,12 @@ def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_3_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4051,11 +4315,12 @@ def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_3_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4066,11 +4331,12 @@ def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_3_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4081,11 +4347,12 @@ def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_3_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4096,11 +4363,12 @@ def test_union_g_month_day_g_year_month_enumeration_2_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_2_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4111,11 +4379,12 @@ def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_2_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4126,11 +4395,12 @@ def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_2_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4141,11 +4411,12 @@ def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_2_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4156,11 +4427,12 @@ def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_2_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4171,11 +4443,12 @@ def test_union_g_month_day_g_year_month_enumeration_1_nistxml_sv_iv_union_g_mont
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_1_1(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4186,11 +4459,12 @@ def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_1_2(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4201,11 +4475,12 @@ def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_1_3(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4216,11 +4491,12 @@ def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_1_4(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4231,11 +4507,12 @@ def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_day_g_year_month_enumeration_1_5(save_xml):
     """
     Type union/gMonthDay-gYearMonth is restricted by facet enumeration.
@@ -4246,11 +4523,12 @@ def test_union_g_month_day_g_year_month_enumeration_nistxml_sv_iv_union_g_month_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_5_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4262,11 +4540,12 @@ def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_5_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4278,11 +4557,12 @@ def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_5_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4294,11 +4574,12 @@ def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_5_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4310,11 +4591,12 @@ def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_5_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4326,11 +4608,12 @@ def test_union_g_month_day_g_year_month_pattern_4_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_4_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4342,11 +4625,12 @@ def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_4_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4358,11 +4642,12 @@ def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_4_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4374,11 +4659,12 @@ def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_4_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4390,11 +4676,12 @@ def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_4_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4406,11 +4693,12 @@ def test_union_g_month_day_g_year_month_pattern_3_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_3_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4422,11 +4710,12 @@ def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_3_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4438,11 +4727,12 @@ def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_3_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4454,11 +4744,12 @@ def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_3_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4470,11 +4761,12 @@ def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_3_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4486,11 +4778,12 @@ def test_union_g_month_day_g_year_month_pattern_2_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_2_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4502,11 +4795,12 @@ def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_2_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4518,11 +4812,12 @@ def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_2_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4534,11 +4829,12 @@ def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_2_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4550,11 +4846,12 @@ def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_2_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4566,11 +4863,12 @@ def test_union_g_month_day_g_year_month_pattern_1_nistxml_sv_iv_union_g_month_da
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_1_1(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4582,11 +4880,12 @@ def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_1_2(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4598,11 +4897,12 @@ def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_1_3(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4614,11 +4914,12 @@ def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_1_4(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4630,11 +4931,12 @@ def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_g_year_month_pattern_1_5(save_xml):
     r"""
     Type union/gMonthDay-gYearMonth is restricted by facet pattern with
@@ -4646,11 +4948,12 @@ def test_union_g_month_day_g_year_month_pattern_nistxml_sv_iv_union_g_month_day_
         instance="nistData/union/gMonthDay-gYearMonth/Schema+Instance/NISTXML-SV-IV-union-gMonthDay-gYearMonth-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionGMonthDayGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enumeration_5_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4661,11 +4964,12 @@ def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enumeration_5_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4676,11 +4980,12 @@ def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enumeration_5_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4691,11 +4996,12 @@ def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enumeration_5_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4706,11 +5012,12 @@ def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enumeration_5_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4721,11 +5028,12 @@ def test_union_any_uri_float_enumeration_4_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enumeration_4_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4736,11 +5044,12 @@ def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enumeration_4_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4751,11 +5060,12 @@ def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enumeration_4_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4766,11 +5076,12 @@ def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enumeration_4_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4781,11 +5092,12 @@ def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enumeration_4_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4796,11 +5108,12 @@ def test_union_any_uri_float_enumeration_3_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enumeration_3_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4811,11 +5124,12 @@ def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enumeration_3_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4826,11 +5140,12 @@ def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enumeration_3_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4841,11 +5156,12 @@ def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enumeration_3_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4856,11 +5172,12 @@ def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enumeration_3_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4871,11 +5188,12 @@ def test_union_any_uri_float_enumeration_2_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enumeration_2_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4886,11 +5204,12 @@ def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enumeration_2_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4901,11 +5220,12 @@ def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enumeration_2_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4916,11 +5236,12 @@ def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enumeration_2_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4931,11 +5252,12 @@ def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enumeration_2_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4946,11 +5268,12 @@ def test_union_any_uri_float_enumeration_1_nistxml_sv_iv_union_any_uri_float_enu
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enumeration_1_1(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4961,11 +5284,12 @@ def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enume
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enumeration_1_2(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4976,11 +5300,12 @@ def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enume
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enumeration_1_3(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -4991,11 +5316,12 @@ def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enume
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enumeration_1_4(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -5006,11 +5332,12 @@ def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enume
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enumeration_1_5(save_xml):
     """
     Type union/anyURI-float is restricted by facet enumeration.
@@ -5021,11 +5348,12 @@ def test_union_any_uri_float_enumeration_nistxml_sv_iv_union_any_uri_float_enume
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern_5_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5037,11 +5365,12 @@ def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern_5_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5053,11 +5382,12 @@ def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern_5_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5069,11 +5399,12 @@ def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern_5_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5085,11 +5416,12 @@ def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern_5_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5101,11 +5433,12 @@ def test_union_any_uri_float_pattern_4_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern_4_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5117,11 +5450,12 @@ def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern_4_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5133,11 +5467,12 @@ def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern_4_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5149,11 +5484,12 @@ def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern_4_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5165,11 +5501,12 @@ def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern_4_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5181,11 +5518,12 @@ def test_union_any_uri_float_pattern_3_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern_3_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5197,11 +5535,12 @@ def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern_3_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5213,11 +5552,12 @@ def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern_3_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5229,11 +5569,12 @@ def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern_3_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5245,11 +5586,12 @@ def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern_3_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5261,11 +5603,12 @@ def test_union_any_uri_float_pattern_2_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern_2_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5277,11 +5620,12 @@ def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern_2_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5293,11 +5637,12 @@ def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern_2_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5309,11 +5654,12 @@ def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern_2_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5325,11 +5671,12 @@ def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern_2_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5341,11 +5688,12 @@ def test_union_any_uri_float_pattern_1_nistxml_sv_iv_union_any_uri_float_pattern
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1_1(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5357,11 +5705,12 @@ def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1_2(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5373,11 +5722,12 @@ def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1_3(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5389,11 +5739,12 @@ def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1_4(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5405,11 +5756,12 @@ def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1_5(save_xml):
     r"""
     Type union/anyURI-float is restricted by facet pattern with value
@@ -5421,11 +5773,12 @@ def test_union_any_uri_float_pattern_nistxml_sv_iv_union_any_uri_float_pattern_1
         instance="nistData/union/anyURI-float/Schema+Instance/NISTXML-SV-IV-union-anyURI-float-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionAnyUriFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decimal_enumeration_5_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5436,11 +5789,12 @@ def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decimal_enumeration_5_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5451,11 +5805,12 @@ def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decimal_enumeration_5_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5466,11 +5821,12 @@ def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decimal_enumeration_5_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5481,11 +5837,12 @@ def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decimal_enumeration_5_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5496,11 +5853,12 @@ def test_union_duration_decimal_enumeration_4_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decimal_enumeration_4_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5511,11 +5869,12 @@ def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decimal_enumeration_4_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5526,11 +5885,12 @@ def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decimal_enumeration_4_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5541,11 +5901,12 @@ def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decimal_enumeration_4_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5556,11 +5917,12 @@ def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decimal_enumeration_4_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5571,11 +5933,12 @@ def test_union_duration_decimal_enumeration_3_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decimal_enumeration_3_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5586,11 +5949,12 @@ def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decimal_enumeration_3_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5601,11 +5965,12 @@ def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decimal_enumeration_3_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5616,11 +5981,12 @@ def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decimal_enumeration_3_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5631,11 +5997,12 @@ def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decimal_enumeration_3_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5646,11 +6013,12 @@ def test_union_duration_decimal_enumeration_2_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decimal_enumeration_2_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5661,11 +6029,12 @@ def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decimal_enumeration_2_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5676,11 +6045,12 @@ def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decimal_enumeration_2_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5691,11 +6061,12 @@ def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decimal_enumeration_2_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5706,11 +6077,12 @@ def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decimal_enumeration_2_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5721,11 +6093,12 @@ def test_union_duration_decimal_enumeration_1_nistxml_sv_iv_union_duration_decim
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal_enumeration_1_1(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5736,11 +6109,12 @@ def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal_enumeration_1_2(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5751,11 +6125,12 @@ def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal_enumeration_1_3(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5766,11 +6141,12 @@ def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal_enumeration_1_4(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5781,11 +6157,12 @@ def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal_enumeration_1_5(save_xml):
     """
     Type union/duration-decimal is restricted by facet enumeration.
@@ -5796,11 +6173,12 @@ def test_union_duration_decimal_enumeration_nistxml_sv_iv_union_duration_decimal
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_pattern_5_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5812,11 +6190,12 @@ def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_pattern_5_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5828,11 +6207,12 @@ def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_pattern_5_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5844,11 +6224,12 @@ def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_pattern_5_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5860,11 +6241,12 @@ def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_pattern_5_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5876,11 +6258,12 @@ def test_union_duration_decimal_pattern_4_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_pattern_4_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5892,11 +6275,12 @@ def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_pattern_4_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5908,11 +6292,12 @@ def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_pattern_4_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5924,11 +6309,12 @@ def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_pattern_4_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5940,11 +6326,12 @@ def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_pattern_4_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5956,11 +6343,12 @@ def test_union_duration_decimal_pattern_3_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_pattern_3_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5972,11 +6360,12 @@ def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_pattern_3_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -5988,11 +6377,12 @@ def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_pattern_3_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6004,11 +6394,12 @@ def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_pattern_3_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6020,11 +6411,12 @@ def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_pattern_3_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6036,11 +6428,12 @@ def test_union_duration_decimal_pattern_2_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_pattern_2_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6052,11 +6445,12 @@ def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_pattern_2_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6068,11 +6462,12 @@ def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_pattern_2_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6084,11 +6479,12 @@ def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_pattern_2_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6100,11 +6496,12 @@ def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_pattern_2_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6116,11 +6513,12 @@ def test_union_duration_decimal_pattern_1_nistxml_sv_iv_union_duration_decimal_p
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pattern_1_1(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6132,11 +6530,12 @@ def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pat
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pattern_1_2(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6148,11 +6547,12 @@ def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pat
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pattern_1_3(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6164,11 +6564,12 @@ def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pat
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pattern_1_4(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6180,11 +6581,12 @@ def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pat
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pattern_1_5(save_xml):
     r"""
     Type union/duration-decimal is restricted by facet pattern with value
@@ -6196,11 +6598,12 @@ def test_union_duration_decimal_pattern_nistxml_sv_iv_union_duration_decimal_pat
         instance="nistData/union/duration-decimal/Schema+Instance/NISTXML-SV-IV-union-duration-decimal-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvUnionDurationDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -6211,11 +6614,12 @@ def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -6226,11 +6630,12 @@ def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -6241,11 +6646,12 @@ def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -6256,11 +6662,12 @@ def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -6271,11 +6678,12 @@ def test_list_qname_length_9_nistxml_sv_ii_list_qname_length_5_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -6286,11 +6694,12 @@ def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -6301,11 +6710,12 @@ def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -6316,11 +6726,12 @@ def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -6331,11 +6742,12 @@ def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -6346,11 +6758,12 @@ def test_list_qname_length_8_nistxml_sv_ii_list_qname_length_4_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -6361,11 +6774,12 @@ def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -6376,11 +6790,12 @@ def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -6391,11 +6806,12 @@ def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -6406,11 +6822,12 @@ def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -6421,11 +6838,12 @@ def test_list_qname_length_7_nistxml_sv_ii_list_qname_length_3_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -6436,11 +6854,12 @@ def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -6451,11 +6870,12 @@ def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -6466,11 +6886,12 @@ def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -6481,11 +6902,12 @@ def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -6496,11 +6918,12 @@ def test_list_qname_length_6_nistxml_sv_ii_list_qname_length_2_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -6511,11 +6934,12 @@ def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -6526,11 +6950,12 @@ def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -6541,11 +6966,12 @@ def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -6556,11 +6982,12 @@ def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -6571,11 +6998,12 @@ def test_list_qname_length_5_nistxml_sv_ii_list_qname_length_1_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -6586,11 +7014,12 @@ def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -6601,11 +7030,12 @@ def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -6616,11 +7046,12 @@ def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -6631,11 +7062,12 @@ def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -6646,11 +7078,12 @@ def test_list_qname_min_length_9_nistxml_sv_ii_list_qname_min_length_5_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -6661,11 +7094,12 @@ def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -6676,11 +7110,12 @@ def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -6691,11 +7126,12 @@ def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -6706,11 +7142,12 @@ def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -6721,11 +7158,12 @@ def test_list_qname_min_length_8_nistxml_sv_ii_list_qname_min_length_4_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -6736,11 +7174,12 @@ def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -6751,11 +7190,12 @@ def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -6766,11 +7206,12 @@ def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -6781,11 +7222,12 @@ def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -6796,11 +7238,12 @@ def test_list_qname_min_length_7_nistxml_sv_ii_list_qname_min_length_3_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -6811,11 +7254,12 @@ def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -6826,11 +7270,12 @@ def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -6841,11 +7286,12 @@ def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -6856,11 +7302,12 @@ def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -6871,11 +7318,12 @@ def test_list_qname_min_length_6_nistxml_sv_ii_list_qname_min_length_2_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -6886,11 +7334,12 @@ def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -6901,11 +7350,12 @@ def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -6916,11 +7366,12 @@ def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -6931,11 +7382,12 @@ def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -6946,11 +7398,12 @@ def test_list_qname_min_length_5_nistxml_sv_ii_list_qname_min_length_1_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -6961,11 +7414,12 @@ def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -6976,11 +7430,12 @@ def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -6991,11 +7446,12 @@ def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -7006,11 +7462,12 @@ def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -7021,11 +7478,12 @@ def test_list_qname_max_length_9_nistxml_sv_ii_list_qname_max_length_5_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -7036,11 +7494,12 @@ def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -7051,11 +7510,12 @@ def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -7066,11 +7526,12 @@ def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -7081,11 +7542,12 @@ def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -7096,11 +7558,12 @@ def test_list_qname_max_length_8_nistxml_sv_ii_list_qname_max_length_4_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -7111,11 +7574,12 @@ def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -7126,11 +7590,12 @@ def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -7141,11 +7606,12 @@ def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -7156,11 +7622,12 @@ def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -7171,11 +7638,12 @@ def test_list_qname_max_length_7_nistxml_sv_ii_list_qname_max_length_3_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -7186,11 +7654,12 @@ def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -7201,11 +7670,12 @@ def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -7216,11 +7686,12 @@ def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -7231,11 +7702,12 @@ def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -7246,11 +7718,12 @@ def test_list_qname_max_length_6_nistxml_sv_ii_list_qname_max_length_2_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -7261,11 +7734,12 @@ def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -7276,11 +7750,12 @@ def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -7291,11 +7766,12 @@ def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -7306,11 +7782,12 @@ def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -7321,11 +7798,12 @@ def test_list_qname_max_length_5_nistxml_sv_ii_list_qname_max_length_1_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-II-list-QName-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_1(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -7336,11 +7814,12 @@ def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_2(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -7351,11 +7830,12 @@ def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_3(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -7366,11 +7846,12 @@ def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_4(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -7381,11 +7862,12 @@ def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_5(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -7396,11 +7878,12 @@ def test_list_language_length_9_nistxml_sv_ii_list_language_length_5_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_1(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -7411,11 +7894,12 @@ def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_2(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -7426,11 +7910,12 @@ def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_3(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -7441,11 +7926,12 @@ def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_4(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -7456,11 +7942,12 @@ def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_5(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -7471,11 +7958,12 @@ def test_list_language_length_8_nistxml_sv_ii_list_language_length_4_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_1(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -7486,11 +7974,12 @@ def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_2(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -7501,11 +7990,12 @@ def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_3(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -7516,11 +8006,12 @@ def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_4(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -7531,11 +8022,12 @@ def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_5(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -7546,11 +8038,12 @@ def test_list_language_length_7_nistxml_sv_ii_list_language_length_3_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_1(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -7561,11 +8054,12 @@ def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_2(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -7576,11 +8070,12 @@ def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_3(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -7591,11 +8086,12 @@ def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_4(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -7606,11 +8102,12 @@ def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_5(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -7621,11 +8118,12 @@ def test_list_language_length_6_nistxml_sv_ii_list_language_length_2_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_1(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -7636,11 +8134,12 @@ def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_2(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -7651,11 +8150,12 @@ def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_3(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -7666,11 +8166,12 @@ def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_4(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -7681,11 +8182,12 @@ def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_5(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -7696,11 +8198,12 @@ def test_list_language_length_5_nistxml_sv_ii_list_language_length_1_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -7711,11 +8214,12 @@ def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -7726,11 +8230,12 @@ def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -7741,11 +8246,12 @@ def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -7756,11 +8262,12 @@ def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -7771,11 +8278,12 @@ def test_list_language_min_length_9_nistxml_sv_ii_list_language_min_length_5_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -7786,11 +8294,12 @@ def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -7801,11 +8310,12 @@ def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -7816,11 +8326,12 @@ def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -7831,11 +8342,12 @@ def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -7846,11 +8358,12 @@ def test_list_language_min_length_8_nistxml_sv_ii_list_language_min_length_4_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -7861,11 +8374,12 @@ def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -7876,11 +8390,12 @@ def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -7891,11 +8406,12 @@ def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -7906,11 +8422,12 @@ def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -7921,11 +8438,12 @@ def test_list_language_min_length_7_nistxml_sv_ii_list_language_min_length_3_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -7936,11 +8454,12 @@ def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -7951,11 +8470,12 @@ def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -7966,11 +8486,12 @@ def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -7981,11 +8502,12 @@ def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -7996,11 +8518,12 @@ def test_list_language_min_length_6_nistxml_sv_ii_list_language_min_length_2_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -8011,11 +8534,12 @@ def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -8026,11 +8550,12 @@ def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -8041,11 +8566,12 @@ def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -8056,11 +8582,12 @@ def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -8071,11 +8598,12 @@ def test_list_language_min_length_5_nistxml_sv_ii_list_language_min_length_1_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -8086,11 +8614,12 @@ def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -8101,11 +8630,12 @@ def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -8116,11 +8646,12 @@ def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -8131,11 +8662,12 @@ def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -8146,11 +8678,12 @@ def test_list_language_max_length_9_nistxml_sv_ii_list_language_max_length_5_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -8161,11 +8694,12 @@ def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -8176,11 +8710,12 @@ def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -8191,11 +8726,12 @@ def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -8206,11 +8742,12 @@ def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -8221,11 +8758,12 @@ def test_list_language_max_length_8_nistxml_sv_ii_list_language_max_length_4_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -8236,11 +8774,12 @@ def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -8251,11 +8790,12 @@ def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -8266,11 +8806,12 @@ def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -8281,11 +8822,12 @@ def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -8296,11 +8838,12 @@ def test_list_language_max_length_7_nistxml_sv_ii_list_language_max_length_3_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -8311,11 +8854,12 @@ def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -8326,11 +8870,12 @@ def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -8341,11 +8886,12 @@ def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -8356,11 +8902,12 @@ def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -8371,11 +8918,12 @@ def test_list_language_max_length_6_nistxml_sv_ii_list_language_max_length_2_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -8386,11 +8934,12 @@ def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -8401,11 +8950,12 @@ def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -8416,11 +8966,12 @@ def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -8431,11 +8982,12 @@ def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -8446,11 +8998,12 @@ def test_list_language_max_length_5_nistxml_sv_ii_list_language_max_length_1_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-II-list-language-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -8461,11 +9014,12 @@ def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-5-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -8476,11 +9030,12 @@ def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-5-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -8491,11 +9046,12 @@ def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-5-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -8506,11 +9062,12 @@ def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-5-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -8521,11 +9078,12 @@ def test_list_id_length_9_nistxml_sv_ii_list_id_length_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-5-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -8536,11 +9094,12 @@ def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-4-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -8551,11 +9110,12 @@ def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-4-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -8566,11 +9126,12 @@ def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-4-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -8581,11 +9142,12 @@ def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-4-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -8596,11 +9158,12 @@ def test_list_id_length_8_nistxml_sv_ii_list_id_length_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-4-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -8611,11 +9174,12 @@ def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-3-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -8626,11 +9190,12 @@ def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-3-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -8641,11 +9206,12 @@ def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-3-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -8656,11 +9222,12 @@ def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-3-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -8671,11 +9238,12 @@ def test_list_id_length_7_nistxml_sv_ii_list_id_length_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-3-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -8686,11 +9254,12 @@ def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-2-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -8701,11 +9270,12 @@ def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-2-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -8716,11 +9286,12 @@ def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-2-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -8731,11 +9302,12 @@ def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-2-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -8746,11 +9318,12 @@ def test_list_id_length_6_nistxml_sv_ii_list_id_length_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-2-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -8761,11 +9334,12 @@ def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-1-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -8776,11 +9350,12 @@ def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-1-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -8791,11 +9366,12 @@ def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-1-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -8806,11 +9382,12 @@ def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-1-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -8821,11 +9398,12 @@ def test_list_id_length_5_nistxml_sv_ii_list_id_length_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-length-1-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -8836,11 +9414,12 @@ def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -8851,11 +9430,12 @@ def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -8866,11 +9446,12 @@ def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -8881,11 +9462,12 @@ def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -8896,11 +9478,12 @@ def test_list_id_min_length_9_nistxml_sv_ii_list_id_min_length_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -8911,11 +9494,12 @@ def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -8926,11 +9510,12 @@ def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -8941,11 +9526,12 @@ def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -8956,11 +9542,12 @@ def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -8971,11 +9558,12 @@ def test_list_id_min_length_8_nistxml_sv_ii_list_id_min_length_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -8986,11 +9574,12 @@ def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -9001,11 +9590,12 @@ def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -9016,11 +9606,12 @@ def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -9031,11 +9622,12 @@ def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -9046,11 +9638,12 @@ def test_list_id_min_length_7_nistxml_sv_ii_list_id_min_length_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -9061,11 +9654,12 @@ def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -9076,11 +9670,12 @@ def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -9091,11 +9686,12 @@ def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -9106,11 +9702,12 @@ def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -9121,11 +9718,12 @@ def test_list_id_min_length_6_nistxml_sv_ii_list_id_min_length_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -9136,11 +9734,12 @@ def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -9151,11 +9750,12 @@ def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -9166,11 +9766,12 @@ def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -9181,11 +9782,12 @@ def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -9196,11 +9798,12 @@ def test_list_id_min_length_5_nistxml_sv_ii_list_id_min_length_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -9211,11 +9814,12 @@ def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -9226,11 +9830,12 @@ def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -9241,11 +9846,12 @@ def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -9256,11 +9862,12 @@ def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -9271,11 +9878,12 @@ def test_list_id_max_length_9_nistxml_sv_ii_list_id_max_length_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -9286,11 +9894,12 @@ def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -9301,11 +9910,12 @@ def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -9316,11 +9926,12 @@ def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -9331,11 +9942,12 @@ def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -9346,11 +9958,12 @@ def test_list_id_max_length_8_nistxml_sv_ii_list_id_max_length_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -9361,11 +9974,12 @@ def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -9376,11 +9990,12 @@ def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -9391,11 +10006,12 @@ def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -9406,11 +10022,12 @@ def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -9421,11 +10038,12 @@ def test_list_id_max_length_7_nistxml_sv_ii_list_id_max_length_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -9436,11 +10054,12 @@ def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -9451,11 +10070,12 @@ def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -9466,11 +10086,12 @@ def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -9481,11 +10102,12 @@ def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -9496,11 +10118,12 @@ def test_list_id_max_length_6_nistxml_sv_ii_list_id_max_length_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -9511,11 +10134,12 @@ def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -9526,11 +10150,12 @@ def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -9541,11 +10166,12 @@ def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -9556,11 +10182,12 @@ def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -9571,11 +10198,12 @@ def test_list_id_max_length_5_nistxml_sv_ii_list_id_max_length_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-II-list-ID-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -9586,11 +10214,12 @@ def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -9601,11 +10230,12 @@ def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -9616,11 +10246,12 @@ def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -9631,11 +10262,12 @@ def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -9646,11 +10278,12 @@ def test_list_ncname_length_9_nistxml_sv_ii_list_ncname_length_5_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -9661,11 +10294,12 @@ def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -9676,11 +10310,12 @@ def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -9691,11 +10326,12 @@ def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -9706,11 +10342,12 @@ def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -9721,11 +10358,12 @@ def test_list_ncname_length_8_nistxml_sv_ii_list_ncname_length_4_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -9736,11 +10374,12 @@ def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -9751,11 +10390,12 @@ def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -9766,11 +10406,12 @@ def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -9781,11 +10422,12 @@ def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -9796,11 +10438,12 @@ def test_list_ncname_length_7_nistxml_sv_ii_list_ncname_length_3_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -9811,11 +10454,12 @@ def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -9826,11 +10470,12 @@ def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -9841,11 +10486,12 @@ def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -9856,11 +10502,12 @@ def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -9871,11 +10518,12 @@ def test_list_ncname_length_6_nistxml_sv_ii_list_ncname_length_2_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -9886,11 +10534,12 @@ def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -9901,11 +10550,12 @@ def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -9916,11 +10566,12 @@ def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -9931,11 +10582,12 @@ def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -9946,11 +10598,12 @@ def test_list_ncname_length_5_nistxml_sv_ii_list_ncname_length_1_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -9961,11 +10614,12 @@ def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -9976,11 +10630,12 @@ def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -9991,11 +10646,12 @@ def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -10006,11 +10662,12 @@ def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -10021,11 +10678,12 @@ def test_list_ncname_min_length_9_nistxml_sv_ii_list_ncname_min_length_5_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -10036,11 +10694,12 @@ def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -10051,11 +10710,12 @@ def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -10066,11 +10726,12 @@ def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -10081,11 +10742,12 @@ def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -10096,11 +10758,12 @@ def test_list_ncname_min_length_8_nistxml_sv_ii_list_ncname_min_length_4_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -10111,11 +10774,12 @@ def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -10126,11 +10790,12 @@ def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -10141,11 +10806,12 @@ def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -10156,11 +10822,12 @@ def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -10171,11 +10838,12 @@ def test_list_ncname_min_length_7_nistxml_sv_ii_list_ncname_min_length_3_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -10186,11 +10854,12 @@ def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -10201,11 +10870,12 @@ def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -10216,11 +10886,12 @@ def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -10231,11 +10902,12 @@ def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -10246,11 +10918,12 @@ def test_list_ncname_min_length_6_nistxml_sv_ii_list_ncname_min_length_2_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -10261,11 +10934,12 @@ def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -10276,11 +10950,12 @@ def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -10291,11 +10966,12 @@ def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -10306,11 +10982,12 @@ def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -10321,11 +10998,12 @@ def test_list_ncname_min_length_5_nistxml_sv_ii_list_ncname_min_length_1_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -10336,11 +11014,12 @@ def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -10351,11 +11030,12 @@ def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -10366,11 +11046,12 @@ def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -10381,11 +11062,12 @@ def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -10396,11 +11078,12 @@ def test_list_ncname_max_length_9_nistxml_sv_ii_list_ncname_max_length_5_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -10411,11 +11094,12 @@ def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -10426,11 +11110,12 @@ def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -10441,11 +11126,12 @@ def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -10456,11 +11142,12 @@ def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -10471,11 +11158,12 @@ def test_list_ncname_max_length_8_nistxml_sv_ii_list_ncname_max_length_4_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -10486,11 +11174,12 @@ def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -10501,11 +11190,12 @@ def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -10516,11 +11206,12 @@ def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -10531,11 +11222,12 @@ def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -10546,11 +11238,12 @@ def test_list_ncname_max_length_7_nistxml_sv_ii_list_ncname_max_length_3_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -10561,11 +11254,12 @@ def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -10576,11 +11270,12 @@ def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -10591,11 +11286,12 @@ def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -10606,11 +11302,12 @@ def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -10621,11 +11318,12 @@ def test_list_ncname_max_length_6_nistxml_sv_ii_list_ncname_max_length_2_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -10636,11 +11334,12 @@ def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -10651,11 +11350,12 @@ def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -10666,11 +11366,12 @@ def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -10681,11 +11382,12 @@ def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -10696,11 +11398,12 @@ def test_list_ncname_max_length_5_nistxml_sv_ii_list_ncname_max_length_1_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-II-list-NCName-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -10711,11 +11414,12 @@ def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -10726,11 +11430,12 @@ def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -10741,11 +11446,12 @@ def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -10756,11 +11462,12 @@ def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -10771,11 +11478,12 @@ def test_list_nmtokens_length_9_nistxml_sv_ii_list_nmtokens_length_5_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -10786,11 +11494,12 @@ def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -10801,11 +11510,12 @@ def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -10816,11 +11526,12 @@ def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -10831,11 +11542,12 @@ def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -10846,11 +11558,12 @@ def test_list_nmtokens_length_8_nistxml_sv_ii_list_nmtokens_length_4_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -10861,11 +11574,12 @@ def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -10876,11 +11590,12 @@ def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -10891,11 +11606,12 @@ def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -10906,11 +11622,12 @@ def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -10921,11 +11638,12 @@ def test_list_nmtokens_length_7_nistxml_sv_ii_list_nmtokens_length_3_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -10936,11 +11654,12 @@ def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -10951,11 +11670,12 @@ def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -10966,11 +11686,12 @@ def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -10981,11 +11702,12 @@ def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -10996,11 +11718,12 @@ def test_list_nmtokens_length_6_nistxml_sv_ii_list_nmtokens_length_2_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -11011,11 +11734,12 @@ def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -11026,11 +11750,12 @@ def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -11041,11 +11766,12 @@ def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -11056,11 +11782,12 @@ def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -11071,11 +11798,12 @@ def test_list_nmtokens_length_5_nistxml_sv_ii_list_nmtokens_length_1_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -11086,11 +11814,12 @@ def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -11101,11 +11830,12 @@ def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -11116,11 +11846,12 @@ def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -11131,11 +11862,12 @@ def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -11146,11 +11878,12 @@ def test_list_nmtokens_min_length_9_nistxml_sv_ii_list_nmtokens_min_length_5_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -11161,11 +11894,12 @@ def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -11176,11 +11910,12 @@ def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -11191,11 +11926,12 @@ def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -11206,11 +11942,12 @@ def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -11221,11 +11958,12 @@ def test_list_nmtokens_min_length_8_nistxml_sv_ii_list_nmtokens_min_length_4_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -11236,11 +11974,12 @@ def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -11251,11 +11990,12 @@ def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -11266,11 +12006,12 @@ def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -11281,11 +12022,12 @@ def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -11296,11 +12038,12 @@ def test_list_nmtokens_min_length_7_nistxml_sv_ii_list_nmtokens_min_length_3_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -11311,11 +12054,12 @@ def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -11326,11 +12070,12 @@ def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -11341,11 +12086,12 @@ def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -11356,11 +12102,12 @@ def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -11371,11 +12118,12 @@ def test_list_nmtokens_min_length_6_nistxml_sv_ii_list_nmtokens_min_length_2_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -11386,11 +12134,12 @@ def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -11401,11 +12150,12 @@ def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -11416,11 +12166,12 @@ def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -11431,11 +12182,12 @@ def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -11446,11 +12198,12 @@ def test_list_nmtokens_min_length_5_nistxml_sv_ii_list_nmtokens_min_length_1_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -11461,11 +12214,12 @@ def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -11476,11 +12230,12 @@ def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -11491,11 +12246,12 @@ def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -11506,11 +12262,12 @@ def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -11521,11 +12278,12 @@ def test_list_nmtokens_max_length_9_nistxml_sv_ii_list_nmtokens_max_length_5_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -11536,11 +12294,12 @@ def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -11551,11 +12310,12 @@ def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -11566,11 +12326,12 @@ def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -11581,11 +12342,12 @@ def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -11596,11 +12358,12 @@ def test_list_nmtokens_max_length_8_nistxml_sv_ii_list_nmtokens_max_length_4_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -11611,11 +12374,12 @@ def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -11626,11 +12390,12 @@ def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -11641,11 +12406,12 @@ def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -11656,11 +12422,12 @@ def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -11671,11 +12438,12 @@ def test_list_nmtokens_max_length_7_nistxml_sv_ii_list_nmtokens_max_length_3_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -11686,11 +12454,12 @@ def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -11701,11 +12470,12 @@ def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -11716,11 +12486,12 @@ def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -11731,11 +12502,12 @@ def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -11746,11 +12518,12 @@ def test_list_nmtokens_max_length_6_nistxml_sv_ii_list_nmtokens_max_length_2_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -11761,11 +12534,12 @@ def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -11776,11 +12550,12 @@ def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -11791,11 +12566,12 @@ def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -11806,11 +12582,12 @@ def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -11821,11 +12598,12 @@ def test_list_nmtokens_max_length_5_nistxml_sv_ii_list_nmtokens_max_length_1_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-II-list-NMTOKENS-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -11836,11 +12614,12 @@ def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -11851,11 +12630,12 @@ def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -11866,11 +12646,12 @@ def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -11881,11 +12662,12 @@ def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -11896,11 +12678,12 @@ def test_list_nmtoken_length_9_nistxml_sv_ii_list_nmtoken_length_5_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -11911,11 +12694,12 @@ def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -11926,11 +12710,12 @@ def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -11941,11 +12726,12 @@ def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -11956,11 +12742,12 @@ def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -11971,11 +12758,12 @@ def test_list_nmtoken_length_8_nistxml_sv_ii_list_nmtoken_length_4_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -11986,11 +12774,12 @@ def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -12001,11 +12790,12 @@ def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -12016,11 +12806,12 @@ def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -12031,11 +12822,12 @@ def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -12046,11 +12838,12 @@ def test_list_nmtoken_length_7_nistxml_sv_ii_list_nmtoken_length_3_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -12061,11 +12854,12 @@ def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -12076,11 +12870,12 @@ def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -12091,11 +12886,12 @@ def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -12106,11 +12902,12 @@ def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -12121,11 +12918,12 @@ def test_list_nmtoken_length_6_nistxml_sv_ii_list_nmtoken_length_2_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -12136,11 +12934,12 @@ def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -12151,11 +12950,12 @@ def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -12166,11 +12966,12 @@ def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -12181,11 +12982,12 @@ def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -12196,11 +12998,12 @@ def test_list_nmtoken_length_5_nistxml_sv_ii_list_nmtoken_length_1_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -12211,11 +13014,12 @@ def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -12226,11 +13030,12 @@ def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -12241,11 +13046,12 @@ def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -12256,11 +13062,12 @@ def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -12271,11 +13078,12 @@ def test_list_nmtoken_min_length_9_nistxml_sv_ii_list_nmtoken_min_length_5_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -12286,11 +13094,12 @@ def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -12301,11 +13110,12 @@ def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -12316,11 +13126,12 @@ def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -12331,11 +13142,12 @@ def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -12346,11 +13158,12 @@ def test_list_nmtoken_min_length_8_nistxml_sv_ii_list_nmtoken_min_length_4_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -12361,11 +13174,12 @@ def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -12376,11 +13190,12 @@ def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -12391,11 +13206,12 @@ def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -12406,11 +13222,12 @@ def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -12421,11 +13238,12 @@ def test_list_nmtoken_min_length_7_nistxml_sv_ii_list_nmtoken_min_length_3_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -12436,11 +13254,12 @@ def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -12451,11 +13270,12 @@ def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -12466,11 +13286,12 @@ def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -12481,11 +13302,12 @@ def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -12496,11 +13318,12 @@ def test_list_nmtoken_min_length_6_nistxml_sv_ii_list_nmtoken_min_length_2_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -12511,11 +13334,12 @@ def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -12526,11 +13350,12 @@ def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -12541,11 +13366,12 @@ def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -12556,11 +13382,12 @@ def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -12571,11 +13398,12 @@ def test_list_nmtoken_min_length_5_nistxml_sv_ii_list_nmtoken_min_length_1_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -12586,11 +13414,12 @@ def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -12601,11 +13430,12 @@ def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -12616,11 +13446,12 @@ def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -12631,11 +13462,12 @@ def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -12646,11 +13478,12 @@ def test_list_nmtoken_max_length_9_nistxml_sv_ii_list_nmtoken_max_length_5_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -12661,11 +13494,12 @@ def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -12676,11 +13510,12 @@ def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -12691,11 +13526,12 @@ def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -12706,11 +13542,12 @@ def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -12721,11 +13558,12 @@ def test_list_nmtoken_max_length_8_nistxml_sv_ii_list_nmtoken_max_length_4_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -12736,11 +13574,12 @@ def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -12751,11 +13590,12 @@ def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -12766,11 +13606,12 @@ def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -12781,11 +13622,12 @@ def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -12796,11 +13638,12 @@ def test_list_nmtoken_max_length_7_nistxml_sv_ii_list_nmtoken_max_length_3_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -12811,11 +13654,12 @@ def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -12826,11 +13670,12 @@ def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -12841,11 +13686,12 @@ def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -12856,11 +13702,12 @@ def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -12871,11 +13718,12 @@ def test_list_nmtoken_max_length_6_nistxml_sv_ii_list_nmtoken_max_length_2_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -12886,11 +13734,12 @@ def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -12901,11 +13750,12 @@ def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -12916,11 +13766,12 @@ def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -12931,11 +13782,12 @@ def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -12946,11 +13798,12 @@ def test_list_nmtoken_max_length_5_nistxml_sv_ii_list_nmtoken_max_length_1_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-II-list-NMTOKEN-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -12961,11 +13814,12 @@ def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -12976,11 +13830,12 @@ def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -12991,11 +13846,12 @@ def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -13006,11 +13862,12 @@ def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -13021,11 +13878,12 @@ def test_list_name_length_9_nistxml_sv_ii_list_name_length_5_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -13036,11 +13894,12 @@ def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -13051,11 +13910,12 @@ def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -13066,11 +13926,12 @@ def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -13081,11 +13942,12 @@ def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -13096,11 +13958,12 @@ def test_list_name_length_8_nistxml_sv_ii_list_name_length_4_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -13111,11 +13974,12 @@ def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -13126,11 +13990,12 @@ def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -13141,11 +14006,12 @@ def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -13156,11 +14022,12 @@ def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -13171,11 +14038,12 @@ def test_list_name_length_7_nistxml_sv_ii_list_name_length_3_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -13186,11 +14054,12 @@ def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -13201,11 +14070,12 @@ def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -13216,11 +14086,12 @@ def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -13231,11 +14102,12 @@ def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -13246,11 +14118,12 @@ def test_list_name_length_6_nistxml_sv_ii_list_name_length_2_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -13261,11 +14134,12 @@ def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -13276,11 +14150,12 @@ def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -13291,11 +14166,12 @@ def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -13306,11 +14182,12 @@ def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -13321,11 +14198,12 @@ def test_list_name_length_5_nistxml_sv_ii_list_name_length_1_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -13336,11 +14214,12 @@ def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -13351,11 +14230,12 @@ def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -13366,11 +14246,12 @@ def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -13381,11 +14262,12 @@ def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -13396,11 +14278,12 @@ def test_list_name_min_length_9_nistxml_sv_ii_list_name_min_length_5_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -13411,11 +14294,12 @@ def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -13426,11 +14310,12 @@ def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -13441,11 +14326,12 @@ def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -13456,11 +14342,12 @@ def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -13471,11 +14358,12 @@ def test_list_name_min_length_8_nistxml_sv_ii_list_name_min_length_4_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -13486,11 +14374,12 @@ def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -13501,11 +14390,12 @@ def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -13516,11 +14406,12 @@ def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -13531,11 +14422,12 @@ def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -13546,11 +14438,12 @@ def test_list_name_min_length_7_nistxml_sv_ii_list_name_min_length_3_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -13561,11 +14454,12 @@ def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -13576,11 +14470,12 @@ def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -13591,11 +14486,12 @@ def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -13606,11 +14502,12 @@ def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -13621,11 +14518,12 @@ def test_list_name_min_length_6_nistxml_sv_ii_list_name_min_length_2_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -13636,11 +14534,12 @@ def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -13651,11 +14550,12 @@ def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -13666,11 +14566,12 @@ def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -13681,11 +14582,12 @@ def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -13696,11 +14598,12 @@ def test_list_name_min_length_5_nistxml_sv_ii_list_name_min_length_1_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -13711,11 +14614,12 @@ def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -13726,11 +14630,12 @@ def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -13741,11 +14646,12 @@ def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -13756,11 +14662,12 @@ def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -13771,11 +14678,12 @@ def test_list_name_max_length_9_nistxml_sv_ii_list_name_max_length_5_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -13786,11 +14694,12 @@ def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -13801,11 +14710,12 @@ def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -13816,11 +14726,12 @@ def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -13831,11 +14742,12 @@ def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -13846,11 +14758,12 @@ def test_list_name_max_length_8_nistxml_sv_ii_list_name_max_length_4_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -13861,11 +14774,12 @@ def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -13876,11 +14790,12 @@ def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -13891,11 +14806,12 @@ def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -13906,11 +14822,12 @@ def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -13921,11 +14838,12 @@ def test_list_name_max_length_7_nistxml_sv_ii_list_name_max_length_3_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -13936,11 +14854,12 @@ def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -13951,11 +14870,12 @@ def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -13966,11 +14886,12 @@ def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -13981,11 +14902,12 @@ def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -13996,11 +14918,12 @@ def test_list_name_max_length_6_nistxml_sv_ii_list_name_max_length_2_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -14011,11 +14934,12 @@ def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -14026,11 +14950,12 @@ def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -14041,11 +14966,12 @@ def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -14056,11 +14982,12 @@ def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -14071,11 +14998,12 @@ def test_list_name_max_length_5_nistxml_sv_ii_list_name_max_length_1_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-II-list-Name-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_1(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -14086,11 +15014,12 @@ def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_2(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -14101,11 +15030,12 @@ def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_3(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -14116,11 +15046,12 @@ def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_4(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -14131,11 +15062,12 @@ def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_5(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -14146,11 +15078,12 @@ def test_list_token_length_9_nistxml_sv_ii_list_token_length_5_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_1(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -14161,11 +15094,12 @@ def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_2(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -14176,11 +15110,12 @@ def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_3(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -14191,11 +15126,12 @@ def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_4(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -14206,11 +15142,12 @@ def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_5(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -14221,11 +15158,12 @@ def test_list_token_length_8_nistxml_sv_ii_list_token_length_4_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_1(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -14236,11 +15174,12 @@ def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_2(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -14251,11 +15190,12 @@ def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_3(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -14266,11 +15206,12 @@ def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_4(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -14281,11 +15222,12 @@ def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_5(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -14296,11 +15238,12 @@ def test_list_token_length_7_nistxml_sv_ii_list_token_length_3_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_1(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -14311,11 +15254,12 @@ def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_2(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -14326,11 +15270,12 @@ def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_3(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -14341,11 +15286,12 @@ def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_4(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -14356,11 +15302,12 @@ def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_5(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -14371,11 +15318,12 @@ def test_list_token_length_6_nistxml_sv_ii_list_token_length_2_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_1(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -14386,11 +15334,12 @@ def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_2(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -14401,11 +15350,12 @@ def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_3(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -14416,11 +15366,12 @@ def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_4(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -14431,11 +15382,12 @@ def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_5(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -14446,11 +15398,12 @@ def test_list_token_length_5_nistxml_sv_ii_list_token_length_1_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14461,11 +15414,12 @@ def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14476,11 +15430,12 @@ def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14491,11 +15446,12 @@ def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14506,11 +15462,12 @@ def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14521,11 +15478,12 @@ def test_list_token_min_length_9_nistxml_sv_ii_list_token_min_length_5_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14536,11 +15494,12 @@ def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14551,11 +15510,12 @@ def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14566,11 +15526,12 @@ def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14581,11 +15542,12 @@ def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14596,11 +15558,12 @@ def test_list_token_min_length_8_nistxml_sv_ii_list_token_min_length_4_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14611,11 +15574,12 @@ def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14626,11 +15590,12 @@ def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14641,11 +15606,12 @@ def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14656,11 +15622,12 @@ def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14671,11 +15638,12 @@ def test_list_token_min_length_7_nistxml_sv_ii_list_token_min_length_3_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14686,11 +15654,12 @@ def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14701,11 +15670,12 @@ def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14716,11 +15686,12 @@ def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14731,11 +15702,12 @@ def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14746,11 +15718,12 @@ def test_list_token_min_length_6_nistxml_sv_ii_list_token_min_length_2_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14761,11 +15734,12 @@ def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14776,11 +15750,12 @@ def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14791,11 +15766,12 @@ def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14806,11 +15782,12 @@ def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14821,11 +15798,12 @@ def test_list_token_min_length_5_nistxml_sv_ii_list_token_min_length_1_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14836,11 +15814,12 @@ def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14851,11 +15830,12 @@ def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14866,11 +15846,12 @@ def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14881,11 +15862,12 @@ def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14896,11 +15878,12 @@ def test_list_token_max_length_9_nistxml_sv_ii_list_token_max_length_5_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14911,11 +15894,12 @@ def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14926,11 +15910,12 @@ def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14941,11 +15926,12 @@ def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14956,11 +15942,12 @@ def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14971,11 +15958,12 @@ def test_list_token_max_length_8_nistxml_sv_ii_list_token_max_length_4_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -14986,11 +15974,12 @@ def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -15001,11 +15990,12 @@ def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -15016,11 +16006,12 @@ def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -15031,11 +16022,12 @@ def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -15046,11 +16038,12 @@ def test_list_token_max_length_7_nistxml_sv_ii_list_token_max_length_3_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -15061,11 +16054,12 @@ def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -15076,11 +16070,12 @@ def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -15091,11 +16086,12 @@ def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -15106,11 +16102,12 @@ def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -15121,11 +16118,12 @@ def test_list_token_max_length_6_nistxml_sv_ii_list_token_max_length_2_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -15136,11 +16134,12 @@ def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -15151,11 +16150,12 @@ def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -15166,11 +16166,12 @@ def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -15181,11 +16182,12 @@ def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -15196,6 +16198,6 @@ def test_list_token_max_length_5_nistxml_sv_ii_list_token_max_length_1_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-II-list-token-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_10000.py
+++ b/tests/test_nist_meta_10000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -11,11 +14,12 @@ def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -26,11 +30,12 @@ def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -41,11 +46,12 @@ def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -56,11 +62,12 @@ def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -71,11 +78,12 @@ def test_list_negative_integer_length_nistxml_sv_iv_list_negative_integer_length
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_min_length_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -87,11 +95,12 @@ def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_min_length_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -103,11 +112,12 @@ def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_min_length_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -119,11 +129,12 @@ def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_min_length_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -135,11 +146,12 @@ def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_min_length_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -151,11 +163,12 @@ def test_list_negative_integer_min_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_min_length_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -167,11 +180,12 @@ def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_min_length_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -183,11 +197,12 @@ def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_min_length_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -199,11 +214,12 @@ def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_min_length_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -215,11 +231,12 @@ def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_min_length_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -231,11 +248,12 @@ def test_list_negative_integer_min_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_min_length_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -247,11 +265,12 @@ def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_min_length_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -263,11 +282,12 @@ def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_min_length_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -279,11 +299,12 @@ def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_min_length_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -295,11 +316,12 @@ def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_min_length_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -311,11 +333,12 @@ def test_list_negative_integer_min_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_min_length_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -327,11 +350,12 @@ def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_min_length_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -343,11 +367,12 @@ def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_min_length_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -359,11 +384,12 @@ def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_min_length_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -375,11 +401,12 @@ def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_min_length_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -391,11 +418,12 @@ def test_list_negative_integer_min_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_min_length_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -407,11 +435,12 @@ def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_mi
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_min_length_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -423,11 +452,12 @@ def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_mi
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_min_length_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -439,11 +469,12 @@ def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_mi
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_min_length_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -455,11 +486,12 @@ def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_mi
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_min_length_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -471,11 +503,12 @@ def test_list_negative_integer_min_length_nistxml_sv_iv_list_negative_integer_mi
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_max_length_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -487,11 +520,12 @@ def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_max_length_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -503,11 +537,12 @@ def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_max_length_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -519,11 +554,12 @@ def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_max_length_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -535,11 +571,12 @@ def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_max_length_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -551,11 +588,12 @@ def test_list_negative_integer_max_length_4_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_max_length_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -567,11 +605,12 @@ def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_max_length_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -583,11 +622,12 @@ def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_max_length_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -599,11 +639,12 @@ def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_max_length_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -615,11 +656,12 @@ def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_max_length_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -631,11 +673,12 @@ def test_list_negative_integer_max_length_3_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_max_length_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -647,11 +690,12 @@ def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_max_length_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -663,11 +707,12 @@ def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_max_length_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -679,11 +724,12 @@ def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_max_length_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -695,11 +741,12 @@ def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_max_length_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -711,11 +758,12 @@ def test_list_negative_integer_max_length_2_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_max_length_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -727,11 +775,12 @@ def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_max_length_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -743,11 +792,12 @@ def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_max_length_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -759,11 +809,12 @@ def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_max_length_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -775,11 +826,12 @@ def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_max_length_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -791,11 +843,12 @@ def test_list_negative_integer_max_length_1_nistxml_sv_iv_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_max_length_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -807,11 +860,12 @@ def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_ma
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_max_length_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -823,11 +877,12 @@ def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_ma
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_max_length_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -839,11 +894,12 @@ def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_ma
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_max_length_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -855,11 +911,12 @@ def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_ma
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_max_length_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -871,11 +928,12 @@ def test_list_negative_integer_max_length_nistxml_sv_iv_list_negative_integer_ma
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_integer_white_space_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet whiteSpace with
@@ -887,11 +945,12 @@ def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_integer_white_space_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet whiteSpace with
@@ -903,11 +962,12 @@ def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_integer_white_space_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet whiteSpace with
@@ -919,11 +979,12 @@ def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_integer_white_space_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet whiteSpace with
@@ -935,11 +996,12 @@ def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_integer_white_space_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet whiteSpace with
@@ -951,11 +1013,12 @@ def test_list_non_positive_integer_white_space_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive_integer_enumeration_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -966,11 +1029,12 @@ def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive_integer_enumeration_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -981,11 +1045,12 @@ def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive_integer_enumeration_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -996,11 +1061,12 @@ def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive_integer_enumeration_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1011,11 +1077,12 @@ def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive_integer_enumeration_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1026,11 +1093,12 @@ def test_list_non_positive_integer_enumeration_4_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive_integer_enumeration_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1041,11 +1109,12 @@ def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive_integer_enumeration_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1056,11 +1125,12 @@ def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive_integer_enumeration_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1071,11 +1141,12 @@ def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive_integer_enumeration_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1086,11 +1157,12 @@ def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive_integer_enumeration_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1101,11 +1173,12 @@ def test_list_non_positive_integer_enumeration_3_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive_integer_enumeration_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1116,11 +1189,12 @@ def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive_integer_enumeration_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1131,11 +1205,12 @@ def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive_integer_enumeration_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1146,11 +1221,12 @@ def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive_integer_enumeration_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1161,11 +1237,12 @@ def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive_integer_enumeration_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1176,11 +1253,12 @@ def test_list_non_positive_integer_enumeration_2_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive_integer_enumeration_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1191,11 +1269,12 @@ def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive_integer_enumeration_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1206,11 +1285,12 @@ def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive_integer_enumeration_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1221,11 +1301,12 @@ def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive_integer_enumeration_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1236,11 +1317,12 @@ def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive_integer_enumeration_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1251,11 +1333,12 @@ def test_list_non_positive_integer_enumeration_1_nistxml_sv_iv_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_integer_enumeration_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1266,11 +1349,12 @@ def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_integer_enumeration_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1281,11 +1365,12 @@ def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_integer_enumeration_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1296,11 +1381,12 @@ def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_integer_enumeration_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1311,11 +1397,12 @@ def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_integer_enumeration_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -1326,11 +1413,12 @@ def test_list_non_positive_integer_enumeration_nistxml_sv_iv_list_non_positive_i
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_integer_pattern_5_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1342,11 +1430,12 @@ def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_integer_pattern_5_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1358,11 +1447,12 @@ def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_integer_pattern_5_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1374,11 +1464,12 @@ def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_integer_pattern_5_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1390,11 +1481,12 @@ def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_integer_pattern_5_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1406,11 +1498,12 @@ def test_list_non_positive_integer_pattern_4_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_integer_pattern_4_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1423,11 +1516,12 @@ def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_integer_pattern_4_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1440,11 +1534,12 @@ def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_integer_pattern_4_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1457,11 +1552,12 @@ def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_integer_pattern_4_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1474,11 +1570,12 @@ def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_integer_pattern_4_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1491,11 +1588,12 @@ def test_list_non_positive_integer_pattern_3_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_integer_pattern_3_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1507,11 +1605,12 @@ def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_integer_pattern_3_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1523,11 +1622,12 @@ def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_integer_pattern_3_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1539,11 +1639,12 @@ def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_integer_pattern_3_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1555,11 +1656,12 @@ def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_integer_pattern_3_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1571,11 +1673,12 @@ def test_list_non_positive_integer_pattern_2_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_integer_pattern_2_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1587,11 +1690,12 @@ def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_integer_pattern_2_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1603,11 +1707,12 @@ def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_integer_pattern_2_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1619,11 +1724,12 @@ def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_integer_pattern_2_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1635,11 +1741,12 @@ def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_integer_pattern_2_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1651,11 +1758,12 @@ def test_list_non_positive_integer_pattern_1_nistxml_sv_iv_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integer_pattern_1_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1667,11 +1775,12 @@ def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integ
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integer_pattern_1_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1683,11 +1792,12 @@ def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integ
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integer_pattern_1_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1699,11 +1809,12 @@ def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integ
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integer_pattern_1_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1715,11 +1826,12 @@ def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integ
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integer_pattern_1_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1731,11 +1843,12 @@ def test_list_non_positive_integer_pattern_nistxml_sv_iv_list_non_positive_integ
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_integer_length_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1747,11 +1860,12 @@ def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_integer_length_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1763,11 +1877,12 @@ def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_integer_length_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1779,11 +1894,12 @@ def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_integer_length_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1795,11 +1911,12 @@ def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_integer_length_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1811,11 +1928,12 @@ def test_list_non_positive_integer_length_4_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_integer_length_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1827,11 +1945,12 @@ def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_integer_length_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1843,11 +1962,12 @@ def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_integer_length_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1859,11 +1979,12 @@ def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_integer_length_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1875,11 +1996,12 @@ def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_integer_length_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1891,11 +2013,12 @@ def test_list_non_positive_integer_length_3_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_integer_length_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1907,11 +2030,12 @@ def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_integer_length_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1923,11 +2047,12 @@ def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_integer_length_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1939,11 +2064,12 @@ def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_integer_length_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1955,11 +2081,12 @@ def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_integer_length_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1971,11 +2098,12 @@ def test_list_non_positive_integer_length_2_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_integer_length_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1987,11 +2115,12 @@ def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_integer_length_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2003,11 +2132,12 @@ def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_integer_length_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2019,11 +2149,12 @@ def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_integer_length_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2035,11 +2166,12 @@ def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_integer_length_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2051,11 +2183,12 @@ def test_list_non_positive_integer_length_1_nistxml_sv_iv_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_integer_length_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2067,11 +2200,12 @@ def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_intege
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_integer_length_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2083,11 +2217,12 @@ def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_intege
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_integer_length_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2099,11 +2234,12 @@ def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_intege
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_integer_length_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2115,11 +2251,12 @@ def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_intege
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_integer_length_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -2131,11 +2268,12 @@ def test_list_non_positive_integer_length_nistxml_sv_iv_list_non_positive_intege
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_integer_min_length_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2147,11 +2285,12 @@ def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_integer_min_length_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2163,11 +2302,12 @@ def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_integer_min_length_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2179,11 +2319,12 @@ def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_integer_min_length_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2195,11 +2336,12 @@ def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_integer_min_length_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2211,11 +2353,12 @@ def test_list_non_positive_integer_min_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_integer_min_length_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2227,11 +2370,12 @@ def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_integer_min_length_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2243,11 +2387,12 @@ def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_integer_min_length_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2259,11 +2404,12 @@ def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_integer_min_length_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2275,11 +2421,12 @@ def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_integer_min_length_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2291,11 +2438,12 @@ def test_list_non_positive_integer_min_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_integer_min_length_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2307,11 +2455,12 @@ def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_integer_min_length_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2323,11 +2472,12 @@ def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_integer_min_length_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2339,11 +2489,12 @@ def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_integer_min_length_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2355,11 +2506,12 @@ def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_integer_min_length_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2371,11 +2523,12 @@ def test_list_non_positive_integer_min_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_integer_min_length_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2387,11 +2540,12 @@ def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_integer_min_length_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2403,11 +2557,12 @@ def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_integer_min_length_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2419,11 +2574,12 @@ def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_integer_min_length_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2435,11 +2591,12 @@ def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_integer_min_length_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2451,11 +2608,12 @@ def test_list_non_positive_integer_min_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_integer_min_length_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2467,11 +2625,12 @@ def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_integer_min_length_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2483,11 +2642,12 @@ def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_integer_min_length_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2499,11 +2659,12 @@ def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_integer_min_length_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2515,11 +2676,12 @@ def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_integer_min_length_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -2531,11 +2693,12 @@ def test_list_non_positive_integer_min_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_integer_max_length_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2547,11 +2710,12 @@ def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_integer_max_length_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2563,11 +2727,12 @@ def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_integer_max_length_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2579,11 +2744,12 @@ def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_integer_max_length_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2595,11 +2761,12 @@ def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_integer_max_length_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2611,11 +2778,12 @@ def test_list_non_positive_integer_max_length_4_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_integer_max_length_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2627,11 +2795,12 @@ def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_integer_max_length_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2643,11 +2812,12 @@ def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_integer_max_length_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2659,11 +2829,12 @@ def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_integer_max_length_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2675,11 +2846,12 @@ def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_integer_max_length_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2691,11 +2863,12 @@ def test_list_non_positive_integer_max_length_3_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_integer_max_length_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2707,11 +2880,12 @@ def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_integer_max_length_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2723,11 +2897,12 @@ def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_integer_max_length_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2739,11 +2914,12 @@ def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_integer_max_length_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2755,11 +2931,12 @@ def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_integer_max_length_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2771,11 +2948,12 @@ def test_list_non_positive_integer_max_length_2_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_integer_max_length_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2787,11 +2965,12 @@ def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_integer_max_length_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2803,11 +2982,12 @@ def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_integer_max_length_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2819,11 +2999,12 @@ def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_integer_max_length_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2835,11 +3016,12 @@ def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_integer_max_length_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2851,11 +3033,12 @@ def test_list_non_positive_integer_max_length_1_nistxml_sv_iv_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_integer_max_length_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2867,11 +3050,12 @@ def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_integer_max_length_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2883,11 +3067,12 @@ def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_integer_max_length_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2899,11 +3084,12 @@ def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_integer_max_length_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2915,11 +3101,12 @@ def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_integer_max_length_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2931,11 +3118,12 @@ def test_list_non_positive_integer_max_length_nistxml_sv_iv_list_non_positive_in
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-list-nonPositiveInteger-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_1(save_xml):
     """
     Type list/integer is restricted by facet whiteSpace with value
@@ -2947,11 +3135,12 @@ def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_2(save_xml):
     """
     Type list/integer is restricted by facet whiteSpace with value
@@ -2963,11 +3152,12 @@ def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_3(save_xml):
     """
     Type list/integer is restricted by facet whiteSpace with value
@@ -2979,11 +3169,12 @@ def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_4(save_xml):
     """
     Type list/integer is restricted by facet whiteSpace with value
@@ -2995,11 +3186,12 @@ def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_5(save_xml):
     """
     Type list/integer is restricted by facet whiteSpace with value
@@ -3011,11 +3203,12 @@ def test_list_integer_white_space_nistxml_sv_iv_list_integer_white_space_1_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3026,11 +3219,12 @@ def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3041,11 +3235,12 @@ def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3056,11 +3251,12 @@ def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3071,11 +3267,12 @@ def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3086,11 +3283,12 @@ def test_list_integer_enumeration_4_nistxml_sv_iv_list_integer_enumeration_5_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3101,11 +3299,12 @@ def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3116,11 +3315,12 @@ def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3131,11 +3331,12 @@ def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3146,11 +3347,12 @@ def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3161,11 +3363,12 @@ def test_list_integer_enumeration_3_nistxml_sv_iv_list_integer_enumeration_4_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3176,11 +3379,12 @@ def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3191,11 +3395,12 @@ def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3206,11 +3411,12 @@ def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3221,11 +3427,12 @@ def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3236,11 +3443,12 @@ def test_list_integer_enumeration_2_nistxml_sv_iv_list_integer_enumeration_3_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3251,11 +3459,12 @@ def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3266,11 +3475,12 @@ def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3281,11 +3491,12 @@ def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3296,11 +3507,12 @@ def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3311,11 +3523,12 @@ def test_list_integer_enumeration_1_nistxml_sv_iv_list_integer_enumeration_2_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3326,11 +3539,12 @@ def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3341,11 +3555,12 @@ def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3356,11 +3571,12 @@ def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3371,11 +3587,12 @@ def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -3386,11 +3603,12 @@ def test_list_integer_enumeration_nistxml_sv_iv_list_integer_enumeration_1_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3402,11 +3620,12 @@ def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3418,11 +3637,12 @@ def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3434,11 +3654,12 @@ def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3450,11 +3671,12 @@ def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3466,11 +3688,12 @@ def test_list_integer_pattern_4_nistxml_sv_iv_list_integer_pattern_5_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3482,11 +3705,12 @@ def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3498,11 +3722,12 @@ def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3514,11 +3739,12 @@ def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3530,11 +3756,12 @@ def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3546,11 +3773,12 @@ def test_list_integer_pattern_3_nistxml_sv_iv_list_integer_pattern_4_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3562,11 +3790,12 @@ def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3578,11 +3807,12 @@ def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3594,11 +3824,12 @@ def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3610,11 +3841,12 @@ def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3626,11 +3858,12 @@ def test_list_integer_pattern_2_nistxml_sv_iv_list_integer_pattern_3_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3642,11 +3875,12 @@ def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3658,11 +3892,12 @@ def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3674,11 +3909,12 @@ def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3690,11 +3926,12 @@ def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3706,11 +3943,12 @@ def test_list_integer_pattern_1_nistxml_sv_iv_list_integer_pattern_2_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3722,11 +3960,12 @@ def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3738,11 +3977,12 @@ def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3754,11 +3994,12 @@ def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3770,11 +4011,12 @@ def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3786,11 +4028,12 @@ def test_list_integer_pattern_nistxml_sv_iv_list_integer_pattern_1_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3801,11 +4044,12 @@ def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3816,11 +4060,12 @@ def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3831,11 +4076,12 @@ def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3846,11 +4092,12 @@ def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3861,11 +4108,12 @@ def test_list_integer_length_4_nistxml_sv_iv_list_integer_length_5_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3876,11 +4124,12 @@ def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3891,11 +4140,12 @@ def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3906,11 +4156,12 @@ def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3921,11 +4172,12 @@ def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3936,11 +4188,12 @@ def test_list_integer_length_3_nistxml_sv_iv_list_integer_length_4_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3951,11 +4204,12 @@ def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3966,11 +4220,12 @@ def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3981,11 +4236,12 @@ def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3996,11 +4252,12 @@ def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -4011,11 +4268,12 @@ def test_list_integer_length_2_nistxml_sv_iv_list_integer_length_3_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -4026,11 +4284,12 @@ def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -4041,11 +4300,12 @@ def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -4056,11 +4316,12 @@ def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -4071,11 +4332,12 @@ def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -4086,11 +4348,12 @@ def test_list_integer_length_1_nistxml_sv_iv_list_integer_length_2_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -4101,11 +4364,12 @@ def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -4116,11 +4380,12 @@ def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -4131,11 +4396,12 @@ def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -4146,11 +4412,12 @@ def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -4161,11 +4428,12 @@ def test_list_integer_length_nistxml_sv_iv_list_integer_length_1_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -4176,11 +4444,12 @@ def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -4191,11 +4460,12 @@ def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -4206,11 +4476,12 @@ def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -4221,11 +4492,12 @@ def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -4236,11 +4508,12 @@ def test_list_integer_min_length_4_nistxml_sv_iv_list_integer_min_length_5_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -4251,11 +4524,12 @@ def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -4266,11 +4540,12 @@ def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -4281,11 +4556,12 @@ def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -4296,11 +4572,12 @@ def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -4311,11 +4588,12 @@ def test_list_integer_min_length_3_nistxml_sv_iv_list_integer_min_length_4_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -4326,11 +4604,12 @@ def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -4341,11 +4620,12 @@ def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -4356,11 +4636,12 @@ def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -4371,11 +4652,12 @@ def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -4386,11 +4668,12 @@ def test_list_integer_min_length_2_nistxml_sv_iv_list_integer_min_length_3_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -4401,11 +4684,12 @@ def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -4416,11 +4700,12 @@ def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -4431,11 +4716,12 @@ def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -4446,11 +4732,12 @@ def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -4461,11 +4748,12 @@ def test_list_integer_min_length_1_nistxml_sv_iv_list_integer_min_length_2_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -4476,11 +4764,12 @@ def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_1(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -4491,11 +4780,12 @@ def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_2(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -4506,11 +4796,12 @@ def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_3(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -4521,11 +4812,12 @@ def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_4(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -4536,11 +4828,12 @@ def test_list_integer_min_length_nistxml_sv_iv_list_integer_min_length_1_5(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -4551,11 +4844,12 @@ def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -4566,11 +4860,12 @@ def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -4581,11 +4876,12 @@ def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -4596,11 +4892,12 @@ def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -4611,11 +4908,12 @@ def test_list_integer_max_length_4_nistxml_sv_iv_list_integer_max_length_5_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4626,11 +4924,12 @@ def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4641,11 +4940,12 @@ def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4656,11 +4956,12 @@ def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4671,11 +4972,12 @@ def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4686,11 +4988,12 @@ def test_list_integer_max_length_3_nistxml_sv_iv_list_integer_max_length_4_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4701,11 +5004,12 @@ def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4716,11 +5020,12 @@ def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4731,11 +5036,12 @@ def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4746,11 +5052,12 @@ def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4761,11 +5068,12 @@ def test_list_integer_max_length_2_nistxml_sv_iv_list_integer_max_length_3_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4776,11 +5084,12 @@ def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4791,11 +5100,12 @@ def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4806,11 +5116,12 @@ def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4821,11 +5132,12 @@ def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4836,11 +5148,12 @@ def test_list_integer_max_length_1_nistxml_sv_iv_list_integer_max_length_2_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4851,11 +5164,12 @@ def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_1(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4866,11 +5180,12 @@ def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_2(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4881,11 +5196,12 @@ def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_3(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4896,11 +5212,12 @@ def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_4(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4911,11 +5228,12 @@ def test_list_integer_max_length_nistxml_sv_iv_list_integer_max_length_1_5(save_
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-IV-list-integer-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_1(save_xml):
     """
     Type list/decimal is restricted by facet whiteSpace with value
@@ -4927,11 +5245,12 @@ def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_2(save_xml):
     """
     Type list/decimal is restricted by facet whiteSpace with value
@@ -4943,11 +5262,12 @@ def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_3(save_xml):
     """
     Type list/decimal is restricted by facet whiteSpace with value
@@ -4959,11 +5279,12 @@ def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_4(save_xml):
     """
     Type list/decimal is restricted by facet whiteSpace with value
@@ -4975,11 +5296,12 @@ def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_5(save_xml):
     """
     Type list/decimal is restricted by facet whiteSpace with value
@@ -4991,11 +5313,12 @@ def test_list_decimal_white_space_nistxml_sv_iv_list_decimal_white_space_1_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5006,11 +5329,12 @@ def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5021,11 +5345,12 @@ def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5036,11 +5361,12 @@ def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5051,11 +5377,12 @@ def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5066,11 +5393,12 @@ def test_list_decimal_enumeration_4_nistxml_sv_iv_list_decimal_enumeration_5_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5081,11 +5409,12 @@ def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5096,11 +5425,12 @@ def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5111,11 +5441,12 @@ def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5126,11 +5457,12 @@ def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5141,11 +5473,12 @@ def test_list_decimal_enumeration_3_nistxml_sv_iv_list_decimal_enumeration_4_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5156,11 +5489,12 @@ def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5171,11 +5505,12 @@ def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5186,11 +5521,12 @@ def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5201,11 +5537,12 @@ def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5216,11 +5553,12 @@ def test_list_decimal_enumeration_2_nistxml_sv_iv_list_decimal_enumeration_3_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5231,11 +5569,12 @@ def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5246,11 +5585,12 @@ def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5261,11 +5601,12 @@ def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5276,11 +5617,12 @@ def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5291,11 +5633,12 @@ def test_list_decimal_enumeration_1_nistxml_sv_iv_list_decimal_enumeration_2_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5306,11 +5649,12 @@ def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5321,11 +5665,12 @@ def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5336,11 +5681,12 @@ def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5351,11 +5697,12 @@ def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -5366,11 +5713,12 @@ def test_list_decimal_enumeration_nistxml_sv_iv_list_decimal_enumeration_1_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5383,11 +5731,12 @@ def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5400,11 +5749,12 @@ def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5417,11 +5767,12 @@ def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5434,11 +5785,12 @@ def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5451,11 +5803,12 @@ def test_list_decimal_pattern_4_nistxml_sv_iv_list_decimal_pattern_5_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5468,11 +5821,12 @@ def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5485,11 +5839,12 @@ def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5502,11 +5857,12 @@ def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5519,11 +5875,12 @@ def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5536,11 +5893,12 @@ def test_list_decimal_pattern_3_nistxml_sv_iv_list_decimal_pattern_4_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5553,11 +5911,12 @@ def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5570,11 +5929,12 @@ def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5587,11 +5947,12 @@ def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5604,11 +5965,12 @@ def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5621,11 +5983,12 @@ def test_list_decimal_pattern_2_nistxml_sv_iv_list_decimal_pattern_3_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5638,11 +6001,12 @@ def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5655,11 +6019,12 @@ def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5672,11 +6037,12 @@ def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5689,11 +6055,12 @@ def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5706,11 +6073,12 @@ def test_list_decimal_pattern_1_nistxml_sv_iv_list_decimal_pattern_2_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5723,11 +6091,12 @@ def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5740,11 +6109,12 @@ def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5757,11 +6127,12 @@ def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5774,11 +6145,12 @@ def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -5791,11 +6163,12 @@ def test_list_decimal_pattern_nistxml_sv_iv_list_decimal_pattern_1_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5806,11 +6179,12 @@ def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5821,11 +6195,12 @@ def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5836,11 +6211,12 @@ def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5851,11 +6227,12 @@ def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5866,11 +6243,12 @@ def test_list_decimal_length_4_nistxml_sv_iv_list_decimal_length_5_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5881,11 +6259,12 @@ def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5896,11 +6275,12 @@ def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5911,11 +6291,12 @@ def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5926,11 +6307,12 @@ def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5941,11 +6323,12 @@ def test_list_decimal_length_3_nistxml_sv_iv_list_decimal_length_4_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5956,11 +6339,12 @@ def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5971,11 +6355,12 @@ def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5986,11 +6371,12 @@ def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -6001,11 +6387,12 @@ def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -6016,11 +6403,12 @@ def test_list_decimal_length_2_nistxml_sv_iv_list_decimal_length_3_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -6031,11 +6419,12 @@ def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -6046,11 +6435,12 @@ def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -6061,11 +6451,12 @@ def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -6076,11 +6467,12 @@ def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -6091,11 +6483,12 @@ def test_list_decimal_length_1_nistxml_sv_iv_list_decimal_length_2_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -6106,11 +6499,12 @@ def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -6121,11 +6515,12 @@ def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -6136,11 +6531,12 @@ def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -6151,11 +6547,12 @@ def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -6166,11 +6563,12 @@ def test_list_decimal_length_nistxml_sv_iv_list_decimal_length_1_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -6181,11 +6579,12 @@ def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -6196,11 +6595,12 @@ def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -6211,11 +6611,12 @@ def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -6226,11 +6627,12 @@ def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -6241,11 +6643,12 @@ def test_list_decimal_min_length_4_nistxml_sv_iv_list_decimal_min_length_5_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -6256,11 +6659,12 @@ def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -6271,11 +6675,12 @@ def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -6286,11 +6691,12 @@ def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -6301,11 +6707,12 @@ def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -6316,11 +6723,12 @@ def test_list_decimal_min_length_3_nistxml_sv_iv_list_decimal_min_length_4_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -6331,11 +6739,12 @@ def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -6346,11 +6755,12 @@ def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -6361,11 +6771,12 @@ def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -6376,11 +6787,12 @@ def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -6391,11 +6803,12 @@ def test_list_decimal_min_length_2_nistxml_sv_iv_list_decimal_min_length_3_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -6406,11 +6819,12 @@ def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -6421,11 +6835,12 @@ def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -6436,11 +6851,12 @@ def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -6451,11 +6867,12 @@ def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -6466,11 +6883,12 @@ def test_list_decimal_min_length_1_nistxml_sv_iv_list_decimal_min_length_2_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -6481,11 +6899,12 @@ def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_1(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -6496,11 +6915,12 @@ def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_2(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -6511,11 +6931,12 @@ def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_3(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -6526,11 +6947,12 @@ def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_4(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -6541,11 +6963,12 @@ def test_list_decimal_min_length_nistxml_sv_iv_list_decimal_min_length_1_5(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -6556,11 +6979,12 @@ def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -6571,11 +6995,12 @@ def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -6586,11 +7011,12 @@ def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -6601,11 +7027,12 @@ def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -6616,11 +7043,12 @@ def test_list_decimal_max_length_4_nistxml_sv_iv_list_decimal_max_length_5_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -6631,11 +7059,12 @@ def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -6646,11 +7075,12 @@ def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -6661,11 +7091,12 @@ def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -6676,11 +7107,12 @@ def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -6691,11 +7123,12 @@ def test_list_decimal_max_length_3_nistxml_sv_iv_list_decimal_max_length_4_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6706,11 +7139,12 @@ def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6721,11 +7155,12 @@ def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6736,11 +7171,12 @@ def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6751,11 +7187,12 @@ def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6766,11 +7203,12 @@ def test_list_decimal_max_length_2_nistxml_sv_iv_list_decimal_max_length_3_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6781,11 +7219,12 @@ def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6796,11 +7235,12 @@ def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6811,11 +7251,12 @@ def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6826,11 +7267,12 @@ def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6841,11 +7283,12 @@ def test_list_decimal_max_length_1_nistxml_sv_iv_list_decimal_max_length_2_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6856,11 +7299,12 @@ def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_1(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6871,11 +7315,12 @@ def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_2(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6886,11 +7331,12 @@ def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_3(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6901,11 +7347,12 @@ def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_4(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6916,11 +7363,12 @@ def test_list_decimal_max_length_nistxml_sv_iv_list_decimal_max_length_1_5(save_
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-IV-list-decimal-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -6931,11 +7379,12 @@ def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -6946,11 +7395,12 @@ def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -6961,11 +7411,12 @@ def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -6976,11 +7427,12 @@ def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -6991,11 +7443,12 @@ def test_atomic_any_uri_enumeration_9_nistxml_sv_ii_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7006,11 +7459,12 @@ def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7021,11 +7475,12 @@ def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7036,11 +7491,12 @@ def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7051,11 +7507,12 @@ def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7066,11 +7523,12 @@ def test_atomic_any_uri_enumeration_8_nistxml_sv_ii_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7081,11 +7539,12 @@ def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7096,11 +7555,12 @@ def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7111,11 +7571,12 @@ def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7126,11 +7587,12 @@ def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7141,11 +7603,12 @@ def test_atomic_any_uri_enumeration_7_nistxml_sv_ii_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7156,11 +7619,12 @@ def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7171,11 +7635,12 @@ def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7186,11 +7651,12 @@ def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7201,11 +7667,12 @@ def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7216,11 +7683,12 @@ def test_atomic_any_uri_enumeration_6_nistxml_sv_ii_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7231,11 +7699,12 @@ def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7246,11 +7715,12 @@ def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7261,11 +7731,12 @@ def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7276,11 +7747,12 @@ def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -7291,11 +7763,12 @@ def test_atomic_any_uri_enumeration_5_nistxml_sv_ii_atomic_any_uri_enumeration_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7307,11 +7780,12 @@ def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7323,11 +7797,12 @@ def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7339,11 +7814,12 @@ def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7355,11 +7831,12 @@ def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7371,11 +7848,12 @@ def test_atomic_any_uri_pattern_9_nistxml_sv_ii_atomic_any_uri_pattern_5_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7387,11 +7865,12 @@ def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7403,11 +7882,12 @@ def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7419,11 +7899,12 @@ def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7435,11 +7916,12 @@ def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7451,11 +7933,12 @@ def test_atomic_any_uri_pattern_8_nistxml_sv_ii_atomic_any_uri_pattern_4_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7467,11 +7950,12 @@ def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7483,11 +7967,12 @@ def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7499,11 +7984,12 @@ def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7515,11 +8001,12 @@ def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7531,11 +8018,12 @@ def test_atomic_any_uri_pattern_7_nistxml_sv_ii_atomic_any_uri_pattern_3_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7547,11 +8035,12 @@ def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7563,11 +8052,12 @@ def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7579,11 +8069,12 @@ def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7595,11 +8086,12 @@ def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7611,11 +8103,12 @@ def test_atomic_any_uri_pattern_6_nistxml_sv_ii_atomic_any_uri_pattern_2_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7627,11 +8120,12 @@ def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7643,11 +8137,12 @@ def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7659,11 +8154,12 @@ def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7675,11 +8171,12 @@ def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -7691,11 +8188,12 @@ def test_atomic_any_uri_pattern_5_nistxml_sv_ii_atomic_any_uri_pattern_1_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7706,11 +8204,12 @@ def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7721,11 +8220,12 @@ def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7736,11 +8236,12 @@ def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7751,11 +8252,12 @@ def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7766,11 +8268,12 @@ def test_atomic_language_length_9_nistxml_sv_ii_atomic_language_length_5_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7781,11 +8284,12 @@ def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7796,11 +8300,12 @@ def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7811,11 +8316,12 @@ def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7826,11 +8332,12 @@ def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7841,11 +8348,12 @@ def test_atomic_language_length_8_nistxml_sv_ii_atomic_language_length_4_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7856,11 +8364,12 @@ def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7871,11 +8380,12 @@ def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7886,11 +8396,12 @@ def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7901,11 +8412,12 @@ def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7916,11 +8428,12 @@ def test_atomic_language_length_7_nistxml_sv_ii_atomic_language_length_3_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 6.
@@ -7931,11 +8444,12 @@ def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 6.
@@ -7946,11 +8460,12 @@ def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 6.
@@ -7961,11 +8476,12 @@ def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 6.
@@ -7976,11 +8492,12 @@ def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 6.
@@ -7991,11 +8508,12 @@ def test_atomic_language_length_6_nistxml_sv_ii_atomic_language_length_2_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -8006,11 +8524,12 @@ def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -8021,11 +8540,12 @@ def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -8036,11 +8556,12 @@ def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -8051,11 +8572,12 @@ def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -8066,11 +8588,12 @@ def test_atomic_language_length_5_nistxml_sv_ii_atomic_language_length_1_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -8081,11 +8604,12 @@ def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -8096,11 +8620,12 @@ def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -8111,11 +8636,12 @@ def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -8126,11 +8652,12 @@ def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -8141,11 +8668,12 @@ def test_atomic_any_uri_length_9_nistxml_sv_ii_atomic_any_uri_length_5_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 14.
@@ -8156,11 +8684,12 @@ def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 14.
@@ -8171,11 +8700,12 @@ def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 14.
@@ -8186,11 +8716,12 @@ def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 14.
@@ -8201,11 +8732,12 @@ def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 14.
@@ -8216,11 +8748,12 @@ def test_atomic_any_uri_length_8_nistxml_sv_ii_atomic_any_uri_length_4_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 15.
@@ -8231,11 +8764,12 @@ def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 15.
@@ -8246,11 +8780,12 @@ def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 15.
@@ -8261,11 +8796,12 @@ def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 15.
@@ -8276,11 +8812,12 @@ def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 15.
@@ -8291,11 +8828,12 @@ def test_atomic_any_uri_length_7_nistxml_sv_ii_atomic_any_uri_length_3_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 53.
@@ -8306,11 +8844,12 @@ def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 53.
@@ -8321,11 +8860,12 @@ def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 53.
@@ -8336,11 +8876,12 @@ def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 53.
@@ -8351,11 +8892,12 @@ def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 53.
@@ -8366,11 +8908,12 @@ def test_atomic_any_uri_length_6_nistxml_sv_ii_atomic_any_uri_length_2_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -8381,11 +8924,12 @@ def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -8396,11 +8940,12 @@ def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -8411,11 +8956,12 @@ def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -8426,11 +8972,12 @@ def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -8441,11 +8988,12 @@ def test_atomic_any_uri_length_5_nistxml_sv_ii_atomic_any_uri_length_1_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 8.
@@ -8456,11 +9004,12 @@ def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 8.
@@ -8471,11 +9020,12 @@ def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 8.
@@ -8486,11 +9036,12 @@ def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 8.
@@ -8501,11 +9052,12 @@ def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 8.
@@ -8516,11 +9068,12 @@ def test_atomic_language_max_length_9_nistxml_sv_ii_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 7.
@@ -8531,11 +9084,12 @@ def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 7.
@@ -8546,11 +9100,12 @@ def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 7.
@@ -8561,11 +9116,12 @@ def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 7.
@@ -8576,11 +9132,12 @@ def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 7.
@@ -8591,11 +9148,12 @@ def test_atomic_language_max_length_8_nistxml_sv_ii_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8606,11 +9164,12 @@ def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8621,11 +9180,12 @@ def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8636,11 +9196,12 @@ def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8651,11 +9212,12 @@ def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8666,11 +9228,12 @@ def test_atomic_language_max_length_7_nistxml_sv_ii_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 5.
@@ -8681,11 +9244,12 @@ def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 5.
@@ -8696,11 +9260,12 @@ def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 5.
@@ -8711,11 +9276,12 @@ def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 5.
@@ -8726,11 +9292,12 @@ def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 5.
@@ -8741,11 +9308,12 @@ def test_atomic_language_max_length_6_nistxml_sv_ii_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8756,11 +9324,12 @@ def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8771,11 +9340,12 @@ def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8786,11 +9356,12 @@ def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8801,11 +9372,12 @@ def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8816,11 +9388,12 @@ def test_atomic_language_max_length_5_nistxml_sv_ii_atomic_language_max_length_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -8831,11 +9404,12 @@ def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -8846,11 +9420,12 @@ def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -8861,11 +9436,12 @@ def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -8876,11 +9452,12 @@ def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -8891,11 +9468,12 @@ def test_atomic_language_min_length_8_nistxml_sv_ii_atomic_language_min_length_6
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8906,11 +9484,12 @@ def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8921,11 +9500,12 @@ def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8936,11 +9516,12 @@ def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8951,11 +9532,12 @@ def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8966,11 +9548,12 @@ def test_atomic_language_min_length_7_nistxml_sv_ii_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -8981,11 +9564,12 @@ def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -8996,11 +9580,12 @@ def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9011,11 +9596,12 @@ def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9026,11 +9612,12 @@ def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9041,11 +9628,12 @@ def test_atomic_language_min_length_6_nistxml_sv_ii_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9056,11 +9644,12 @@ def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9071,11 +9660,12 @@ def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9086,11 +9676,12 @@ def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9101,11 +9692,12 @@ def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 6.
@@ -9116,11 +9708,12 @@ def test_atomic_language_min_length_5_nistxml_sv_ii_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-II-atomic-language-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 17.
@@ -9131,11 +9724,12 @@ def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 17.
@@ -9146,11 +9740,12 @@ def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 17.
@@ -9161,11 +9756,12 @@ def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 17.
@@ -9176,11 +9772,12 @@ def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 17.
@@ -9191,11 +9788,12 @@ def test_atomic_any_uri_max_length_9_nistxml_sv_ii_atomic_any_uri_max_length_5_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 37.
@@ -9206,11 +9804,12 @@ def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 37.
@@ -9221,11 +9820,12 @@ def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 37.
@@ -9236,11 +9836,12 @@ def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 37.
@@ -9251,11 +9852,12 @@ def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 37.
@@ -9266,11 +9868,12 @@ def test_atomic_any_uri_max_length_8_nistxml_sv_ii_atomic_any_uri_max_length_4_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 33.
@@ -9281,11 +9884,12 @@ def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 33.
@@ -9296,11 +9900,12 @@ def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 33.
@@ -9311,11 +9916,12 @@ def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 33.
@@ -9326,11 +9932,12 @@ def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 33.
@@ -9341,11 +9948,12 @@ def test_atomic_any_uri_max_length_7_nistxml_sv_ii_atomic_any_uri_max_length_3_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 60.
@@ -9356,11 +9964,12 @@ def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 60.
@@ -9371,11 +9980,12 @@ def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 60.
@@ -9386,11 +9996,12 @@ def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 60.
@@ -9401,11 +10012,12 @@ def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 60.
@@ -9416,11 +10028,12 @@ def test_atomic_any_uri_max_length_6_nistxml_sv_ii_atomic_any_uri_max_length_2_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -9431,11 +10044,12 @@ def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -9446,11 +10060,12 @@ def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -9461,11 +10076,12 @@ def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -9476,11 +10092,12 @@ def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -9491,11 +10108,12 @@ def test_atomic_any_uri_max_length_5_nistxml_sv_ii_atomic_any_uri_max_length_1_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -9506,11 +10124,12 @@ def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -9521,11 +10140,12 @@ def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -9536,11 +10156,12 @@ def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -9551,11 +10172,12 @@ def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -9566,11 +10188,12 @@ def test_atomic_any_uri_min_length_9_nistxml_sv_ii_atomic_any_uri_min_length_6_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 47.
@@ -9581,11 +10204,12 @@ def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 47.
@@ -9596,11 +10220,12 @@ def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 47.
@@ -9611,11 +10236,12 @@ def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 47.
@@ -9626,11 +10252,12 @@ def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 47.
@@ -9641,11 +10268,12 @@ def test_atomic_any_uri_min_length_8_nistxml_sv_ii_atomic_any_uri_min_length_5_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 48.
@@ -9656,11 +10284,12 @@ def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 48.
@@ -9671,11 +10300,12 @@ def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 48.
@@ -9686,11 +10316,12 @@ def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 48.
@@ -9701,11 +10332,12 @@ def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 48.
@@ -9716,11 +10348,12 @@ def test_atomic_any_uri_min_length_7_nistxml_sv_ii_atomic_any_uri_min_length_4_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 32.
@@ -9731,11 +10364,12 @@ def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 32.
@@ -9746,11 +10380,12 @@ def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 32.
@@ -9761,11 +10396,12 @@ def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 32.
@@ -9776,11 +10412,12 @@ def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 32.
@@ -9791,11 +10428,12 @@ def test_atomic_any_uri_min_length_6_nistxml_sv_ii_atomic_any_uri_min_length_3_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 25.
@@ -9806,11 +10444,12 @@ def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 25.
@@ -9821,11 +10460,12 @@ def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 25.
@@ -9836,11 +10476,12 @@ def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 25.
@@ -9851,11 +10492,12 @@ def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 25.
@@ -9866,11 +10508,12 @@ def test_atomic_any_uri_min_length_5_nistxml_sv_ii_atomic_any_uri_min_length_2_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-II-atomic-anyURI-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9881,11 +10524,12 @@ def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-5-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9896,11 +10540,12 @@ def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-5-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9911,11 +10556,12 @@ def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-5-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9926,11 +10572,12 @@ def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-5-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9941,11 +10588,12 @@ def test_atomic_id_length_9_nistxml_sv_ii_atomic_id_length_5_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-5-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 51.
@@ -9956,11 +10604,12 @@ def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-4-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 51.
@@ -9971,11 +10620,12 @@ def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-4-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 51.
@@ -9986,11 +10636,12 @@ def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-4-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 51.
@@ -10001,11 +10652,12 @@ def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-4-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 51.
@@ -10016,11 +10668,12 @@ def test_atomic_id_length_8_nistxml_sv_ii_atomic_id_length_4_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-4-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 3.
@@ -10031,11 +10684,12 @@ def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-3-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 3.
@@ -10046,11 +10700,12 @@ def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-3-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 3.
@@ -10061,11 +10716,12 @@ def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-3-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 3.
@@ -10076,11 +10732,12 @@ def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-3-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 3.
@@ -10091,11 +10748,12 @@ def test_atomic_id_length_7_nistxml_sv_ii_atomic_id_length_3_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-3-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 33.
@@ -10106,11 +10764,12 @@ def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-2-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 33.
@@ -10121,11 +10780,12 @@ def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-2-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 33.
@@ -10136,11 +10796,12 @@ def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-2-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 33.
@@ -10151,11 +10812,12 @@ def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-2-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 33.
@@ -10166,11 +10828,12 @@ def test_atomic_id_length_6_nistxml_sv_ii_atomic_id_length_2_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-2-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -10181,11 +10844,12 @@ def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-1-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -10196,11 +10860,12 @@ def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-1-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -10211,11 +10876,12 @@ def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-1-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -10226,11 +10892,12 @@ def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-1-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -10241,11 +10908,12 @@ def test_atomic_id_length_5_nistxml_sv_ii_atomic_id_length_1_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-length-1-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10256,11 +10924,12 @@ def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10271,11 +10940,12 @@ def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10286,11 +10956,12 @@ def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10301,11 +10972,12 @@ def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10316,11 +10988,12 @@ def test_atomic_id_max_length_9_nistxml_sv_ii_atomic_id_max_length_5_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 25.
@@ -10331,11 +11004,12 @@ def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 25.
@@ -10346,11 +11020,12 @@ def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 25.
@@ -10361,11 +11036,12 @@ def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 25.
@@ -10376,11 +11052,12 @@ def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 25.
@@ -10391,11 +11068,12 @@ def test_atomic_id_max_length_8_nistxml_sv_ii_atomic_id_max_length_4_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10406,11 +11084,12 @@ def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10421,11 +11100,12 @@ def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10436,11 +11116,12 @@ def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10451,11 +11132,12 @@ def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10466,11 +11148,12 @@ def test_atomic_id_max_length_7_nistxml_sv_ii_atomic_id_max_length_3_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 7.
@@ -10481,11 +11164,12 @@ def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 7.
@@ -10496,11 +11180,12 @@ def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 7.
@@ -10511,11 +11196,12 @@ def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 7.
@@ -10526,11 +11212,12 @@ def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 7.
@@ -10541,11 +11228,12 @@ def test_atomic_id_max_length_6_nistxml_sv_ii_atomic_id_max_length_2_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10556,11 +11244,12 @@ def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10571,11 +11260,12 @@ def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10586,11 +11276,12 @@ def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10601,11 +11292,12 @@ def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10616,11 +11308,12 @@ def test_atomic_id_max_length_5_nistxml_sv_ii_atomic_id_max_length_1_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -10631,11 +11324,12 @@ def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -10646,11 +11340,12 @@ def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -10661,11 +11356,12 @@ def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -10676,11 +11372,12 @@ def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -10691,11 +11388,12 @@ def test_atomic_ncname_length_9_nistxml_sv_ii_atomic_ncname_length_5_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 52.
@@ -10706,11 +11404,12 @@ def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 52.
@@ -10721,11 +11420,12 @@ def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 52.
@@ -10736,11 +11436,12 @@ def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 52.
@@ -10751,11 +11452,12 @@ def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 52.
@@ -10766,11 +11468,12 @@ def test_atomic_ncname_length_8_nistxml_sv_ii_atomic_ncname_length_4_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 11.
@@ -10781,11 +11484,12 @@ def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 11.
@@ -10796,11 +11500,12 @@ def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 11.
@@ -10811,11 +11516,12 @@ def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 11.
@@ -10826,11 +11532,12 @@ def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 11.
@@ -10841,11 +11548,12 @@ def test_atomic_ncname_length_7_nistxml_sv_ii_atomic_ncname_length_3_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 48.
@@ -10856,11 +11564,12 @@ def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 48.
@@ -10871,11 +11580,12 @@ def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 48.
@@ -10886,11 +11596,12 @@ def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 48.
@@ -10901,11 +11612,12 @@ def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 48.
@@ -10916,11 +11628,12 @@ def test_atomic_ncname_length_6_nistxml_sv_ii_atomic_ncname_length_2_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -10931,11 +11644,12 @@ def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -10946,11 +11660,12 @@ def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -10961,11 +11676,12 @@ def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -10976,11 +11692,12 @@ def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -10991,11 +11708,12 @@ def test_atomic_ncname_length_5_nistxml_sv_ii_atomic_ncname_length_1_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -11006,11 +11724,12 @@ def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -11021,11 +11740,12 @@ def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -11036,11 +11756,12 @@ def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -11051,11 +11772,12 @@ def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -11066,11 +11788,12 @@ def test_atomic_ncname_max_length_9_nistxml_sv_ii_atomic_ncname_max_length_5_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 20.
@@ -11081,11 +11804,12 @@ def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 20.
@@ -11096,11 +11820,12 @@ def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 20.
@@ -11111,11 +11836,12 @@ def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 20.
@@ -11126,11 +11852,12 @@ def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 20.
@@ -11141,11 +11868,12 @@ def test_atomic_ncname_max_length_8_nistxml_sv_ii_atomic_ncname_max_length_4_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 56.
@@ -11156,11 +11884,12 @@ def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 56.
@@ -11171,11 +11900,12 @@ def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 56.
@@ -11186,11 +11916,12 @@ def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 56.
@@ -11201,11 +11932,12 @@ def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 56.
@@ -11216,11 +11948,12 @@ def test_atomic_ncname_max_length_7_nistxml_sv_ii_atomic_ncname_max_length_3_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 24.
@@ -11231,11 +11964,12 @@ def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 24.
@@ -11246,11 +11980,12 @@ def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 24.
@@ -11261,11 +11996,12 @@ def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 24.
@@ -11276,11 +12012,12 @@ def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 24.
@@ -11291,11 +12028,12 @@ def test_atomic_ncname_max_length_6_nistxml_sv_ii_atomic_ncname_max_length_2_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -11306,11 +12044,12 @@ def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -11321,11 +12060,12 @@ def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -11336,11 +12076,12 @@ def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -11351,11 +12092,12 @@ def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -11366,11 +12108,12 @@ def test_atomic_ncname_max_length_5_nistxml_sv_ii_atomic_ncname_max_length_1_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -11381,11 +12124,12 @@ def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -11396,11 +12140,12 @@ def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -11411,11 +12156,12 @@ def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -11426,11 +12172,12 @@ def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -11441,11 +12188,12 @@ def test_atomic_nmtoken_length_9_nistxml_sv_ii_atomic_nmtoken_length_5_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 52.
@@ -11456,11 +12204,12 @@ def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 52.
@@ -11471,11 +12220,12 @@ def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 52.
@@ -11486,11 +12236,12 @@ def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 52.
@@ -11501,11 +12252,12 @@ def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 52.
@@ -11516,11 +12268,12 @@ def test_atomic_nmtoken_length_8_nistxml_sv_ii_atomic_nmtoken_length_4_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 50.
@@ -11531,11 +12284,12 @@ def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 50.
@@ -11546,11 +12300,12 @@ def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 50.
@@ -11561,11 +12316,12 @@ def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 50.
@@ -11576,11 +12332,12 @@ def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 50.
@@ -11591,11 +12348,12 @@ def test_atomic_nmtoken_length_7_nistxml_sv_ii_atomic_nmtoken_length_3_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 9.
@@ -11606,11 +12364,12 @@ def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 9.
@@ -11621,11 +12380,12 @@ def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 9.
@@ -11636,11 +12396,12 @@ def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 9.
@@ -11651,11 +12412,12 @@ def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 9.
@@ -11666,11 +12428,12 @@ def test_atomic_nmtoken_length_6_nistxml_sv_ii_atomic_nmtoken_length_2_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -11681,11 +12444,12 @@ def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -11696,11 +12460,12 @@ def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -11711,11 +12476,12 @@ def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -11726,11 +12492,12 @@ def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -11741,11 +12508,12 @@ def test_atomic_nmtoken_length_5_nistxml_sv_ii_atomic_nmtoken_length_1_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -11756,11 +12524,12 @@ def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -11771,11 +12540,12 @@ def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -11786,11 +12556,12 @@ def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -11801,11 +12572,12 @@ def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -11816,11 +12588,12 @@ def test_atomic_nmtoken_max_length_9_nistxml_sv_ii_atomic_nmtoken_max_length_5_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 27.
@@ -11831,11 +12604,12 @@ def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 27.
@@ -11846,11 +12620,12 @@ def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 27.
@@ -11861,11 +12636,12 @@ def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 27.
@@ -11876,11 +12652,12 @@ def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 27.
@@ -11891,11 +12668,12 @@ def test_atomic_nmtoken_max_length_8_nistxml_sv_ii_atomic_nmtoken_max_length_4_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 21.
@@ -11906,11 +12684,12 @@ def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 21.
@@ -11921,11 +12700,12 @@ def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 21.
@@ -11936,11 +12716,12 @@ def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 21.
@@ -11951,11 +12732,12 @@ def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 21.
@@ -11966,11 +12748,12 @@ def test_atomic_nmtoken_max_length_7_nistxml_sv_ii_atomic_nmtoken_max_length_3_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 50.
@@ -11981,11 +12764,12 @@ def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 50.
@@ -11996,11 +12780,12 @@ def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 50.
@@ -12011,11 +12796,12 @@ def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 50.
@@ -12026,11 +12812,12 @@ def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 50.
@@ -12041,11 +12828,12 @@ def test_atomic_nmtoken_max_length_6_nistxml_sv_ii_atomic_nmtoken_max_length_2_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -12056,11 +12844,12 @@ def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -12071,11 +12860,12 @@ def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -12086,11 +12876,12 @@ def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -12101,11 +12892,12 @@ def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -12116,11 +12908,12 @@ def test_atomic_nmtoken_max_length_5_nistxml_sv_ii_atomic_nmtoken_max_length_1_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -12131,11 +12924,12 @@ def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -12146,11 +12940,12 @@ def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -12161,11 +12956,12 @@ def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -12176,11 +12972,12 @@ def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -12191,11 +12988,12 @@ def test_atomic_name_length_9_nistxml_sv_ii_atomic_name_length_5_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 31.
@@ -12206,11 +13004,12 @@ def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 31.
@@ -12221,11 +13020,12 @@ def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 31.
@@ -12236,11 +13036,12 @@ def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 31.
@@ -12251,11 +13052,12 @@ def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 31.
@@ -12266,11 +13068,12 @@ def test_atomic_name_length_8_nistxml_sv_ii_atomic_name_length_4_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 29.
@@ -12281,11 +13084,12 @@ def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 29.
@@ -12296,11 +13100,12 @@ def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 29.
@@ -12311,11 +13116,12 @@ def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 29.
@@ -12326,11 +13132,12 @@ def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 29.
@@ -12341,11 +13148,12 @@ def test_atomic_name_length_7_nistxml_sv_ii_atomic_name_length_3_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 38.
@@ -12356,11 +13164,12 @@ def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 38.
@@ -12371,11 +13180,12 @@ def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 38.
@@ -12386,11 +13196,12 @@ def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 38.
@@ -12401,11 +13212,12 @@ def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 38.
@@ -12416,11 +13228,12 @@ def test_atomic_name_length_6_nistxml_sv_ii_atomic_name_length_2_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -12431,11 +13244,12 @@ def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -12446,11 +13260,12 @@ def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -12461,11 +13276,12 @@ def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -12476,11 +13292,12 @@ def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -12491,11 +13308,12 @@ def test_atomic_name_length_5_nistxml_sv_ii_atomic_name_length_1_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -12506,11 +13324,12 @@ def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -12521,11 +13340,12 @@ def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -12536,11 +13356,12 @@ def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -12551,11 +13372,12 @@ def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -12566,11 +13388,12 @@ def test_atomic_name_max_length_9_nistxml_sv_ii_atomic_name_max_length_5_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 53.
@@ -12581,11 +13404,12 @@ def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 53.
@@ -12596,11 +13420,12 @@ def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 53.
@@ -12611,11 +13436,12 @@ def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 53.
@@ -12626,11 +13452,12 @@ def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 53.
@@ -12641,11 +13468,12 @@ def test_atomic_name_max_length_8_nistxml_sv_ii_atomic_name_max_length_4_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 39.
@@ -12656,11 +13484,12 @@ def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 39.
@@ -12671,11 +13500,12 @@ def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 39.
@@ -12686,11 +13516,12 @@ def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 39.
@@ -12701,11 +13532,12 @@ def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 39.
@@ -12716,11 +13548,12 @@ def test_atomic_name_max_length_7_nistxml_sv_ii_atomic_name_max_length_3_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 31.
@@ -12731,11 +13564,12 @@ def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 31.
@@ -12746,11 +13580,12 @@ def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 31.
@@ -12761,11 +13596,12 @@ def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 31.
@@ -12776,11 +13612,12 @@ def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 31.
@@ -12791,11 +13628,12 @@ def test_atomic_name_max_length_6_nistxml_sv_ii_atomic_name_max_length_2_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -12806,11 +13644,12 @@ def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -12821,11 +13660,12 @@ def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -12836,11 +13676,12 @@ def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -12851,11 +13692,12 @@ def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -12866,11 +13708,12 @@ def test_atomic_name_max_length_5_nistxml_sv_ii_atomic_name_max_length_1_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -12881,11 +13724,12 @@ def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -12896,11 +13740,12 @@ def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -12911,11 +13756,12 @@ def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -12926,11 +13772,12 @@ def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -12941,11 +13788,12 @@ def test_atomic_token_length_9_nistxml_sv_ii_atomic_token_length_5_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 645.
@@ -12956,11 +13804,12 @@ def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 645.
@@ -12971,11 +13820,12 @@ def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 645.
@@ -12986,11 +13836,12 @@ def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 645.
@@ -13001,11 +13852,12 @@ def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 645.
@@ -13016,11 +13868,12 @@ def test_atomic_token_length_8_nistxml_sv_ii_atomic_token_length_4_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 780.
@@ -13031,11 +13884,12 @@ def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 780.
@@ -13046,11 +13900,12 @@ def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 780.
@@ -13061,11 +13916,12 @@ def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 780.
@@ -13076,11 +13932,12 @@ def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 780.
@@ -13091,11 +13948,12 @@ def test_atomic_token_length_7_nistxml_sv_ii_atomic_token_length_3_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 370.
@@ -13106,11 +13964,12 @@ def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 370.
@@ -13121,11 +13980,12 @@ def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 370.
@@ -13136,11 +13996,12 @@ def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 370.
@@ -13151,11 +14012,12 @@ def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 370.
@@ -13166,11 +14028,12 @@ def test_atomic_token_length_6_nistxml_sv_ii_atomic_token_length_2_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -13181,11 +14044,12 @@ def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -13196,11 +14060,12 @@ def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -13211,11 +14076,12 @@ def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -13226,11 +14092,12 @@ def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -13241,11 +14108,12 @@ def test_atomic_token_length_5_nistxml_sv_ii_atomic_token_length_1_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -13256,11 +14124,12 @@ def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -13271,11 +14140,12 @@ def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -13286,11 +14156,12 @@ def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -13301,11 +14172,12 @@ def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -13316,11 +14188,12 @@ def test_atomic_token_max_length_9_nistxml_sv_ii_atomic_token_max_length_5_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 720.
@@ -13331,11 +14204,12 @@ def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 720.
@@ -13346,11 +14220,12 @@ def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 720.
@@ -13361,11 +14236,12 @@ def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 720.
@@ -13376,11 +14252,12 @@ def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 720.
@@ -13391,11 +14268,12 @@ def test_atomic_token_max_length_8_nistxml_sv_ii_atomic_token_max_length_4_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 664.
@@ -13406,11 +14284,12 @@ def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 664.
@@ -13421,11 +14300,12 @@ def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 664.
@@ -13436,11 +14316,12 @@ def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 664.
@@ -13451,11 +14332,12 @@ def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 664.
@@ -13466,11 +14348,12 @@ def test_atomic_token_max_length_7_nistxml_sv_ii_atomic_token_max_length_3_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 576.
@@ -13481,11 +14364,12 @@ def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 576.
@@ -13496,11 +14380,12 @@ def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 576.
@@ -13511,11 +14396,12 @@ def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 576.
@@ -13526,11 +14412,12 @@ def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 576.
@@ -13541,11 +14428,12 @@ def test_atomic_token_max_length_6_nistxml_sv_ii_atomic_token_max_length_2_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -13556,11 +14444,12 @@ def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -13571,11 +14460,12 @@ def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -13586,11 +14476,12 @@ def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -13601,11 +14492,12 @@ def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -13616,11 +14508,12 @@ def test_atomic_token_max_length_5_nistxml_sv_ii_atomic_token_max_length_1_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_string_length_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13632,11 +14525,12 @@ def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_string_length_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13648,11 +14542,12 @@ def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_string_length_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13664,11 +14559,12 @@ def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_string_length_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13680,11 +14576,12 @@ def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_string_length_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13696,11 +14593,12 @@ def test_atomic_normalized_string_length_9_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_string_length_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13712,11 +14610,12 @@ def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_string_length_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13728,11 +14627,12 @@ def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_string_length_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13744,11 +14644,12 @@ def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_string_length_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13760,11 +14661,12 @@ def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_string_length_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13776,11 +14678,12 @@ def test_atomic_normalized_string_length_8_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_string_length_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13792,11 +14695,12 @@ def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_string_length_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13808,11 +14712,12 @@ def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_string_length_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13824,11 +14729,12 @@ def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_string_length_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13840,11 +14746,12 @@ def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_string_length_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13856,11 +14763,12 @@ def test_atomic_normalized_string_length_7_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_string_length_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13872,11 +14780,12 @@ def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_string_length_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13888,11 +14797,12 @@ def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_string_length_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13904,11 +14814,12 @@ def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_string_length_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13920,11 +14831,12 @@ def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_string_length_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13936,11 +14848,12 @@ def test_atomic_normalized_string_length_6_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_string_length_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13952,11 +14865,12 @@ def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_string_length_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13968,11 +14882,12 @@ def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_string_length_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -13984,11 +14899,12 @@ def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_string_length_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -14000,11 +14916,12 @@ def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_string_length_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -14016,11 +14933,12 @@ def test_atomic_normalized_string_length_5_nistxml_sv_ii_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_string_max_length_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14032,11 +14950,12 @@ def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_string_max_length_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14048,11 +14967,12 @@ def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_string_max_length_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14064,11 +14984,12 @@ def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_string_max_length_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14080,11 +15001,12 @@ def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_string_max_length_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14096,11 +15018,12 @@ def test_atomic_normalized_string_max_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_string_max_length_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14112,11 +15035,12 @@ def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_string_max_length_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14128,11 +15052,12 @@ def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_string_max_length_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14144,11 +15069,12 @@ def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_string_max_length_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14160,11 +15086,12 @@ def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_string_max_length_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14176,11 +15103,12 @@ def test_atomic_normalized_string_max_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_string_max_length_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14192,11 +15120,12 @@ def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_string_max_length_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14208,11 +15137,12 @@ def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_string_max_length_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14224,11 +15154,12 @@ def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_string_max_length_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14240,11 +15171,12 @@ def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_string_max_length_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14256,11 +15188,12 @@ def test_atomic_normalized_string_max_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_string_max_length_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14272,11 +15205,12 @@ def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_string_max_length_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14288,11 +15222,12 @@ def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_string_max_length_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14304,11 +15239,12 @@ def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_string_max_length_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14320,11 +15256,12 @@ def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_string_max_length_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14336,11 +15273,12 @@ def test_atomic_normalized_string_max_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_string_max_length_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14352,11 +15290,12 @@ def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_string_max_length_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14368,11 +15307,12 @@ def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_string_max_length_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14384,11 +15324,12 @@ def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_string_max_length_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14400,11 +15341,12 @@ def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_string_max_length_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -14416,11 +15358,12 @@ def test_atomic_normalized_string_max_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -14431,11 +15374,12 @@ def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -14446,11 +15390,12 @@ def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -14461,11 +15406,12 @@ def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -14476,11 +15422,12 @@ def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -14491,11 +15438,12 @@ def test_atomic_string_length_9_nistxml_sv_ii_atomic_string_length_5_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 532.
@@ -14506,11 +15454,12 @@ def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 532.
@@ -14521,11 +15470,12 @@ def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 532.
@@ -14536,11 +15486,12 @@ def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 532.
@@ -14551,11 +15502,12 @@ def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 532.
@@ -14566,11 +15518,12 @@ def test_atomic_string_length_8_nistxml_sv_ii_atomic_string_length_4_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 581.
@@ -14581,11 +15534,12 @@ def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 581.
@@ -14596,11 +15550,12 @@ def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 581.
@@ -14611,11 +15566,12 @@ def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 581.
@@ -14626,11 +15582,12 @@ def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 581.
@@ -14641,11 +15598,12 @@ def test_atomic_string_length_7_nistxml_sv_ii_atomic_string_length_3_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 151.
@@ -14656,11 +15614,12 @@ def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 151.
@@ -14671,11 +15630,12 @@ def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 151.
@@ -14686,11 +15646,12 @@ def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 151.
@@ -14701,11 +15662,12 @@ def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 151.
@@ -14716,11 +15678,12 @@ def test_atomic_string_length_6_nistxml_sv_ii_atomic_string_length_2_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -14731,11 +15694,12 @@ def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -14746,11 +15710,12 @@ def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -14761,11 +15726,12 @@ def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -14776,11 +15742,12 @@ def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -14791,11 +15758,12 @@ def test_atomic_string_length_5_nistxml_sv_ii_atomic_string_length_1_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -14806,11 +15774,12 @@ def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -14821,11 +15790,12 @@ def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -14836,11 +15806,12 @@ def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -14851,11 +15822,12 @@ def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -14866,11 +15838,12 @@ def test_atomic_string_max_length_9_nistxml_sv_ii_atomic_string_max_length_5_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 412.
@@ -14881,11 +15854,12 @@ def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 412.
@@ -14896,11 +15870,12 @@ def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 412.
@@ -14911,11 +15886,12 @@ def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 412.
@@ -14926,11 +15902,12 @@ def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 412.
@@ -14941,11 +15918,12 @@ def test_atomic_string_max_length_8_nistxml_sv_ii_atomic_string_max_length_4_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 46.
@@ -14956,11 +15934,12 @@ def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 46.
@@ -14971,11 +15950,12 @@ def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 46.
@@ -14986,11 +15966,12 @@ def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 46.
@@ -15001,11 +15982,12 @@ def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 46.
@@ -15016,11 +15998,12 @@ def test_atomic_string_max_length_7_nistxml_sv_ii_atomic_string_max_length_3_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 567.
@@ -15031,11 +16014,12 @@ def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 567.
@@ -15046,11 +16030,12 @@ def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 567.
@@ -15061,11 +16046,12 @@ def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 567.
@@ -15076,11 +16062,12 @@ def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 567.
@@ -15091,11 +16078,12 @@ def test_atomic_string_max_length_6_nistxml_sv_ii_atomic_string_max_length_2_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -15106,11 +16094,12 @@ def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -15121,11 +16110,12 @@ def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -15136,11 +16126,12 @@ def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -15151,11 +16142,12 @@ def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -15166,11 +16158,12 @@ def test_atomic_string_max_length_5_nistxml_sv_ii_atomic_string_max_length_1_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -15181,11 +16174,12 @@ def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -15196,11 +16190,12 @@ def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -15211,11 +16206,12 @@ def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -15226,11 +16222,12 @@ def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -15241,11 +16238,12 @@ def test_atomic_id_min_length_9_nistxml_sv_ii_atomic_id_min_length_6_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 3.
@@ -15256,11 +16254,12 @@ def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 3.
@@ -15271,11 +16270,12 @@ def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 3.
@@ -15286,11 +16286,12 @@ def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 3.
@@ -15301,11 +16302,12 @@ def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 3.
@@ -15316,6 +16318,6 @@ def test_atomic_id_min_length_8_nistxml_sv_ii_atomic_id_min_length_5_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_11000.py
+++ b/tests/test_nist_meta_11000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 33.
@@ -11,11 +14,12 @@ def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 33.
@@ -26,11 +30,12 @@ def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 33.
@@ -41,11 +46,12 @@ def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 33.
@@ -56,11 +62,12 @@ def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 33.
@@ -71,11 +78,12 @@ def test_atomic_id_min_length_7_nistxml_sv_ii_atomic_id_min_length_4_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 39.
@@ -86,11 +94,12 @@ def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 39.
@@ -101,11 +110,12 @@ def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 39.
@@ -116,11 +126,12 @@ def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 39.
@@ -131,11 +142,12 @@ def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 39.
@@ -146,11 +158,12 @@ def test_atomic_id_min_length_6_nistxml_sv_ii_atomic_id_min_length_3_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 53.
@@ -161,11 +174,12 @@ def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 53.
@@ -176,11 +190,12 @@ def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 53.
@@ -191,11 +206,12 @@ def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 53.
@@ -206,11 +222,12 @@ def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 53.
@@ -221,11 +238,12 @@ def test_atomic_id_min_length_5_nistxml_sv_ii_atomic_id_min_length_2_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-II-atomic-ID-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -236,11 +254,12 @@ def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -251,11 +270,12 @@ def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -266,11 +286,12 @@ def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -281,11 +302,12 @@ def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -296,11 +318,12 @@ def test_atomic_ncname_min_length_9_nistxml_sv_ii_atomic_ncname_min_length_6_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 53.
@@ -311,11 +334,12 @@ def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 53.
@@ -326,11 +350,12 @@ def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 53.
@@ -341,11 +366,12 @@ def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 53.
@@ -356,11 +382,12 @@ def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 53.
@@ -371,11 +398,12 @@ def test_atomic_ncname_min_length_8_nistxml_sv_ii_atomic_ncname_min_length_5_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 58.
@@ -386,11 +414,12 @@ def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 58.
@@ -401,11 +430,12 @@ def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 58.
@@ -416,11 +446,12 @@ def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 58.
@@ -431,11 +462,12 @@ def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 58.
@@ -446,11 +478,12 @@ def test_atomic_ncname_min_length_7_nistxml_sv_ii_atomic_ncname_min_length_4_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 35.
@@ -461,11 +494,12 @@ def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 35.
@@ -476,11 +510,12 @@ def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 35.
@@ -491,11 +526,12 @@ def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 35.
@@ -506,11 +542,12 @@ def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 35.
@@ -521,11 +558,12 @@ def test_atomic_ncname_min_length_6_nistxml_sv_ii_atomic_ncname_min_length_3_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 23.
@@ -536,11 +574,12 @@ def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 23.
@@ -551,11 +590,12 @@ def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 23.
@@ -566,11 +606,12 @@ def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 23.
@@ -581,11 +622,12 @@ def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 23.
@@ -596,11 +638,12 @@ def test_atomic_ncname_min_length_5_nistxml_sv_ii_atomic_ncname_min_length_2_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-II-atomic-NCName-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -611,11 +654,12 @@ def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -626,11 +670,12 @@ def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -641,11 +686,12 @@ def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -656,11 +702,12 @@ def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -671,11 +718,12 @@ def test_atomic_nmtoken_min_length_9_nistxml_sv_ii_atomic_nmtoken_min_length_6_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 3.
@@ -686,11 +734,12 @@ def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 3.
@@ -701,11 +750,12 @@ def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 3.
@@ -716,11 +766,12 @@ def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 3.
@@ -731,11 +782,12 @@ def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 3.
@@ -746,11 +798,12 @@ def test_atomic_nmtoken_min_length_8_nistxml_sv_ii_atomic_nmtoken_min_length_5_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 17.
@@ -761,11 +814,12 @@ def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 17.
@@ -776,11 +830,12 @@ def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 17.
@@ -791,11 +846,12 @@ def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 17.
@@ -806,11 +862,12 @@ def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 17.
@@ -821,11 +878,12 @@ def test_atomic_nmtoken_min_length_7_nistxml_sv_ii_atomic_nmtoken_min_length_4_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 51.
@@ -836,11 +894,12 @@ def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 51.
@@ -851,11 +910,12 @@ def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 51.
@@ -866,11 +926,12 @@ def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 51.
@@ -881,11 +942,12 @@ def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 51.
@@ -896,11 +958,12 @@ def test_atomic_nmtoken_min_length_6_nistxml_sv_ii_atomic_nmtoken_min_length_3_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 49.
@@ -911,11 +974,12 @@ def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 49.
@@ -926,11 +990,12 @@ def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 49.
@@ -941,11 +1006,12 @@ def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 49.
@@ -956,11 +1022,12 @@ def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 49.
@@ -971,11 +1038,12 @@ def test_atomic_nmtoken_min_length_5_nistxml_sv_ii_atomic_nmtoken_min_length_2_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-II-atomic-NMTOKEN-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -986,11 +1054,12 @@ def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -1001,11 +1070,12 @@ def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -1016,11 +1086,12 @@ def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -1031,11 +1102,12 @@ def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -1046,11 +1118,12 @@ def test_atomic_name_min_length_9_nistxml_sv_ii_atomic_name_min_length_6_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 4.
@@ -1061,11 +1134,12 @@ def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 4.
@@ -1076,11 +1150,12 @@ def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 4.
@@ -1091,11 +1166,12 @@ def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 4.
@@ -1106,11 +1182,12 @@ def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 4.
@@ -1121,11 +1198,12 @@ def test_atomic_name_min_length_8_nistxml_sv_ii_atomic_name_min_length_5_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 58.
@@ -1136,11 +1214,12 @@ def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 58.
@@ -1151,11 +1230,12 @@ def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 58.
@@ -1166,11 +1246,12 @@ def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 58.
@@ -1181,11 +1262,12 @@ def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 58.
@@ -1196,11 +1278,12 @@ def test_atomic_name_min_length_7_nistxml_sv_ii_atomic_name_min_length_4_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 13.
@@ -1211,11 +1294,12 @@ def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 13.
@@ -1226,11 +1310,12 @@ def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 13.
@@ -1241,11 +1326,12 @@ def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 13.
@@ -1256,11 +1342,12 @@ def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 13.
@@ -1271,11 +1358,12 @@ def test_atomic_name_min_length_6_nistxml_sv_ii_atomic_name_min_length_3_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 8.
@@ -1286,11 +1374,12 @@ def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 8.
@@ -1301,11 +1390,12 @@ def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 8.
@@ -1316,11 +1406,12 @@ def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 8.
@@ -1331,11 +1422,12 @@ def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 8.
@@ -1346,11 +1438,12 @@ def test_atomic_name_min_length_5_nistxml_sv_ii_atomic_name_min_length_2_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-II-atomic-Name-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -1361,11 +1454,12 @@ def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -1376,11 +1470,12 @@ def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -1391,11 +1486,12 @@ def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -1406,11 +1502,12 @@ def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -1421,11 +1518,12 @@ def test_atomic_token_min_length_9_nistxml_sv_ii_atomic_token_min_length_6_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 297.
@@ -1436,11 +1534,12 @@ def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 297.
@@ -1451,11 +1550,12 @@ def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 297.
@@ -1466,11 +1566,12 @@ def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 297.
@@ -1481,11 +1582,12 @@ def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 297.
@@ -1496,11 +1598,12 @@ def test_atomic_token_min_length_8_nistxml_sv_ii_atomic_token_min_length_5_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 360.
@@ -1511,11 +1614,12 @@ def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 360.
@@ -1526,11 +1630,12 @@ def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 360.
@@ -1541,11 +1646,12 @@ def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 360.
@@ -1556,11 +1662,12 @@ def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 360.
@@ -1571,11 +1678,12 @@ def test_atomic_token_min_length_7_nistxml_sv_ii_atomic_token_min_length_4_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 735.
@@ -1586,11 +1694,12 @@ def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 735.
@@ -1601,11 +1710,12 @@ def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 735.
@@ -1616,11 +1726,12 @@ def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 735.
@@ -1631,11 +1742,12 @@ def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 735.
@@ -1646,11 +1758,12 @@ def test_atomic_token_min_length_6_nistxml_sv_ii_atomic_token_min_length_3_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 211.
@@ -1661,11 +1774,12 @@ def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 211.
@@ -1676,11 +1790,12 @@ def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 211.
@@ -1691,11 +1806,12 @@ def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 211.
@@ -1706,11 +1822,12 @@ def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 211.
@@ -1721,11 +1838,12 @@ def test_atomic_token_min_length_5_nistxml_sv_ii_atomic_token_min_length_2_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-II-atomic-token-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_string_min_length_6_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1737,11 +1855,12 @@ def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_string_min_length_6_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1753,11 +1872,12 @@ def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_string_min_length_6_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1769,11 +1889,12 @@ def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_string_min_length_6_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1785,11 +1906,12 @@ def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_string_min_length_6_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1801,11 +1923,12 @@ def test_atomic_normalized_string_min_length_9_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_string_min_length_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1817,11 +1940,12 @@ def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_string_min_length_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1833,11 +1957,12 @@ def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_string_min_length_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1849,11 +1974,12 @@ def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_string_min_length_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1865,11 +1991,12 @@ def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_string_min_length_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1881,11 +2008,12 @@ def test_atomic_normalized_string_min_length_8_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_string_min_length_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1897,11 +2025,12 @@ def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_string_min_length_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1913,11 +2042,12 @@ def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_string_min_length_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1929,11 +2059,12 @@ def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_string_min_length_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1945,11 +2076,12 @@ def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_string_min_length_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1961,11 +2093,12 @@ def test_atomic_normalized_string_min_length_7_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_string_min_length_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1977,11 +2110,12 @@ def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_string_min_length_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -1993,11 +2127,12 @@ def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_string_min_length_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2009,11 +2144,12 @@ def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_string_min_length_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2025,11 +2161,12 @@ def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_string_min_length_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2041,11 +2178,12 @@ def test_atomic_normalized_string_min_length_6_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_string_min_length_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2057,11 +2195,12 @@ def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_string_min_length_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2073,11 +2212,12 @@ def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_string_min_length_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2089,11 +2229,12 @@ def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_string_min_length_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2105,11 +2246,12 @@ def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_string_min_length_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -2121,11 +2263,12 @@ def test_atomic_normalized_string_min_length_5_nistxml_sv_ii_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-II-atomic-normalizedString-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -2136,11 +2279,12 @@ def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -2151,11 +2295,12 @@ def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -2166,11 +2311,12 @@ def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -2181,11 +2327,12 @@ def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -2196,11 +2343,12 @@ def test_atomic_string_min_length_9_nistxml_sv_ii_atomic_string_min_length_6_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 791.
@@ -2211,11 +2359,12 @@ def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 791.
@@ -2226,11 +2375,12 @@ def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 791.
@@ -2241,11 +2391,12 @@ def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 791.
@@ -2256,11 +2407,12 @@ def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 791.
@@ -2271,11 +2423,12 @@ def test_atomic_string_min_length_8_nistxml_sv_ii_atomic_string_min_length_5_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 838.
@@ -2286,11 +2439,12 @@ def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 838.
@@ -2301,11 +2455,12 @@ def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 838.
@@ -2316,11 +2471,12 @@ def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 838.
@@ -2331,11 +2487,12 @@ def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 838.
@@ -2346,11 +2503,12 @@ def test_atomic_string_min_length_7_nistxml_sv_ii_atomic_string_min_length_4_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 275.
@@ -2361,11 +2519,12 @@ def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 275.
@@ -2376,11 +2535,12 @@ def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 275.
@@ -2391,11 +2551,12 @@ def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 275.
@@ -2406,11 +2567,12 @@ def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 275.
@@ -2421,11 +2583,12 @@ def test_atomic_string_min_length_6_nistxml_sv_ii_atomic_string_min_length_3_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 998.
@@ -2436,11 +2599,12 @@ def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 998.
@@ -2451,11 +2615,12 @@ def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 998.
@@ -2466,11 +2631,12 @@ def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 998.
@@ -2481,11 +2647,12 @@ def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 998.
@@ -2496,11 +2663,12 @@ def test_atomic_string_min_length_5_nistxml_sv_ii_atomic_string_min_length_2_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-II-atomic-string-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2511,11 +2679,12 @@ def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2526,11 +2695,12 @@ def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2541,11 +2711,12 @@ def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2556,11 +2727,12 @@ def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2571,11 +2743,12 @@ def test_atomic_g_month_enumeration_9_nistxml_sv_ii_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2586,11 +2759,12 @@ def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2601,11 +2775,12 @@ def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2616,11 +2791,12 @@ def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2631,11 +2807,12 @@ def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2646,11 +2823,12 @@ def test_atomic_g_month_enumeration_8_nistxml_sv_ii_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2661,11 +2839,12 @@ def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2676,11 +2855,12 @@ def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2691,11 +2871,12 @@ def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2706,11 +2887,12 @@ def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2721,11 +2903,12 @@ def test_atomic_g_month_enumeration_7_nistxml_sv_ii_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2736,11 +2919,12 @@ def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2751,11 +2935,12 @@ def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2766,11 +2951,12 @@ def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2781,11 +2967,12 @@ def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2796,11 +2983,12 @@ def test_atomic_g_month_enumeration_6_nistxml_sv_ii_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2811,11 +2999,12 @@ def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2826,11 +3015,12 @@ def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2841,11 +3031,12 @@ def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2856,11 +3047,12 @@ def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -2871,11 +3063,12 @@ def test_atomic_g_month_enumeration_5_nistxml_sv_ii_atomic_g_month_enumeration_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -2886,11 +3079,12 @@ def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -2901,11 +3095,12 @@ def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -2916,11 +3111,12 @@ def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -2931,11 +3127,12 @@ def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -2946,11 +3143,12 @@ def test_atomic_g_month_pattern_9_nistxml_sv_ii_atomic_g_month_pattern_5_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -2961,11 +3159,12 @@ def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -2976,11 +3175,12 @@ def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -2991,11 +3191,12 @@ def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3006,11 +3207,12 @@ def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3021,11 +3223,12 @@ def test_atomic_g_month_pattern_8_nistxml_sv_ii_atomic_g_month_pattern_4_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3036,11 +3239,12 @@ def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3051,11 +3255,12 @@ def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3066,11 +3271,12 @@ def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3081,11 +3287,12 @@ def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3096,11 +3303,12 @@ def test_atomic_g_month_pattern_7_nistxml_sv_ii_atomic_g_month_pattern_3_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d1.
@@ -3111,11 +3319,12 @@ def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d1.
@@ -3126,11 +3335,12 @@ def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d1.
@@ -3141,11 +3351,12 @@ def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d1.
@@ -3156,11 +3367,12 @@ def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d1.
@@ -3171,11 +3383,12 @@ def test_atomic_g_month_pattern_6_nistxml_sv_ii_atomic_g_month_pattern_2_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3186,11 +3399,12 @@ def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3201,11 +3415,12 @@ def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3216,11 +3431,12 @@ def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3231,11 +3447,12 @@ def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -3246,11 +3463,12 @@ def test_atomic_g_month_pattern_5_nistxml_sv_ii_atomic_g_month_pattern_1_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_9_nistxml_sv_ii_atomic_g_month_max_exclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3262,11 +3480,12 @@ def test_atomic_g_month_max_exclusive_9_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3278,11 +3497,12 @@ def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3294,11 +3514,12 @@ def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3310,11 +3531,12 @@ def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3326,11 +3548,12 @@ def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3342,11 +3565,12 @@ def test_atomic_g_month_max_exclusive_8_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3358,11 +3582,12 @@ def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3374,11 +3599,12 @@ def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3390,11 +3616,12 @@ def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3406,11 +3633,12 @@ def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3422,11 +3650,12 @@ def test_atomic_g_month_max_exclusive_7_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3438,11 +3667,12 @@ def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3454,11 +3684,12 @@ def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3470,11 +3701,12 @@ def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3486,11 +3718,12 @@ def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3502,11 +3735,12 @@ def test_atomic_g_month_max_exclusive_6_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3518,11 +3752,12 @@ def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusive_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3534,11 +3769,12 @@ def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusive_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3550,11 +3786,12 @@ def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusive_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3566,11 +3803,12 @@ def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusive_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -3582,11 +3820,12 @@ def test_atomic_g_month_max_exclusive_5_nistxml_sv_ii_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3598,11 +3837,12 @@ def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusive_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3614,11 +3854,12 @@ def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusive_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3630,11 +3871,12 @@ def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusive_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3646,11 +3888,12 @@ def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusive_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3662,11 +3905,12 @@ def test_atomic_g_month_min_exclusive_9_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3678,11 +3922,12 @@ def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3694,11 +3939,12 @@ def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3710,11 +3956,12 @@ def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3726,11 +3973,12 @@ def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3742,11 +3990,12 @@ def test_atomic_g_month_min_exclusive_8_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_7_nistxml_sv_ii_atomic_g_month_min_exclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3758,11 +4007,12 @@ def test_atomic_g_month_min_exclusive_7_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3774,11 +4024,12 @@ def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3790,11 +4041,12 @@ def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3806,11 +4058,12 @@ def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3822,11 +4075,12 @@ def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3838,11 +4092,12 @@ def test_atomic_g_month_min_exclusive_6_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_5_nistxml_sv_ii_atomic_g_month_min_exclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -3854,11 +4109,12 @@ def test_atomic_g_month_min_exclusive_5_nistxml_sv_ii_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3869,11 +4125,12 @@ def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3884,11 +4141,12 @@ def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3899,11 +4157,12 @@ def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3914,11 +4173,12 @@ def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3929,11 +4189,12 @@ def test_atomic_g_day_enumeration_9_nistxml_sv_ii_atomic_g_day_enumeration_5_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3944,11 +4205,12 @@ def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3959,11 +4221,12 @@ def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3974,11 +4237,12 @@ def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -3989,11 +4253,12 @@ def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4004,11 +4269,12 @@ def test_atomic_g_day_enumeration_8_nistxml_sv_ii_atomic_g_day_enumeration_4_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4019,11 +4285,12 @@ def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4034,11 +4301,12 @@ def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4049,11 +4317,12 @@ def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4064,11 +4333,12 @@ def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4079,11 +4349,12 @@ def test_atomic_g_day_enumeration_7_nistxml_sv_ii_atomic_g_day_enumeration_3_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4094,11 +4365,12 @@ def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4109,11 +4381,12 @@ def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4124,11 +4397,12 @@ def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4139,11 +4413,12 @@ def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4154,11 +4429,12 @@ def test_atomic_g_day_enumeration_6_nistxml_sv_ii_atomic_g_day_enumeration_2_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4169,11 +4445,12 @@ def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4184,11 +4461,12 @@ def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4199,11 +4477,12 @@ def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4214,11 +4493,12 @@ def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -4229,11 +4509,12 @@ def test_atomic_g_day_enumeration_5_nistxml_sv_ii_atomic_g_day_enumeration_1_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -4244,11 +4525,12 @@ def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -4259,11 +4541,12 @@ def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -4274,11 +4557,12 @@ def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -4289,11 +4573,12 @@ def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -4304,11 +4589,12 @@ def test_atomic_g_day_pattern_9_nistxml_sv_ii_atomic_g_day_pattern_5_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -4319,11 +4605,12 @@ def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -4334,11 +4621,12 @@ def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -4349,11 +4637,12 @@ def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -4364,11 +4653,12 @@ def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -4379,11 +4669,12 @@ def test_atomic_g_day_pattern_8_nistxml_sv_ii_atomic_g_day_pattern_4_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d4.
@@ -4394,11 +4685,12 @@ def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d4.
@@ -4409,11 +4701,12 @@ def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d4.
@@ -4424,11 +4717,12 @@ def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d4.
@@ -4439,11 +4733,12 @@ def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d4.
@@ -4454,11 +4749,12 @@ def test_atomic_g_day_pattern_7_nistxml_sv_ii_atomic_g_day_pattern_3_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d3.
@@ -4469,11 +4765,12 @@ def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d3.
@@ -4484,11 +4781,12 @@ def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d3.
@@ -4499,11 +4797,12 @@ def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d3.
@@ -4514,11 +4813,12 @@ def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d3.
@@ -4529,11 +4829,12 @@ def test_atomic_g_day_pattern_6_nistxml_sv_ii_atomic_g_day_pattern_2_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---2\d.
@@ -4544,11 +4845,12 @@ def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---2\d.
@@ -4559,11 +4861,12 @@ def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---2\d.
@@ -4574,11 +4877,12 @@ def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---2\d.
@@ -4589,11 +4893,12 @@ def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---2\d.
@@ -4604,11 +4909,12 @@ def test_atomic_g_day_pattern_5_nistxml_sv_ii_atomic_g_day_pattern_1_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_9_nistxml_sv_ii_atomic_g_day_max_exclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---31.
@@ -4619,11 +4925,12 @@ def test_atomic_g_day_max_exclusive_9_nistxml_sv_ii_atomic_g_day_max_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---13.
@@ -4634,11 +4941,12 @@ def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---13.
@@ -4649,11 +4957,12 @@ def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---13.
@@ -4664,11 +4973,12 @@ def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---13.
@@ -4679,11 +4989,12 @@ def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---13.
@@ -4694,11 +5005,12 @@ def test_atomic_g_day_max_exclusive_8_nistxml_sv_ii_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---05.
@@ -4709,11 +5021,12 @@ def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---05.
@@ -4724,11 +5037,12 @@ def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---05.
@@ -4739,11 +5053,12 @@ def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---05.
@@ -4754,11 +5069,12 @@ def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---05.
@@ -4769,11 +5085,12 @@ def test_atomic_g_day_max_exclusive_7_nistxml_sv_ii_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---26.
@@ -4784,11 +5101,12 @@ def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---26.
@@ -4799,11 +5117,12 @@ def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---26.
@@ -4814,11 +5133,12 @@ def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---26.
@@ -4829,11 +5149,12 @@ def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---26.
@@ -4844,11 +5165,12 @@ def test_atomic_g_day_max_exclusive_6_nistxml_sv_ii_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---02.
@@ -4859,11 +5181,12 @@ def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---02.
@@ -4874,11 +5197,12 @@ def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---02.
@@ -4889,11 +5213,12 @@ def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---02.
@@ -4904,11 +5229,12 @@ def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---02.
@@ -4919,11 +5245,12 @@ def test_atomic_g_day_max_exclusive_5_nistxml_sv_ii_atomic_g_day_max_exclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---30.
@@ -4934,11 +5261,12 @@ def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---30.
@@ -4949,11 +5277,12 @@ def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---30.
@@ -4964,11 +5293,12 @@ def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---30.
@@ -4979,11 +5309,12 @@ def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---30.
@@ -4994,11 +5325,12 @@ def test_atomic_g_day_min_exclusive_9_nistxml_sv_ii_atomic_g_day_min_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---10.
@@ -5009,11 +5341,12 @@ def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---10.
@@ -5024,11 +5357,12 @@ def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---10.
@@ -5039,11 +5373,12 @@ def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---10.
@@ -5054,11 +5389,12 @@ def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---10.
@@ -5069,11 +5405,12 @@ def test_atomic_g_day_min_exclusive_8_nistxml_sv_ii_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---02.
@@ -5084,11 +5421,12 @@ def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---02.
@@ -5099,11 +5437,12 @@ def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---02.
@@ -5114,11 +5453,12 @@ def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---02.
@@ -5129,11 +5469,12 @@ def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---02.
@@ -5144,11 +5485,12 @@ def test_atomic_g_day_min_exclusive_7_nistxml_sv_ii_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---18.
@@ -5159,11 +5501,12 @@ def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---18.
@@ -5174,11 +5517,12 @@ def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---18.
@@ -5189,11 +5533,12 @@ def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---18.
@@ -5204,11 +5549,12 @@ def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---18.
@@ -5219,11 +5565,12 @@ def test_atomic_g_day_min_exclusive_6_nistxml_sv_ii_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_5_nistxml_sv_ii_atomic_g_day_min_exclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---01.
@@ -5234,11 +5581,12 @@ def test_atomic_g_day_min_exclusive_5_nistxml_sv_ii_atomic_g_day_min_exclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enumeration_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5249,11 +5597,12 @@ def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enumeration_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5264,11 +5613,12 @@ def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enumeration_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5279,11 +5629,12 @@ def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enumeration_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5294,11 +5645,12 @@ def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enumeration_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5309,11 +5661,12 @@ def test_atomic_g_month_day_enumeration_9_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enumeration_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5324,11 +5677,12 @@ def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enumeration_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5339,11 +5693,12 @@ def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enumeration_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5354,11 +5709,12 @@ def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enumeration_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5369,11 +5725,12 @@ def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enumeration_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5384,11 +5741,12 @@ def test_atomic_g_month_day_enumeration_8_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enumeration_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5399,11 +5757,12 @@ def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enumeration_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5414,11 +5773,12 @@ def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enumeration_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5429,11 +5789,12 @@ def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enumeration_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5444,11 +5805,12 @@ def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enumeration_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5459,11 +5821,12 @@ def test_atomic_g_month_day_enumeration_7_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enumeration_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5474,11 +5837,12 @@ def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enumeration_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5489,11 +5853,12 @@ def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enumeration_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5504,11 +5869,12 @@ def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enumeration_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5519,11 +5885,12 @@ def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enumeration_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5534,11 +5901,12 @@ def test_atomic_g_month_day_enumeration_6_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enumeration_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5549,11 +5917,12 @@ def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enumeration_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5564,11 +5933,12 @@ def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enumeration_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5579,11 +5949,12 @@ def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enumeration_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5594,11 +5965,12 @@ def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enumeration_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -5609,11 +5981,12 @@ def test_atomic_g_month_day_enumeration_5_nistxml_sv_ii_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5625,11 +5998,12 @@ def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5641,11 +6015,12 @@ def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5657,11 +6032,12 @@ def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5673,11 +6049,12 @@ def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5689,11 +6066,12 @@ def test_atomic_g_month_day_pattern_9_nistxml_sv_ii_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5705,11 +6083,12 @@ def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5721,11 +6100,12 @@ def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5737,11 +6117,12 @@ def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5753,11 +6134,12 @@ def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5769,11 +6151,12 @@ def test_atomic_g_month_day_pattern_8_nistxml_sv_ii_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5785,11 +6168,12 @@ def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5801,11 +6185,12 @@ def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5817,11 +6202,12 @@ def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5833,11 +6219,12 @@ def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5849,11 +6236,12 @@ def test_atomic_g_month_day_pattern_7_nistxml_sv_ii_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5865,11 +6253,12 @@ def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5881,11 +6270,12 @@ def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5897,11 +6287,12 @@ def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5913,11 +6304,12 @@ def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5929,11 +6321,12 @@ def test_atomic_g_month_day_pattern_6_nistxml_sv_ii_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5945,11 +6338,12 @@ def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5961,11 +6355,12 @@ def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5977,11 +6372,12 @@ def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -5993,11 +6389,12 @@ def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -6009,11 +6406,12 @@ def test_atomic_g_month_day_pattern_5_nistxml_sv_ii_atomic_g_month_day_pattern_1
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_9_nistxml_sv_ii_atomic_g_month_day_max_exclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6025,11 +6423,12 @@ def test_atomic_g_month_day_max_exclusive_9_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max_exclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6041,11 +6440,12 @@ def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max_exclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6057,11 +6457,12 @@ def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max_exclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6073,11 +6474,12 @@ def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max_exclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6089,11 +6491,12 @@ def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max_exclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6105,11 +6508,12 @@ def test_atomic_g_month_day_max_exclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max_exclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6121,11 +6525,12 @@ def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max_exclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6137,11 +6542,12 @@ def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max_exclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6153,11 +6559,12 @@ def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max_exclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6169,11 +6576,12 @@ def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max_exclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6185,11 +6593,12 @@ def test_atomic_g_month_day_max_exclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max_exclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6201,11 +6610,12 @@ def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max_exclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6217,11 +6627,12 @@ def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max_exclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6233,11 +6644,12 @@ def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max_exclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6249,11 +6661,12 @@ def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max_exclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6265,11 +6678,12 @@ def test_atomic_g_month_day_max_exclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max_exclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6281,11 +6695,12 @@ def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max_exclusive_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6297,11 +6712,12 @@ def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max_exclusive_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6313,11 +6729,12 @@ def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max_exclusive_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6329,11 +6746,12 @@ def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max_exclusive_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -6345,11 +6763,12 @@ def test_atomic_g_month_day_max_exclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min_exclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6361,11 +6780,12 @@ def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min_exclusive_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6377,11 +6797,12 @@ def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min_exclusive_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6393,11 +6814,12 @@ def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min_exclusive_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6409,11 +6831,12 @@ def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min_exclusive_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6425,11 +6848,12 @@ def test_atomic_g_month_day_min_exclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min_exclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6441,11 +6865,12 @@ def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min_exclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6457,11 +6882,12 @@ def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min_exclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6473,11 +6899,12 @@ def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min_exclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6489,11 +6916,12 @@ def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min_exclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6505,11 +6933,12 @@ def test_atomic_g_month_day_min_exclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min_exclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6521,11 +6950,12 @@ def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min_exclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6537,11 +6967,12 @@ def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min_exclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6553,11 +6984,12 @@ def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min_exclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6569,11 +7001,12 @@ def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min_exclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6585,11 +7018,12 @@ def test_atomic_g_month_day_min_exclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min_exclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6601,11 +7035,12 @@ def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min_exclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6617,11 +7052,12 @@ def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min_exclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6633,11 +7069,12 @@ def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min_exclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6649,11 +7086,12 @@ def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min_exclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6665,11 +7103,12 @@ def test_atomic_g_month_day_min_exclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_5_nistxml_sv_ii_atomic_g_month_day_min_exclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -6681,11 +7120,12 @@ def test_atomic_g_month_day_min_exclusive_5_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6696,11 +7136,12 @@ def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6711,11 +7152,12 @@ def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6726,11 +7168,12 @@ def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6741,11 +7184,12 @@ def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6756,11 +7200,12 @@ def test_atomic_g_year_enumeration_9_nistxml_sv_ii_atomic_g_year_enumeration_5_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6771,11 +7216,12 @@ def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6786,11 +7232,12 @@ def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6801,11 +7248,12 @@ def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6816,11 +7264,12 @@ def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6831,11 +7280,12 @@ def test_atomic_g_year_enumeration_8_nistxml_sv_ii_atomic_g_year_enumeration_4_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6846,11 +7296,12 @@ def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6861,11 +7312,12 @@ def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6876,11 +7328,12 @@ def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6891,11 +7344,12 @@ def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6906,11 +7360,12 @@ def test_atomic_g_year_enumeration_7_nistxml_sv_ii_atomic_g_year_enumeration_3_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6921,11 +7376,12 @@ def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6936,11 +7392,12 @@ def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6951,11 +7408,12 @@ def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6966,11 +7424,12 @@ def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6981,11 +7440,12 @@ def test_atomic_g_year_enumeration_6_nistxml_sv_ii_atomic_g_year_enumeration_2_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -6996,11 +7456,12 @@ def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -7011,11 +7472,12 @@ def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -7026,11 +7488,12 @@ def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -7041,11 +7504,12 @@ def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -7056,11 +7520,12 @@ def test_atomic_g_year_enumeration_5_nistxml_sv_ii_atomic_g_year_enumeration_1_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d77.
@@ -7071,11 +7536,12 @@ def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d77.
@@ -7086,11 +7552,12 @@ def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d77.
@@ -7101,11 +7568,12 @@ def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d77.
@@ -7116,11 +7584,12 @@ def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d77.
@@ -7131,11 +7600,12 @@ def test_atomic_g_year_pattern_9_nistxml_sv_ii_atomic_g_year_pattern_5_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d66.
@@ -7146,11 +7616,12 @@ def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d66.
@@ -7161,11 +7632,12 @@ def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d66.
@@ -7176,11 +7648,12 @@ def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d66.
@@ -7191,11 +7664,12 @@ def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d66.
@@ -7206,11 +7680,12 @@ def test_atomic_g_year_pattern_8_nistxml_sv_ii_atomic_g_year_pattern_4_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 17\d\d.
@@ -7221,11 +7696,12 @@ def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 17\d\d.
@@ -7236,11 +7712,12 @@ def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 17\d\d.
@@ -7251,11 +7728,12 @@ def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 17\d\d.
@@ -7266,11 +7744,12 @@ def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 17\d\d.
@@ -7281,11 +7760,12 @@ def test_atomic_g_year_pattern_7_nistxml_sv_ii_atomic_g_year_pattern_3_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 19\d\d.
@@ -7296,11 +7776,12 @@ def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 19\d\d.
@@ -7311,11 +7792,12 @@ def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 19\d\d.
@@ -7326,11 +7808,12 @@ def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 19\d\d.
@@ -7341,11 +7824,12 @@ def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value 19\d\d.
@@ -7356,11 +7840,12 @@ def test_atomic_g_year_pattern_6_nistxml_sv_ii_atomic_g_year_pattern_2_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d06.
@@ -7371,11 +7856,12 @@ def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d06.
@@ -7386,11 +7872,12 @@ def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d06.
@@ -7401,11 +7888,12 @@ def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d06.
@@ -7416,11 +7904,12 @@ def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d06.
@@ -7431,11 +7920,12 @@ def test_atomic_g_year_pattern_5_nistxml_sv_ii_atomic_g_year_pattern_1_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_9_nistxml_sv_ii_atomic_g_year_max_exclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2030.
@@ -7446,11 +7936,12 @@ def test_atomic_g_year_max_exclusive_9_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2011.
@@ -7461,11 +7952,12 @@ def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2011.
@@ -7476,11 +7968,12 @@ def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2011.
@@ -7491,11 +7984,12 @@ def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2011.
@@ -7506,11 +8000,12 @@ def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2011.
@@ -7521,11 +8016,12 @@ def test_atomic_g_year_max_exclusive_8_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2014.
@@ -7536,11 +8032,12 @@ def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2014.
@@ -7551,11 +8048,12 @@ def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2014.
@@ -7566,11 +8064,12 @@ def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2014.
@@ -7581,11 +8080,12 @@ def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2014.
@@ -7596,11 +8096,12 @@ def test_atomic_g_year_max_exclusive_7_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1993.
@@ -7611,11 +8112,12 @@ def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1993.
@@ -7626,11 +8128,12 @@ def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1993.
@@ -7641,11 +8144,12 @@ def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1993.
@@ -7656,11 +8160,12 @@ def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1993.
@@ -7671,11 +8176,12 @@ def test_atomic_g_year_max_exclusive_6_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1971.
@@ -7686,11 +8192,12 @@ def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1971.
@@ -7701,11 +8208,12 @@ def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1971.
@@ -7716,11 +8224,12 @@ def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1971.
@@ -7731,11 +8240,12 @@ def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1971.
@@ -7746,11 +8256,12 @@ def test_atomic_g_year_max_exclusive_5_nistxml_sv_ii_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2029.
@@ -7761,11 +8272,12 @@ def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2029.
@@ -7776,11 +8288,12 @@ def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2029.
@@ -7791,11 +8304,12 @@ def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2029.
@@ -7806,11 +8320,12 @@ def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2029.
@@ -7821,11 +8336,12 @@ def test_atomic_g_year_min_exclusive_9_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1988.
@@ -7836,11 +8352,12 @@ def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1988.
@@ -7851,11 +8368,12 @@ def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1988.
@@ -7866,11 +8384,12 @@ def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1988.
@@ -7881,11 +8400,12 @@ def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1988.
@@ -7896,11 +8416,12 @@ def test_atomic_g_year_min_exclusive_8_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1993.
@@ -7911,11 +8432,12 @@ def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1993.
@@ -7926,11 +8448,12 @@ def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1993.
@@ -7941,11 +8464,12 @@ def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1993.
@@ -7956,11 +8480,12 @@ def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1993.
@@ -7971,11 +8496,12 @@ def test_atomic_g_year_min_exclusive_7_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2019.
@@ -7986,11 +8512,12 @@ def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2019.
@@ -8001,11 +8528,12 @@ def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2019.
@@ -8016,11 +8544,12 @@ def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2019.
@@ -8031,11 +8560,12 @@ def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2019.
@@ -8046,11 +8576,12 @@ def test_atomic_g_year_min_exclusive_6_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_5_nistxml_sv_ii_atomic_g_year_min_exclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1970.
@@ -8061,11 +8592,12 @@ def test_atomic_g_year_min_exclusive_5_nistxml_sv_ii_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enumeration_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8076,11 +8608,12 @@ def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enumeration_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8091,11 +8624,12 @@ def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enumeration_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8106,11 +8640,12 @@ def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enumeration_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8121,11 +8656,12 @@ def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enumeration_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8136,11 +8672,12 @@ def test_atomic_g_year_month_enumeration_9_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enumeration_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8151,11 +8688,12 @@ def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enumeration_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8166,11 +8704,12 @@ def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enumeration_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8181,11 +8720,12 @@ def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enumeration_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8196,11 +8736,12 @@ def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enumeration_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8211,11 +8752,12 @@ def test_atomic_g_year_month_enumeration_8_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enumeration_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8226,11 +8768,12 @@ def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enumeration_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8241,11 +8784,12 @@ def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enumeration_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8256,11 +8800,12 @@ def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enumeration_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8271,11 +8816,12 @@ def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enumeration_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8286,11 +8832,12 @@ def test_atomic_g_year_month_enumeration_7_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enumeration_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8301,11 +8848,12 @@ def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enumeration_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8316,11 +8864,12 @@ def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enumeration_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8331,11 +8880,12 @@ def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enumeration_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8346,11 +8896,12 @@ def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enumeration_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8361,11 +8912,12 @@ def test_atomic_g_year_month_enumeration_6_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enumeration_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8376,11 +8928,12 @@ def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enumeration_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8391,11 +8944,12 @@ def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enumeration_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8406,11 +8960,12 @@ def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enumeration_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8421,11 +8976,12 @@ def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enumeration_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -8436,11 +8992,12 @@ def test_atomic_g_year_month_enumeration_5_nistxml_sv_ii_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern_5_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8452,11 +9009,12 @@ def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern_5_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8468,11 +9026,12 @@ def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern_5_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8484,11 +9043,12 @@ def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern_5_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8500,11 +9060,12 @@ def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern_5_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8516,11 +9077,12 @@ def test_atomic_g_year_month_pattern_9_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern_4_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8532,11 +9094,12 @@ def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern_4_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8548,11 +9111,12 @@ def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern_4_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8564,11 +9128,12 @@ def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern_4_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8580,11 +9145,12 @@ def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern_4_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8596,11 +9162,12 @@ def test_atomic_g_year_month_pattern_8_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern_3_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8612,11 +9179,12 @@ def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern_3_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8628,11 +9196,12 @@ def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern_3_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8644,11 +9213,12 @@ def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern_3_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8660,11 +9230,12 @@ def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern_3_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8676,11 +9247,12 @@ def test_atomic_g_year_month_pattern_7_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern_2_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8692,11 +9264,12 @@ def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern_2_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8708,11 +9281,12 @@ def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern_2_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8724,11 +9298,12 @@ def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern_2_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8740,11 +9315,12 @@ def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern_2_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8756,11 +9332,12 @@ def test_atomic_g_year_month_pattern_6_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern_1_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8772,11 +9349,12 @@ def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern_1_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8788,11 +9366,12 @@ def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern_1_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8804,11 +9383,12 @@ def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern_1_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8820,11 +9400,12 @@ def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern_1_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -8836,11 +9417,12 @@ def test_atomic_g_year_month_pattern_5_nistxml_sv_ii_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_9_nistxml_sv_ii_atomic_g_year_month_max_exclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8852,11 +9434,12 @@ def test_atomic_g_year_month_max_exclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_max_exclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8868,11 +9451,12 @@ def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_max_exclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8884,11 +9468,12 @@ def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_max_exclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8900,11 +9485,12 @@ def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_max_exclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8916,11 +9502,12 @@ def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_max_exclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8932,11 +9519,12 @@ def test_atomic_g_year_month_max_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_max_exclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8948,11 +9536,12 @@ def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_max_exclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8964,11 +9553,12 @@ def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_max_exclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8980,11 +9570,12 @@ def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_max_exclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -8996,11 +9587,12 @@ def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_max_exclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9012,11 +9604,12 @@ def test_atomic_g_year_month_max_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_max_exclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9028,11 +9621,12 @@ def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_max_exclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9044,11 +9638,12 @@ def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_max_exclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9060,11 +9655,12 @@ def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_max_exclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9076,11 +9672,12 @@ def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_max_exclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9092,11 +9689,12 @@ def test_atomic_g_year_month_max_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_max_exclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9108,11 +9706,12 @@ def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_max_exclusive_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9124,11 +9723,12 @@ def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_max_exclusive_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9140,11 +9740,12 @@ def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_max_exclusive_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9156,11 +9757,12 @@ def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_max_exclusive_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -9172,11 +9774,12 @@ def test_atomic_g_year_month_max_exclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_min_exclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9188,11 +9791,12 @@ def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_min_exclusive_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9204,11 +9808,12 @@ def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_min_exclusive_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9220,11 +9825,12 @@ def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_min_exclusive_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9236,11 +9842,12 @@ def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_min_exclusive_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9252,11 +9859,12 @@ def test_atomic_g_year_month_min_exclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_min_exclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9268,11 +9876,12 @@ def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_min_exclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9284,11 +9893,12 @@ def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_min_exclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9300,11 +9910,12 @@ def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_min_exclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9316,11 +9927,12 @@ def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_min_exclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9332,11 +9944,12 @@ def test_atomic_g_year_month_min_exclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_min_exclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9348,11 +9961,12 @@ def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_min_exclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9364,11 +9978,12 @@ def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_min_exclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9380,11 +9995,12 @@ def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_min_exclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9396,11 +10012,12 @@ def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_min_exclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9412,11 +10029,12 @@ def test_atomic_g_year_month_min_exclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_min_exclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9428,11 +10046,12 @@ def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_min_exclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9444,11 +10063,12 @@ def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_min_exclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9460,11 +10080,12 @@ def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_min_exclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9476,11 +10097,12 @@ def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_min_exclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9492,11 +10114,12 @@ def test_atomic_g_year_month_min_exclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_5_nistxml_sv_ii_atomic_g_year_month_min_exclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -9508,11 +10131,12 @@ def test_atomic_g_year_month_min_exclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9523,11 +10147,12 @@ def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9538,11 +10163,12 @@ def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9553,11 +10179,12 @@ def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9568,11 +10195,12 @@ def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9583,11 +10211,12 @@ def test_atomic_date_enumeration_9_nistxml_sv_ii_atomic_date_enumeration_5_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9598,11 +10227,12 @@ def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9613,11 +10243,12 @@ def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9628,11 +10259,12 @@ def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9643,11 +10275,12 @@ def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9658,11 +10291,12 @@ def test_atomic_date_enumeration_8_nistxml_sv_ii_atomic_date_enumeration_4_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9673,11 +10307,12 @@ def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9688,11 +10323,12 @@ def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9703,11 +10339,12 @@ def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9718,11 +10355,12 @@ def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9733,11 +10371,12 @@ def test_atomic_date_enumeration_7_nistxml_sv_ii_atomic_date_enumeration_3_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9748,11 +10387,12 @@ def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9763,11 +10403,12 @@ def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9778,11 +10419,12 @@ def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9793,11 +10435,12 @@ def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9808,11 +10451,12 @@ def test_atomic_date_enumeration_6_nistxml_sv_ii_atomic_date_enumeration_2_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9823,11 +10467,12 @@ def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9838,11 +10483,12 @@ def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9853,11 +10499,12 @@ def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9868,11 +10515,12 @@ def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -9883,11 +10531,12 @@ def test_atomic_date_enumeration_5_nistxml_sv_ii_atomic_date_enumeration_1_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9899,11 +10548,12 @@ def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9915,11 +10565,12 @@ def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9931,11 +10582,12 @@ def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9947,11 +10599,12 @@ def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9963,11 +10616,12 @@ def test_atomic_date_pattern_9_nistxml_sv_ii_atomic_date_pattern_5_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9979,11 +10633,12 @@ def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -9995,11 +10650,12 @@ def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10011,11 +10667,12 @@ def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10027,11 +10684,12 @@ def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10043,11 +10701,12 @@ def test_atomic_date_pattern_8_nistxml_sv_ii_atomic_date_pattern_4_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10059,11 +10718,12 @@ def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10075,11 +10735,12 @@ def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10091,11 +10752,12 @@ def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10107,11 +10769,12 @@ def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10123,11 +10786,12 @@ def test_atomic_date_pattern_7_nistxml_sv_ii_atomic_date_pattern_3_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10139,11 +10803,12 @@ def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10155,11 +10820,12 @@ def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10171,11 +10837,12 @@ def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10187,11 +10854,12 @@ def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10203,11 +10871,12 @@ def test_atomic_date_pattern_6_nistxml_sv_ii_atomic_date_pattern_2_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10219,11 +10888,12 @@ def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10235,11 +10905,12 @@ def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10251,11 +10922,12 @@ def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10267,11 +10939,12 @@ def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -10283,11 +10956,12 @@ def test_atomic_date_pattern_5_nistxml_sv_ii_atomic_date_pattern_1_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_9_nistxml_sv_ii_atomic_date_max_exclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10299,11 +10973,12 @@ def test_atomic_date_max_exclusive_9_nistxml_sv_ii_atomic_date_max_exclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10315,11 +10990,12 @@ def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10331,11 +11007,12 @@ def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10347,11 +11024,12 @@ def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10363,11 +11041,12 @@ def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10379,11 +11058,12 @@ def test_atomic_date_max_exclusive_8_nistxml_sv_ii_atomic_date_max_exclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10395,11 +11075,12 @@ def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10411,11 +11092,12 @@ def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10427,11 +11109,12 @@ def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10443,11 +11126,12 @@ def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10459,11 +11143,12 @@ def test_atomic_date_max_exclusive_7_nistxml_sv_ii_atomic_date_max_exclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10475,11 +11160,12 @@ def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10491,11 +11177,12 @@ def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10507,11 +11194,12 @@ def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10523,11 +11211,12 @@ def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10539,11 +11228,12 @@ def test_atomic_date_max_exclusive_6_nistxml_sv_ii_atomic_date_max_exclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10555,11 +11245,12 @@ def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10571,11 +11262,12 @@ def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10587,11 +11279,12 @@ def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10603,11 +11296,12 @@ def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -10619,11 +11313,12 @@ def test_atomic_date_max_exclusive_5_nistxml_sv_ii_atomic_date_max_exclusive_1_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10635,11 +11330,12 @@ def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10651,11 +11347,12 @@ def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10667,11 +11364,12 @@ def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10683,11 +11381,12 @@ def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10699,11 +11398,12 @@ def test_atomic_date_min_exclusive_9_nistxml_sv_ii_atomic_date_min_exclusive_5_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10715,11 +11415,12 @@ def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10731,11 +11432,12 @@ def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10747,11 +11449,12 @@ def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10763,11 +11466,12 @@ def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10779,11 +11483,12 @@ def test_atomic_date_min_exclusive_8_nistxml_sv_ii_atomic_date_min_exclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10795,11 +11500,12 @@ def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10811,11 +11517,12 @@ def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10827,11 +11534,12 @@ def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10843,11 +11551,12 @@ def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10859,11 +11568,12 @@ def test_atomic_date_min_exclusive_7_nistxml_sv_ii_atomic_date_min_exclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10875,11 +11585,12 @@ def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10891,11 +11602,12 @@ def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10907,11 +11619,12 @@ def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10923,11 +11636,12 @@ def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10939,11 +11653,12 @@ def test_atomic_date_min_exclusive_6_nistxml_sv_ii_atomic_date_min_exclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_5_nistxml_sv_ii_atomic_date_min_exclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -10955,11 +11670,12 @@ def test_atomic_date_min_exclusive_5_nistxml_sv_ii_atomic_date_min_exclusive_1_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -10970,11 +11686,12 @@ def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -10985,11 +11702,12 @@ def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11000,11 +11718,12 @@ def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11015,11 +11734,12 @@ def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11030,11 +11750,12 @@ def test_atomic_time_enumeration_9_nistxml_sv_ii_atomic_time_enumeration_5_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11045,11 +11766,12 @@ def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11060,11 +11782,12 @@ def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11075,11 +11798,12 @@ def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11090,11 +11814,12 @@ def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11105,11 +11830,12 @@ def test_atomic_time_enumeration_8_nistxml_sv_ii_atomic_time_enumeration_4_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11120,11 +11846,12 @@ def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11135,11 +11862,12 @@ def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11150,11 +11878,12 @@ def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11165,11 +11894,12 @@ def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11180,11 +11910,12 @@ def test_atomic_time_enumeration_7_nistxml_sv_ii_atomic_time_enumeration_3_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11195,11 +11926,12 @@ def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11210,11 +11942,12 @@ def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11225,11 +11958,12 @@ def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11240,11 +11974,12 @@ def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11255,11 +11990,12 @@ def test_atomic_time_enumeration_6_nistxml_sv_ii_atomic_time_enumeration_2_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11270,11 +12006,12 @@ def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11285,11 +12022,12 @@ def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11300,11 +12038,12 @@ def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11315,11 +12054,12 @@ def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -11330,11 +12070,12 @@ def test_atomic_time_enumeration_5_nistxml_sv_ii_atomic_time_enumeration_1_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11346,11 +12087,12 @@ def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11362,11 +12104,12 @@ def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11378,11 +12121,12 @@ def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11394,11 +12138,12 @@ def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11410,11 +12155,12 @@ def test_atomic_time_pattern_9_nistxml_sv_ii_atomic_time_pattern_5_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11426,11 +12172,12 @@ def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11442,11 +12189,12 @@ def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11458,11 +12206,12 @@ def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11474,11 +12223,12 @@ def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11490,11 +12240,12 @@ def test_atomic_time_pattern_8_nistxml_sv_ii_atomic_time_pattern_4_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11506,11 +12257,12 @@ def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11522,11 +12274,12 @@ def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11538,11 +12291,12 @@ def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11554,11 +12308,12 @@ def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11570,11 +12325,12 @@ def test_atomic_time_pattern_7_nistxml_sv_ii_atomic_time_pattern_3_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11586,11 +12342,12 @@ def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11602,11 +12359,12 @@ def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11618,11 +12376,12 @@ def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11634,11 +12393,12 @@ def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11650,11 +12410,12 @@ def test_atomic_time_pattern_6_nistxml_sv_ii_atomic_time_pattern_2_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11666,11 +12427,12 @@ def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11682,11 +12444,12 @@ def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11698,11 +12461,12 @@ def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11714,11 +12478,12 @@ def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -11730,11 +12495,12 @@ def test_atomic_time_pattern_5_nistxml_sv_ii_atomic_time_pattern_1_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_9_nistxml_sv_ii_atomic_time_max_exclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11746,11 +12512,12 @@ def test_atomic_time_max_exclusive_9_nistxml_sv_ii_atomic_time_max_exclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11762,11 +12529,12 @@ def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11778,11 +12546,12 @@ def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11794,11 +12563,12 @@ def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11810,11 +12580,12 @@ def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11826,11 +12597,12 @@ def test_atomic_time_max_exclusive_8_nistxml_sv_ii_atomic_time_max_exclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11842,11 +12614,12 @@ def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11858,11 +12631,12 @@ def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11874,11 +12648,12 @@ def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11890,11 +12665,12 @@ def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11906,11 +12682,12 @@ def test_atomic_time_max_exclusive_7_nistxml_sv_ii_atomic_time_max_exclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11922,11 +12699,12 @@ def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11938,11 +12716,12 @@ def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11954,11 +12733,12 @@ def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11970,11 +12750,12 @@ def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -11986,11 +12767,12 @@ def test_atomic_time_max_exclusive_6_nistxml_sv_ii_atomic_time_max_exclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -12002,11 +12784,12 @@ def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -12018,11 +12801,12 @@ def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -12034,11 +12818,12 @@ def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -12050,11 +12835,12 @@ def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -12066,11 +12852,12 @@ def test_atomic_time_max_exclusive_5_nistxml_sv_ii_atomic_time_max_exclusive_1_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12082,11 +12869,12 @@ def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12098,11 +12886,12 @@ def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12114,11 +12903,12 @@ def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12130,11 +12920,12 @@ def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12146,11 +12937,12 @@ def test_atomic_time_min_exclusive_9_nistxml_sv_ii_atomic_time_min_exclusive_5_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12162,11 +12954,12 @@ def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12178,11 +12971,12 @@ def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12194,11 +12988,12 @@ def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12210,11 +13005,12 @@ def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12226,11 +13022,12 @@ def test_atomic_time_min_exclusive_8_nistxml_sv_ii_atomic_time_min_exclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12242,11 +13039,12 @@ def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12258,11 +13056,12 @@ def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12274,11 +13073,12 @@ def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12290,11 +13090,12 @@ def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12306,11 +13107,12 @@ def test_atomic_time_min_exclusive_7_nistxml_sv_ii_atomic_time_min_exclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12322,11 +13124,12 @@ def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12338,11 +13141,12 @@ def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12354,11 +13158,12 @@ def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12370,11 +13175,12 @@ def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12386,11 +13192,12 @@ def test_atomic_time_min_exclusive_6_nistxml_sv_ii_atomic_time_min_exclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_5_nistxml_sv_ii_atomic_time_min_exclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -12402,11 +13209,12 @@ def test_atomic_time_min_exclusive_5_nistxml_sv_ii_atomic_time_min_exclusive_1_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumeration_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12417,11 +13225,12 @@ def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumeration_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12432,11 +13241,12 @@ def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumeration_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12447,11 +13257,12 @@ def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumeration_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12462,11 +13273,12 @@ def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumeration_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12477,11 +13289,12 @@ def test_atomic_date_time_enumeration_9_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumeration_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12492,11 +13305,12 @@ def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumeration_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12507,11 +13321,12 @@ def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumeration_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12522,11 +13337,12 @@ def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumeration_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12537,11 +13353,12 @@ def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumeration_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12552,11 +13369,12 @@ def test_atomic_date_time_enumeration_8_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumeration_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12567,11 +13385,12 @@ def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumeration_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12582,11 +13401,12 @@ def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumeration_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12597,11 +13417,12 @@ def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumeration_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12612,11 +13433,12 @@ def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumeration_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12627,11 +13449,12 @@ def test_atomic_date_time_enumeration_7_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumeration_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12642,11 +13465,12 @@ def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumeration_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12657,11 +13481,12 @@ def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumeration_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12672,11 +13497,12 @@ def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumeration_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12687,11 +13513,12 @@ def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumeration_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12702,11 +13529,12 @@ def test_atomic_date_time_enumeration_6_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumeration_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12717,11 +13545,12 @@ def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumeration_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12732,11 +13561,12 @@ def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumeration_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12747,11 +13577,12 @@ def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumeration_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12762,11 +13593,12 @@ def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumeration_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -12777,11 +13609,12 @@ def test_atomic_date_time_enumeration_5_nistxml_sv_ii_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12793,11 +13626,12 @@ def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12809,11 +13643,12 @@ def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12825,11 +13660,12 @@ def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12841,11 +13677,12 @@ def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12857,11 +13694,12 @@ def test_atomic_date_time_pattern_9_nistxml_sv_ii_atomic_date_time_pattern_5_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12873,11 +13711,12 @@ def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12889,11 +13728,12 @@ def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12905,11 +13745,12 @@ def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12921,11 +13762,12 @@ def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12937,11 +13779,12 @@ def test_atomic_date_time_pattern_8_nistxml_sv_ii_atomic_date_time_pattern_4_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12953,11 +13796,12 @@ def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12969,11 +13813,12 @@ def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -12985,11 +13830,12 @@ def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13001,11 +13847,12 @@ def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13017,11 +13864,12 @@ def test_atomic_date_time_pattern_7_nistxml_sv_ii_atomic_date_time_pattern_3_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13033,11 +13881,12 @@ def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13049,11 +13898,12 @@ def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13065,11 +13915,12 @@ def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13081,11 +13932,12 @@ def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13097,11 +13949,12 @@ def test_atomic_date_time_pattern_6_nistxml_sv_ii_atomic_date_time_pattern_2_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13113,11 +13966,12 @@ def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13129,11 +13983,12 @@ def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13145,11 +14000,12 @@ def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13161,11 +14017,12 @@ def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -13177,11 +14034,12 @@ def test_atomic_date_time_pattern_5_nistxml_sv_ii_atomic_date_time_pattern_1_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_9_nistxml_sv_ii_atomic_date_time_max_exclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13193,11 +14051,12 @@ def test_atomic_date_time_max_exclusive_9_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13209,11 +14068,12 @@ def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13225,11 +14085,12 @@ def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13241,11 +14102,12 @@ def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13257,11 +14119,12 @@ def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13273,11 +14136,12 @@ def test_atomic_date_time_max_exclusive_8_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13289,11 +14153,12 @@ def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13305,11 +14170,12 @@ def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13321,11 +14187,12 @@ def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13337,11 +14204,12 @@ def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13353,11 +14221,12 @@ def test_atomic_date_time_max_exclusive_7_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13369,11 +14238,12 @@ def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13385,11 +14255,12 @@ def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13401,11 +14272,12 @@ def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13417,11 +14289,12 @@ def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13433,11 +14306,12 @@ def test_atomic_date_time_max_exclusive_6_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13449,11 +14323,12 @@ def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exclusive_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13465,11 +14340,12 @@ def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exclusive_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13481,11 +14357,12 @@ def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exclusive_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13497,11 +14374,12 @@ def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exclusive_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -13513,11 +14391,12 @@ def test_atomic_date_time_max_exclusive_5_nistxml_sv_ii_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13529,11 +14408,12 @@ def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exclusive_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13545,11 +14425,12 @@ def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exclusive_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13561,11 +14442,12 @@ def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exclusive_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13577,11 +14459,12 @@ def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exclusive_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13593,11 +14476,12 @@ def test_atomic_date_time_min_exclusive_9_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13609,11 +14493,12 @@ def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13625,11 +14510,12 @@ def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13641,11 +14527,12 @@ def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13657,11 +14544,12 @@ def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13673,11 +14561,12 @@ def test_atomic_date_time_min_exclusive_8_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13689,11 +14578,12 @@ def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13705,11 +14595,12 @@ def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13721,11 +14612,12 @@ def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13737,11 +14629,12 @@ def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13753,11 +14646,12 @@ def test_atomic_date_time_min_exclusive_7_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13769,11 +14663,12 @@ def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13785,11 +14680,12 @@ def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13801,11 +14697,12 @@ def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13817,11 +14714,12 @@ def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13833,11 +14731,12 @@ def test_atomic_date_time_min_exclusive_6_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_5_nistxml_sv_ii_atomic_date_time_min_exclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -13849,11 +14748,12 @@ def test_atomic_date_time_min_exclusive_5_nistxml_sv_ii_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13864,11 +14764,12 @@ def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13879,11 +14780,12 @@ def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13894,11 +14796,12 @@ def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13909,11 +14812,12 @@ def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13924,11 +14828,12 @@ def test_atomic_duration_enumeration_9_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13939,11 +14844,12 @@ def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13954,11 +14860,12 @@ def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13969,11 +14876,12 @@ def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13984,11 +14892,12 @@ def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -13999,11 +14908,12 @@ def test_atomic_duration_enumeration_8_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14014,11 +14924,12 @@ def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14029,11 +14940,12 @@ def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14044,11 +14956,12 @@ def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14059,11 +14972,12 @@ def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14074,11 +14988,12 @@ def test_atomic_duration_enumeration_7_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14089,11 +15004,12 @@ def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14104,11 +15020,12 @@ def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14119,11 +15036,12 @@ def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14134,11 +15052,12 @@ def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14149,11 +15068,12 @@ def test_atomic_duration_enumeration_6_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14164,11 +15084,12 @@ def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14179,11 +15100,12 @@ def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14194,11 +15116,12 @@ def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14209,11 +15132,12 @@ def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -14224,11 +15148,12 @@ def test_atomic_duration_enumeration_5_nistxml_sv_ii_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14240,11 +15165,12 @@ def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14256,11 +15182,12 @@ def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14272,11 +15199,12 @@ def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14288,11 +15216,12 @@ def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14304,11 +15233,12 @@ def test_atomic_duration_pattern_9_nistxml_sv_ii_atomic_duration_pattern_5_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14320,11 +15250,12 @@ def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14336,11 +15267,12 @@ def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14352,11 +15284,12 @@ def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14368,11 +15301,12 @@ def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14384,11 +15318,12 @@ def test_atomic_duration_pattern_8_nistxml_sv_ii_atomic_duration_pattern_4_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14400,11 +15335,12 @@ def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14416,11 +15352,12 @@ def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14432,11 +15369,12 @@ def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14448,11 +15386,12 @@ def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14464,11 +15403,12 @@ def test_atomic_duration_pattern_7_nistxml_sv_ii_atomic_duration_pattern_3_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14480,11 +15420,12 @@ def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14496,11 +15437,12 @@ def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14512,11 +15454,12 @@ def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14528,11 +15471,12 @@ def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14544,11 +15488,12 @@ def test_atomic_duration_pattern_6_nistxml_sv_ii_atomic_duration_pattern_2_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14560,11 +15505,12 @@ def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14576,11 +15522,12 @@ def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14592,11 +15539,12 @@ def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14608,11 +15556,12 @@ def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -14624,11 +15573,12 @@ def test_atomic_duration_pattern_5_nistxml_sv_ii_atomic_duration_pattern_1_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_9_nistxml_sv_ii_atomic_duration_max_exclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14640,11 +15590,12 @@ def test_atomic_duration_max_exclusive_9_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14656,11 +15607,12 @@ def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14672,11 +15624,12 @@ def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14688,11 +15641,12 @@ def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14704,11 +15658,12 @@ def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14720,11 +15675,12 @@ def test_atomic_duration_max_exclusive_8_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14736,11 +15692,12 @@ def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14752,11 +15709,12 @@ def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14768,11 +15726,12 @@ def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14784,11 +15743,12 @@ def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14800,11 +15760,12 @@ def test_atomic_duration_max_exclusive_7_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14816,11 +15777,12 @@ def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14832,11 +15794,12 @@ def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14848,11 +15811,12 @@ def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14864,11 +15828,12 @@ def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14880,11 +15845,12 @@ def test_atomic_duration_max_exclusive_6_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14896,11 +15862,12 @@ def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclusive_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14912,11 +15879,12 @@ def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclusive_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14928,11 +15896,12 @@ def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclusive_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14944,11 +15913,12 @@ def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclusive_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -14960,11 +15930,12 @@ def test_atomic_duration_max_exclusive_5_nistxml_sv_ii_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -14976,11 +15947,12 @@ def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclusive_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -14992,11 +15964,12 @@ def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclusive_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15008,11 +15981,12 @@ def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclusive_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15024,11 +15998,12 @@ def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclusive_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15040,11 +16015,12 @@ def test_atomic_duration_min_exclusive_9_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15056,11 +16032,12 @@ def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15072,11 +16049,12 @@ def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15088,11 +16066,12 @@ def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15104,11 +16083,12 @@ def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15120,11 +16100,12 @@ def test_atomic_duration_min_exclusive_8_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15136,11 +16117,12 @@ def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15152,11 +16134,12 @@ def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15168,11 +16151,12 @@ def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15184,11 +16168,12 @@ def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15200,11 +16185,12 @@ def test_atomic_duration_min_exclusive_7_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15216,11 +16202,12 @@ def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15232,11 +16219,12 @@ def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15248,11 +16236,12 @@ def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15264,11 +16253,12 @@ def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15280,11 +16270,12 @@ def test_atomic_duration_min_exclusive_6_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_5_nistxml_sv_ii_atomic_duration_min_exclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -15296,11 +16287,12 @@ def test_atomic_duration_min_exclusive_5_nistxml_sv_ii_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_integer_enumeration_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15311,11 +16303,12 @@ def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_integer_enumeration_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15326,11 +16319,12 @@ def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_integer_enumeration_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15341,11 +16335,12 @@ def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_integer_enumeration_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15356,11 +16351,12 @@ def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_integer_enumeration_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15371,11 +16367,12 @@ def test_atomic_positive_integer_enumeration_9_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_integer_enumeration_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15386,11 +16383,12 @@ def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_integer_enumeration_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15401,11 +16399,12 @@ def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_integer_enumeration_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15416,11 +16415,12 @@ def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_integer_enumeration_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15431,11 +16431,12 @@ def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_integer_enumeration_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15446,11 +16447,12 @@ def test_atomic_positive_integer_enumeration_8_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_integer_enumeration_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -15461,6 +16463,6 @@ def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_12000.py
+++ b/tests/test_nist_meta_12000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_integer_enumeration_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -11,11 +14,12 @@ def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_integer_enumeration_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -26,11 +30,12 @@ def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_integer_enumeration_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -41,11 +46,12 @@ def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_integer_enumeration_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -56,11 +62,12 @@ def test_atomic_positive_integer_enumeration_7_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_integer_enumeration_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -71,11 +78,12 @@ def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_integer_enumeration_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -86,11 +94,12 @@ def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_integer_enumeration_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -101,11 +110,12 @@ def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_integer_enumeration_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -116,11 +126,12 @@ def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_integer_enumeration_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -131,11 +142,12 @@ def test_atomic_positive_integer_enumeration_6_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_integer_enumeration_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -146,11 +158,12 @@ def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_integer_enumeration_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -161,11 +174,12 @@ def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_integer_enumeration_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -176,11 +190,12 @@ def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_integer_enumeration_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -191,11 +206,12 @@ def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_integer_enumeration_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -206,11 +222,12 @@ def test_atomic_positive_integer_enumeration_5_nistxml_sv_ii_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -222,11 +239,12 @@ def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -238,11 +256,12 @@ def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -254,11 +273,12 @@ def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -270,11 +290,12 @@ def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -286,11 +307,12 @@ def test_atomic_positive_integer_pattern_9_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -302,11 +324,12 @@ def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -318,11 +341,12 @@ def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -334,11 +358,12 @@ def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -350,11 +375,12 @@ def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -366,11 +392,12 @@ def test_atomic_positive_integer_pattern_8_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -382,11 +409,12 @@ def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -398,11 +426,12 @@ def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -414,11 +443,12 @@ def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -430,11 +460,12 @@ def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -446,11 +477,12 @@ def test_atomic_positive_integer_pattern_7_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -462,11 +494,12 @@ def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -478,11 +511,12 @@ def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -494,11 +528,12 @@ def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -510,11 +545,12 @@ def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -526,11 +562,12 @@ def test_atomic_positive_integer_pattern_6_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -542,11 +579,12 @@ def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -558,11 +596,12 @@ def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -574,11 +613,12 @@ def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -590,11 +630,12 @@ def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -606,11 +647,12 @@ def test_atomic_positive_integer_pattern_5_nistxml_sv_ii_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_9_nistxml_sv_ii_atomic_positive_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -622,11 +664,12 @@ def test_atomic_positive_integer_max_exclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -638,11 +681,12 @@ def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -654,11 +698,12 @@ def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -670,11 +715,12 @@ def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -686,11 +732,12 @@ def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -702,11 +749,12 @@ def test_atomic_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -718,11 +766,12 @@ def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -734,11 +783,12 @@ def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -750,11 +800,12 @@ def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -766,11 +817,12 @@ def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -782,11 +834,12 @@ def test_atomic_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -798,11 +851,12 @@ def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -814,11 +868,12 @@ def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -830,11 +885,12 @@ def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -846,11 +902,12 @@ def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -862,11 +919,12 @@ def test_atomic_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -878,11 +936,12 @@ def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_integer_max_exclusive_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -894,11 +953,12 @@ def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_integer_max_exclusive_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -910,11 +970,12 @@ def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_integer_max_exclusive_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -926,11 +987,12 @@ def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_integer_max_exclusive_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -942,11 +1004,12 @@ def test_atomic_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -958,11 +1021,12 @@ def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_integer_min_exclusive_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -974,11 +1038,12 @@ def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_integer_min_exclusive_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -990,11 +1055,12 @@ def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_integer_min_exclusive_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1006,11 +1072,12 @@ def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_integer_min_exclusive_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1022,11 +1089,12 @@ def test_atomic_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1038,11 +1106,12 @@ def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1054,11 +1123,12 @@ def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1070,11 +1140,12 @@ def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1086,11 +1157,12 @@ def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1102,11 +1174,12 @@ def test_atomic_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1118,11 +1191,12 @@ def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1134,11 +1208,12 @@ def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1150,11 +1225,12 @@ def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1166,11 +1242,12 @@ def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1182,11 +1259,12 @@ def test_atomic_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1198,11 +1276,12 @@ def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1214,11 +1293,12 @@ def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1230,11 +1310,12 @@ def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1246,11 +1327,12 @@ def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1262,11 +1344,12 @@ def test_atomic_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_5_nistxml_sv_ii_atomic_positive_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -1278,11 +1361,12 @@ def test_atomic_positive_integer_min_exclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1293,11 +1377,12 @@ def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1308,11 +1393,12 @@ def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1323,11 +1409,12 @@ def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1338,11 +1425,12 @@ def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1353,11 +1441,12 @@ def test_atomic_unsigned_byte_enumeration_9_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1368,11 +1457,12 @@ def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1383,11 +1473,12 @@ def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1398,11 +1489,12 @@ def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1413,11 +1505,12 @@ def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1428,11 +1521,12 @@ def test_atomic_unsigned_byte_enumeration_8_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1443,11 +1537,12 @@ def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1458,11 +1553,12 @@ def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1473,11 +1569,12 @@ def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1488,11 +1585,12 @@ def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1503,11 +1601,12 @@ def test_atomic_unsigned_byte_enumeration_7_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1518,11 +1617,12 @@ def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1533,11 +1633,12 @@ def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1548,11 +1649,12 @@ def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1563,11 +1665,12 @@ def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1578,11 +1681,12 @@ def test_atomic_unsigned_byte_enumeration_6_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1593,11 +1697,12 @@ def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1608,11 +1713,12 @@ def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1623,11 +1729,12 @@ def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1638,11 +1745,12 @@ def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -1653,11 +1761,12 @@ def test_atomic_unsigned_byte_enumeration_5_nistxml_sv_ii_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1669,11 +1778,12 @@ def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1685,11 +1795,12 @@ def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1701,11 +1812,12 @@ def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1717,11 +1829,12 @@ def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1733,11 +1846,12 @@ def test_atomic_unsigned_byte_pattern_9_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1749,11 +1863,12 @@ def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1765,11 +1880,12 @@ def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1781,11 +1897,12 @@ def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1797,11 +1914,12 @@ def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1813,11 +1931,12 @@ def test_atomic_unsigned_byte_pattern_8_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1829,11 +1948,12 @@ def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1845,11 +1965,12 @@ def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1861,11 +1982,12 @@ def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1877,11 +1999,12 @@ def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1893,11 +2016,12 @@ def test_atomic_unsigned_byte_pattern_7_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1909,11 +2033,12 @@ def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1925,11 +2050,12 @@ def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1941,11 +2067,12 @@ def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1957,11 +2084,12 @@ def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1973,11 +2101,12 @@ def test_atomic_unsigned_byte_pattern_6_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1989,11 +2118,12 @@ def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -2005,11 +2135,12 @@ def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -2021,11 +2152,12 @@ def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -2037,11 +2169,12 @@ def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -2053,11 +2186,12 @@ def test_atomic_unsigned_byte_pattern_5_nistxml_sv_ii_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2069,11 +2203,12 @@ def test_atomic_unsigned_byte_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2085,11 +2220,12 @@ def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2101,11 +2237,12 @@ def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2117,11 +2254,12 @@ def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2133,11 +2271,12 @@ def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2149,11 +2288,12 @@ def test_atomic_unsigned_byte_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2165,11 +2305,12 @@ def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2181,11 +2322,12 @@ def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2197,11 +2339,12 @@ def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2213,11 +2356,12 @@ def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2229,11 +2373,12 @@ def test_atomic_unsigned_byte_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2245,11 +2390,12 @@ def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2261,11 +2407,12 @@ def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2277,11 +2424,12 @@ def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2293,11 +2441,12 @@ def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2309,11 +2458,12 @@ def test_atomic_unsigned_byte_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2325,11 +2475,12 @@ def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2341,11 +2492,12 @@ def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2357,11 +2509,12 @@ def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2373,11 +2526,12 @@ def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2389,11 +2543,12 @@ def test_atomic_unsigned_byte_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2405,11 +2560,12 @@ def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2421,11 +2577,12 @@ def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2437,11 +2594,12 @@ def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2453,11 +2611,12 @@ def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2469,11 +2628,12 @@ def test_atomic_unsigned_byte_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2485,11 +2645,12 @@ def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2501,11 +2662,12 @@ def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2517,11 +2679,12 @@ def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2533,11 +2696,12 @@ def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2549,11 +2713,12 @@ def test_atomic_unsigned_byte_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2565,11 +2730,12 @@ def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2581,11 +2747,12 @@ def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2597,11 +2764,12 @@ def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2613,11 +2781,12 @@ def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2629,11 +2798,12 @@ def test_atomic_unsigned_byte_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2645,11 +2815,12 @@ def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2661,11 +2832,12 @@ def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2677,11 +2849,12 @@ def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2693,11 +2866,12 @@ def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2709,11 +2883,12 @@ def test_atomic_unsigned_byte_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2725,11 +2900,12 @@ def test_atomic_unsigned_byte_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2740,11 +2916,12 @@ def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2755,11 +2932,12 @@ def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2770,11 +2948,12 @@ def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2785,11 +2964,12 @@ def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2800,11 +2980,12 @@ def test_atomic_unsigned_short_enumeration_9_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2815,11 +2996,12 @@ def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2830,11 +3012,12 @@ def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2845,11 +3028,12 @@ def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2860,11 +3044,12 @@ def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2875,11 +3060,12 @@ def test_atomic_unsigned_short_enumeration_8_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2890,11 +3076,12 @@ def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2905,11 +3092,12 @@ def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2920,11 +3108,12 @@ def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2935,11 +3124,12 @@ def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2950,11 +3140,12 @@ def test_atomic_unsigned_short_enumeration_7_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2965,11 +3156,12 @@ def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2980,11 +3172,12 @@ def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2995,11 +3188,12 @@ def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3010,11 +3204,12 @@ def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3025,11 +3220,12 @@ def test_atomic_unsigned_short_enumeration_6_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3040,11 +3236,12 @@ def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3055,11 +3252,12 @@ def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3070,11 +3268,12 @@ def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3085,11 +3284,12 @@ def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3100,11 +3300,12 @@ def test_atomic_unsigned_short_enumeration_5_nistxml_sv_ii_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3116,11 +3317,12 @@ def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3132,11 +3334,12 @@ def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3148,11 +3351,12 @@ def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3164,11 +3368,12 @@ def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3180,11 +3385,12 @@ def test_atomic_unsigned_short_pattern_9_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3196,11 +3402,12 @@ def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3212,11 +3419,12 @@ def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3228,11 +3436,12 @@ def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3244,11 +3453,12 @@ def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3260,11 +3470,12 @@ def test_atomic_unsigned_short_pattern_8_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3276,11 +3487,12 @@ def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3292,11 +3504,12 @@ def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3308,11 +3521,12 @@ def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3324,11 +3538,12 @@ def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3340,11 +3555,12 @@ def test_atomic_unsigned_short_pattern_7_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3356,11 +3572,12 @@ def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3372,11 +3589,12 @@ def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3388,11 +3606,12 @@ def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3404,11 +3623,12 @@ def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3420,11 +3640,12 @@ def test_atomic_unsigned_short_pattern_6_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3436,11 +3657,12 @@ def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3452,11 +3674,12 @@ def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3468,11 +3691,12 @@ def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3484,11 +3708,12 @@ def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3500,11 +3725,12 @@ def test_atomic_unsigned_short_pattern_5_nistxml_sv_ii_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3516,11 +3742,12 @@ def test_atomic_unsigned_short_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3532,11 +3759,12 @@ def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3548,11 +3776,12 @@ def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3564,11 +3793,12 @@ def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3580,11 +3810,12 @@ def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3596,11 +3827,12 @@ def test_atomic_unsigned_short_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3612,11 +3844,12 @@ def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3628,11 +3861,12 @@ def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3644,11 +3878,12 @@ def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3660,11 +3895,12 @@ def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3676,11 +3912,12 @@ def test_atomic_unsigned_short_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3692,11 +3929,12 @@ def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3708,11 +3946,12 @@ def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3724,11 +3963,12 @@ def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3740,11 +3980,12 @@ def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3756,11 +3997,12 @@ def test_atomic_unsigned_short_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3772,11 +4014,12 @@ def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3788,11 +4031,12 @@ def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3804,11 +4048,12 @@ def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3820,11 +4065,12 @@ def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -3836,11 +4082,12 @@ def test_atomic_unsigned_short_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3852,11 +4099,12 @@ def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3868,11 +4116,12 @@ def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3884,11 +4133,12 @@ def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3900,11 +4150,12 @@ def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3916,11 +4167,12 @@ def test_atomic_unsigned_short_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3932,11 +4184,12 @@ def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3948,11 +4201,12 @@ def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3964,11 +4218,12 @@ def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3980,11 +4235,12 @@ def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -3996,11 +4252,12 @@ def test_atomic_unsigned_short_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4012,11 +4269,12 @@ def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4028,11 +4286,12 @@ def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4044,11 +4303,12 @@ def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4060,11 +4320,12 @@ def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4076,11 +4337,12 @@ def test_atomic_unsigned_short_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4092,11 +4354,12 @@ def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4108,11 +4371,12 @@ def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4124,11 +4388,12 @@ def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4140,11 +4405,12 @@ def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4156,11 +4422,12 @@ def test_atomic_unsigned_short_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_short_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -4172,11 +4439,12 @@ def test_atomic_unsigned_short_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4187,11 +4455,12 @@ def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4202,11 +4471,12 @@ def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4217,11 +4487,12 @@ def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4232,11 +4503,12 @@ def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4247,11 +4519,12 @@ def test_atomic_unsigned_int_enumeration_9_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4262,11 +4535,12 @@ def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4277,11 +4551,12 @@ def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4292,11 +4567,12 @@ def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4307,11 +4583,12 @@ def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4322,11 +4599,12 @@ def test_atomic_unsigned_int_enumeration_8_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4337,11 +4615,12 @@ def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4352,11 +4631,12 @@ def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4367,11 +4647,12 @@ def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4382,11 +4663,12 @@ def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4397,11 +4679,12 @@ def test_atomic_unsigned_int_enumeration_7_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4412,11 +4695,12 @@ def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4427,11 +4711,12 @@ def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4442,11 +4727,12 @@ def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4457,11 +4743,12 @@ def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4472,11 +4759,12 @@ def test_atomic_unsigned_int_enumeration_6_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4487,11 +4775,12 @@ def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4502,11 +4791,12 @@ def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4517,11 +4807,12 @@ def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4532,11 +4823,12 @@ def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -4547,11 +4839,12 @@ def test_atomic_unsigned_int_enumeration_5_nistxml_sv_ii_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4563,11 +4856,12 @@ def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4579,11 +4873,12 @@ def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4595,11 +4890,12 @@ def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4611,11 +4907,12 @@ def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4627,11 +4924,12 @@ def test_atomic_unsigned_int_pattern_9_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4643,11 +4941,12 @@ def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4659,11 +4958,12 @@ def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4675,11 +4975,12 @@ def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4691,11 +4992,12 @@ def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4707,11 +5009,12 @@ def test_atomic_unsigned_int_pattern_8_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4723,11 +5026,12 @@ def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4739,11 +5043,12 @@ def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4755,11 +5060,12 @@ def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4771,11 +5077,12 @@ def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4787,11 +5094,12 @@ def test_atomic_unsigned_int_pattern_7_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4803,11 +5111,12 @@ def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4819,11 +5128,12 @@ def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4835,11 +5145,12 @@ def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4851,11 +5162,12 @@ def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4867,11 +5179,12 @@ def test_atomic_unsigned_int_pattern_6_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4883,11 +5196,12 @@ def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4899,11 +5213,12 @@ def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4915,11 +5230,12 @@ def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4931,11 +5247,12 @@ def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -4947,11 +5264,12 @@ def test_atomic_unsigned_int_pattern_5_nistxml_sv_ii_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -4963,11 +5281,12 @@ def test_atomic_unsigned_int_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -4979,11 +5298,12 @@ def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -4995,11 +5315,12 @@ def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5011,11 +5332,12 @@ def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5027,11 +5349,12 @@ def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5043,11 +5366,12 @@ def test_atomic_unsigned_int_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5059,11 +5383,12 @@ def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5075,11 +5400,12 @@ def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5091,11 +5417,12 @@ def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5107,11 +5434,12 @@ def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5123,11 +5451,12 @@ def test_atomic_unsigned_int_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5139,11 +5468,12 @@ def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5155,11 +5485,12 @@ def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5171,11 +5502,12 @@ def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5187,11 +5519,12 @@ def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5203,11 +5536,12 @@ def test_atomic_unsigned_int_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5219,11 +5553,12 @@ def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5235,11 +5570,12 @@ def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5251,11 +5587,12 @@ def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5267,11 +5604,12 @@ def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -5283,11 +5621,12 @@ def test_atomic_unsigned_int_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5299,11 +5638,12 @@ def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5315,11 +5655,12 @@ def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5331,11 +5672,12 @@ def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5347,11 +5689,12 @@ def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5363,11 +5706,12 @@ def test_atomic_unsigned_int_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5379,11 +5723,12 @@ def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5395,11 +5740,12 @@ def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5411,11 +5757,12 @@ def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5427,11 +5774,12 @@ def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5443,11 +5791,12 @@ def test_atomic_unsigned_int_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5459,11 +5808,12 @@ def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5475,11 +5825,12 @@ def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5491,11 +5842,12 @@ def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5507,11 +5859,12 @@ def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5523,11 +5876,12 @@ def test_atomic_unsigned_int_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5539,11 +5893,12 @@ def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5555,11 +5910,12 @@ def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5571,11 +5927,12 @@ def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5587,11 +5944,12 @@ def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5603,11 +5961,12 @@ def test_atomic_unsigned_int_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -5619,11 +5978,12 @@ def test_atomic_unsigned_int_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5634,11 +5994,12 @@ def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5649,11 +6010,12 @@ def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5664,11 +6026,12 @@ def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5679,11 +6042,12 @@ def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5694,11 +6058,12 @@ def test_atomic_unsigned_long_enumeration_9_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5709,11 +6074,12 @@ def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5724,11 +6090,12 @@ def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5739,11 +6106,12 @@ def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5754,11 +6122,12 @@ def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5769,11 +6138,12 @@ def test_atomic_unsigned_long_enumeration_8_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5784,11 +6154,12 @@ def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5799,11 +6170,12 @@ def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5814,11 +6186,12 @@ def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5829,11 +6202,12 @@ def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5844,11 +6218,12 @@ def test_atomic_unsigned_long_enumeration_7_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5859,11 +6234,12 @@ def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5874,11 +6250,12 @@ def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5889,11 +6266,12 @@ def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5904,11 +6282,12 @@ def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5919,11 +6298,12 @@ def test_atomic_unsigned_long_enumeration_6_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5934,11 +6314,12 @@ def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5949,11 +6330,12 @@ def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5964,11 +6346,12 @@ def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5979,11 +6362,12 @@ def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -5994,11 +6378,12 @@ def test_atomic_unsigned_long_enumeration_5_nistxml_sv_ii_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6010,11 +6395,12 @@ def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6026,11 +6412,12 @@ def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6042,11 +6429,12 @@ def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6058,11 +6446,12 @@ def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6074,11 +6463,12 @@ def test_atomic_unsigned_long_pattern_9_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6090,11 +6480,12 @@ def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6106,11 +6497,12 @@ def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6122,11 +6514,12 @@ def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6138,11 +6531,12 @@ def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6154,11 +6548,12 @@ def test_atomic_unsigned_long_pattern_8_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6170,11 +6565,12 @@ def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6186,11 +6582,12 @@ def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6202,11 +6599,12 @@ def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6218,11 +6616,12 @@ def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6234,11 +6633,12 @@ def test_atomic_unsigned_long_pattern_7_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6250,11 +6650,12 @@ def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6266,11 +6667,12 @@ def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6282,11 +6684,12 @@ def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6298,11 +6701,12 @@ def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6314,11 +6718,12 @@ def test_atomic_unsigned_long_pattern_6_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6330,11 +6735,12 @@ def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6346,11 +6752,12 @@ def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6362,11 +6769,12 @@ def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6378,11 +6786,12 @@ def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -6394,11 +6803,12 @@ def test_atomic_unsigned_long_pattern_5_nistxml_sv_ii_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6410,11 +6820,12 @@ def test_atomic_unsigned_long_max_exclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6426,11 +6837,12 @@ def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6442,11 +6854,12 @@ def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6458,11 +6871,12 @@ def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6474,11 +6888,12 @@ def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6490,11 +6905,12 @@ def test_atomic_unsigned_long_max_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6506,11 +6922,12 @@ def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6522,11 +6939,12 @@ def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6538,11 +6956,12 @@ def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6554,11 +6973,12 @@ def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6570,11 +6990,12 @@ def test_atomic_unsigned_long_max_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6586,11 +7007,12 @@ def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6602,11 +7024,12 @@ def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6618,11 +7041,12 @@ def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6634,11 +7058,12 @@ def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6650,11 +7075,12 @@ def test_atomic_unsigned_long_max_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6666,11 +7092,12 @@ def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6682,11 +7109,12 @@ def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6698,11 +7126,12 @@ def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6714,11 +7143,12 @@ def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -6730,11 +7160,12 @@ def test_atomic_unsigned_long_max_exclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6746,11 +7177,12 @@ def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6762,11 +7194,12 @@ def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6778,11 +7211,12 @@ def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6794,11 +7228,12 @@ def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6810,11 +7245,12 @@ def test_atomic_unsigned_long_min_exclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6826,11 +7262,12 @@ def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6842,11 +7279,12 @@ def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6858,11 +7296,12 @@ def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6874,11 +7313,12 @@ def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6890,11 +7330,12 @@ def test_atomic_unsigned_long_min_exclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6906,11 +7347,12 @@ def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6922,11 +7364,12 @@ def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6938,11 +7381,12 @@ def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6954,11 +7398,12 @@ def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6970,11 +7415,12 @@ def test_atomic_unsigned_long_min_exclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -6986,11 +7432,12 @@ def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -7002,11 +7449,12 @@ def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -7018,11 +7466,12 @@ def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -7034,11 +7483,12 @@ def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -7050,11 +7500,12 @@ def test_atomic_unsigned_long_min_exclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_long_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -7066,11 +7517,12 @@ def test_atomic_unsigned_long_min_exclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_negative_integer_enumeration_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7081,11 +7533,12 @@ def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_negative_integer_enumeration_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7096,11 +7549,12 @@ def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_negative_integer_enumeration_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7111,11 +7565,12 @@ def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_negative_integer_enumeration_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7126,11 +7581,12 @@ def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_negative_integer_enumeration_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7141,11 +7597,12 @@ def test_atomic_non_negative_integer_enumeration_9_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_negative_integer_enumeration_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7156,11 +7613,12 @@ def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_negative_integer_enumeration_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7171,11 +7629,12 @@ def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_negative_integer_enumeration_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7186,11 +7645,12 @@ def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_negative_integer_enumeration_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7201,11 +7661,12 @@ def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_negative_integer_enumeration_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7216,11 +7677,12 @@ def test_atomic_non_negative_integer_enumeration_8_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_negative_integer_enumeration_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7231,11 +7693,12 @@ def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_negative_integer_enumeration_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7246,11 +7709,12 @@ def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_negative_integer_enumeration_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7261,11 +7725,12 @@ def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_negative_integer_enumeration_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7276,11 +7741,12 @@ def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_negative_integer_enumeration_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7291,11 +7757,12 @@ def test_atomic_non_negative_integer_enumeration_7_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_negative_integer_enumeration_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7306,11 +7773,12 @@ def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_negative_integer_enumeration_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7321,11 +7789,12 @@ def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_negative_integer_enumeration_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7336,11 +7805,12 @@ def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_negative_integer_enumeration_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7351,11 +7821,12 @@ def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_negative_integer_enumeration_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7366,11 +7837,12 @@ def test_atomic_non_negative_integer_enumeration_6_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_negative_integer_enumeration_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7381,11 +7853,12 @@ def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_negative_integer_enumeration_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7396,11 +7869,12 @@ def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_negative_integer_enumeration_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7411,11 +7885,12 @@ def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_negative_integer_enumeration_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7426,11 +7901,12 @@ def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_negative_integer_enumeration_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -7441,11 +7917,12 @@ def test_atomic_non_negative_integer_enumeration_5_nistxml_sv_ii_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7457,11 +7934,12 @@ def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7473,11 +7951,12 @@ def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7489,11 +7968,12 @@ def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7505,11 +7985,12 @@ def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7521,11 +8002,12 @@ def test_atomic_non_negative_integer_pattern_9_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7537,11 +8019,12 @@ def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7553,11 +8036,12 @@ def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7569,11 +8053,12 @@ def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7585,11 +8070,12 @@ def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7601,11 +8087,12 @@ def test_atomic_non_negative_integer_pattern_8_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7617,11 +8104,12 @@ def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7633,11 +8121,12 @@ def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7649,11 +8138,12 @@ def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7665,11 +8155,12 @@ def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7681,11 +8172,12 @@ def test_atomic_non_negative_integer_pattern_7_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7697,11 +8189,12 @@ def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7713,11 +8206,12 @@ def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7729,11 +8223,12 @@ def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7745,11 +8240,12 @@ def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7761,11 +8257,12 @@ def test_atomic_non_negative_integer_pattern_6_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7777,11 +8274,12 @@ def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7793,11 +8291,12 @@ def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7809,11 +8308,12 @@ def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7825,11 +8325,12 @@ def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -7841,11 +8342,12 @@ def test_atomic_non_negative_integer_pattern_5_nistxml_sv_ii_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_9_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7857,11 +8359,12 @@ def test_atomic_non_negative_integer_max_exclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7873,11 +8376,12 @@ def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7889,11 +8393,12 @@ def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7905,11 +8410,12 @@ def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7921,11 +8427,12 @@ def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7937,11 +8444,12 @@ def test_atomic_non_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7953,11 +8461,12 @@ def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7969,11 +8478,12 @@ def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -7985,11 +8495,12 @@ def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8001,11 +8512,12 @@ def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8017,11 +8529,12 @@ def test_atomic_non_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8033,11 +8546,12 @@ def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8049,11 +8563,12 @@ def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8065,11 +8580,12 @@ def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8081,11 +8597,12 @@ def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8097,11 +8614,12 @@ def test_atomic_non_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8113,11 +8631,12 @@ def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8129,11 +8648,12 @@ def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8145,11 +8665,12 @@ def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8161,11 +8682,12 @@ def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_exclusive_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -8177,11 +8699,12 @@ def test_atomic_non_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8193,11 +8716,12 @@ def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8209,11 +8733,12 @@ def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8225,11 +8750,12 @@ def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8241,11 +8767,12 @@ def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8257,11 +8784,12 @@ def test_atomic_non_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8273,11 +8801,12 @@ def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8289,11 +8818,12 @@ def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8305,11 +8835,12 @@ def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8321,11 +8852,12 @@ def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8337,11 +8869,12 @@ def test_atomic_non_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8353,11 +8886,12 @@ def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8369,11 +8903,12 @@ def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8385,11 +8920,12 @@ def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8401,11 +8937,12 @@ def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8417,11 +8954,12 @@ def test_atomic_non_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8433,11 +8971,12 @@ def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8449,11 +8988,12 @@ def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8465,11 +9005,12 @@ def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8481,11 +9022,12 @@ def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8497,11 +9039,12 @@ def test_atomic_non_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_5_nistxml_sv_ii_atomic_non_negative_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -8513,11 +9056,12 @@ def test_atomic_non_negative_integer_min_exclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8528,11 +9072,12 @@ def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8543,11 +9088,12 @@ def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8558,11 +9104,12 @@ def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8573,11 +9120,12 @@ def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8588,11 +9136,12 @@ def test_atomic_byte_enumeration_9_nistxml_sv_ii_atomic_byte_enumeration_5_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8603,11 +9152,12 @@ def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8618,11 +9168,12 @@ def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8633,11 +9184,12 @@ def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8648,11 +9200,12 @@ def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8663,11 +9216,12 @@ def test_atomic_byte_enumeration_8_nistxml_sv_ii_atomic_byte_enumeration_4_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8678,11 +9232,12 @@ def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8693,11 +9248,12 @@ def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8708,11 +9264,12 @@ def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8723,11 +9280,12 @@ def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8738,11 +9296,12 @@ def test_atomic_byte_enumeration_7_nistxml_sv_ii_atomic_byte_enumeration_3_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8753,11 +9312,12 @@ def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8768,11 +9328,12 @@ def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8783,11 +9344,12 @@ def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8798,11 +9360,12 @@ def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8813,11 +9376,12 @@ def test_atomic_byte_enumeration_6_nistxml_sv_ii_atomic_byte_enumeration_2_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8828,11 +9392,12 @@ def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8843,11 +9408,12 @@ def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8858,11 +9424,12 @@ def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8873,11 +9440,12 @@ def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -8888,11 +9456,12 @@ def test_atomic_byte_enumeration_5_nistxml_sv_ii_atomic_byte_enumeration_1_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -8903,11 +9472,12 @@ def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -8918,11 +9488,12 @@ def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -8933,11 +9504,12 @@ def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -8948,11 +9520,12 @@ def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -8963,11 +9536,12 @@ def test_atomic_byte_pattern_9_nistxml_sv_ii_atomic_byte_pattern_5_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -8978,11 +9552,12 @@ def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -8993,11 +9568,12 @@ def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -9008,11 +9584,12 @@ def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -9023,11 +9600,12 @@ def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -9038,11 +9616,12 @@ def test_atomic_byte_pattern_8_nistxml_sv_ii_atomic_byte_pattern_4_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -9053,11 +9632,12 @@ def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -9068,11 +9648,12 @@ def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -9083,11 +9664,12 @@ def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -9098,11 +9680,12 @@ def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -9113,11 +9696,12 @@ def test_atomic_byte_pattern_7_nistxml_sv_ii_atomic_byte_pattern_3_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -9128,11 +9712,12 @@ def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -9143,11 +9728,12 @@ def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -9158,11 +9744,12 @@ def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -9173,11 +9760,12 @@ def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -9188,11 +9776,12 @@ def test_atomic_byte_pattern_6_nistxml_sv_ii_atomic_byte_pattern_2_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -9203,11 +9792,12 @@ def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -9218,11 +9808,12 @@ def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -9233,11 +9824,12 @@ def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -9248,11 +9840,12 @@ def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -9263,11 +9856,12 @@ def test_atomic_byte_pattern_5_nistxml_sv_ii_atomic_byte_pattern_1_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_9_nistxml_sv_ii_atomic_byte_max_exclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 127.
@@ -9278,11 +9872,12 @@ def test_atomic_byte_max_exclusive_9_nistxml_sv_ii_atomic_byte_max_exclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -38.
@@ -9293,11 +9888,12 @@ def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -38.
@@ -9308,11 +9904,12 @@ def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -38.
@@ -9323,11 +9920,12 @@ def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -38.
@@ -9338,11 +9936,12 @@ def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -38.
@@ -9353,11 +9952,12 @@ def test_atomic_byte_max_exclusive_8_nistxml_sv_ii_atomic_byte_max_exclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 100.
@@ -9368,11 +9968,12 @@ def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 100.
@@ -9383,11 +9984,12 @@ def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 100.
@@ -9398,11 +10000,12 @@ def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 100.
@@ -9413,11 +10016,12 @@ def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 100.
@@ -9428,11 +10032,12 @@ def test_atomic_byte_max_exclusive_7_nistxml_sv_ii_atomic_byte_max_exclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 48.
@@ -9443,11 +10048,12 @@ def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 48.
@@ -9458,11 +10064,12 @@ def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 48.
@@ -9473,11 +10080,12 @@ def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 48.
@@ -9488,11 +10096,12 @@ def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 48.
@@ -9503,11 +10112,12 @@ def test_atomic_byte_max_exclusive_6_nistxml_sv_ii_atomic_byte_max_exclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -127.
@@ -9518,11 +10128,12 @@ def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -127.
@@ -9533,11 +10144,12 @@ def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -127.
@@ -9548,11 +10160,12 @@ def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -127.
@@ -9563,11 +10176,12 @@ def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -127.
@@ -9578,11 +10192,12 @@ def test_atomic_byte_max_exclusive_5_nistxml_sv_ii_atomic_byte_max_exclusive_1_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 126.
@@ -9593,11 +10208,12 @@ def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 126.
@@ -9608,11 +10224,12 @@ def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 126.
@@ -9623,11 +10240,12 @@ def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 126.
@@ -9638,11 +10256,12 @@ def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 126.
@@ -9653,11 +10272,12 @@ def test_atomic_byte_min_exclusive_9_nistxml_sv_ii_atomic_byte_min_exclusive_5_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -118.
@@ -9668,11 +10288,12 @@ def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -118.
@@ -9683,11 +10304,12 @@ def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -118.
@@ -9698,11 +10320,12 @@ def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -118.
@@ -9713,11 +10336,12 @@ def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -118.
@@ -9728,11 +10352,12 @@ def test_atomic_byte_min_exclusive_8_nistxml_sv_ii_atomic_byte_min_exclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 113.
@@ -9743,11 +10368,12 @@ def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 113.
@@ -9758,11 +10384,12 @@ def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 113.
@@ -9773,11 +10400,12 @@ def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 113.
@@ -9788,11 +10416,12 @@ def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 113.
@@ -9803,11 +10432,12 @@ def test_atomic_byte_min_exclusive_7_nistxml_sv_ii_atomic_byte_min_exclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 17.
@@ -9818,11 +10448,12 @@ def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 17.
@@ -9833,11 +10464,12 @@ def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 17.
@@ -9848,11 +10480,12 @@ def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 17.
@@ -9863,11 +10496,12 @@ def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 17.
@@ -9878,11 +10512,12 @@ def test_atomic_byte_min_exclusive_6_nistxml_sv_ii_atomic_byte_min_exclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_5_nistxml_sv_ii_atomic_byte_min_exclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -128.
@@ -9893,11 +10528,12 @@ def test_atomic_byte_min_exclusive_5_nistxml_sv_ii_atomic_byte_min_exclusive_1_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9908,11 +10544,12 @@ def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9923,11 +10560,12 @@ def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9938,11 +10576,12 @@ def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9953,11 +10592,12 @@ def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9968,11 +10608,12 @@ def test_atomic_short_enumeration_9_nistxml_sv_ii_atomic_short_enumeration_5_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9983,11 +10624,12 @@ def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -9998,11 +10640,12 @@ def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10013,11 +10656,12 @@ def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10028,11 +10672,12 @@ def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10043,11 +10688,12 @@ def test_atomic_short_enumeration_8_nistxml_sv_ii_atomic_short_enumeration_4_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10058,11 +10704,12 @@ def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10073,11 +10720,12 @@ def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10088,11 +10736,12 @@ def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10103,11 +10752,12 @@ def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10118,11 +10768,12 @@ def test_atomic_short_enumeration_7_nistxml_sv_ii_atomic_short_enumeration_3_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10133,11 +10784,12 @@ def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10148,11 +10800,12 @@ def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10163,11 +10816,12 @@ def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10178,11 +10832,12 @@ def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10193,11 +10848,12 @@ def test_atomic_short_enumeration_6_nistxml_sv_ii_atomic_short_enumeration_2_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10208,11 +10864,12 @@ def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10223,11 +10880,12 @@ def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10238,11 +10896,12 @@ def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10253,11 +10912,12 @@ def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -10268,11 +10928,12 @@ def test_atomic_short_enumeration_5_nistxml_sv_ii_atomic_short_enumeration_1_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -10283,11 +10944,12 @@ def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -10298,11 +10960,12 @@ def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -10313,11 +10976,12 @@ def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -10328,11 +10992,12 @@ def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -10343,11 +11008,12 @@ def test_atomic_short_pattern_9_nistxml_sv_ii_atomic_short_pattern_5_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -10358,11 +11024,12 @@ def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -10373,11 +11040,12 @@ def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -10388,11 +11056,12 @@ def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -10403,11 +11072,12 @@ def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -10418,11 +11088,12 @@ def test_atomic_short_pattern_8_nistxml_sv_ii_atomic_short_pattern_4_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -10433,11 +11104,12 @@ def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -10448,11 +11120,12 @@ def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -10463,11 +11136,12 @@ def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -10478,11 +11152,12 @@ def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -10493,11 +11168,12 @@ def test_atomic_short_pattern_7_nistxml_sv_ii_atomic_short_pattern_3_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -10508,11 +11184,12 @@ def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -10523,11 +11200,12 @@ def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -10538,11 +11216,12 @@ def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -10553,11 +11232,12 @@ def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -10568,11 +11248,12 @@ def test_atomic_short_pattern_6_nistxml_sv_ii_atomic_short_pattern_2_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -10583,11 +11264,12 @@ def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -10598,11 +11280,12 @@ def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -10613,11 +11296,12 @@ def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -10628,11 +11312,12 @@ def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -10643,11 +11328,12 @@ def test_atomic_short_pattern_5_nistxml_sv_ii_atomic_short_pattern_1_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_9_nistxml_sv_ii_atomic_short_max_exclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10659,11 +11345,12 @@ def test_atomic_short_max_exclusive_9_nistxml_sv_ii_atomic_short_max_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10675,11 +11362,12 @@ def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10691,11 +11379,12 @@ def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10707,11 +11396,12 @@ def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10723,11 +11413,12 @@ def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10739,11 +11430,12 @@ def test_atomic_short_max_exclusive_8_nistxml_sv_ii_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10755,11 +11447,12 @@ def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10771,11 +11464,12 @@ def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10787,11 +11481,12 @@ def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10803,11 +11498,12 @@ def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10819,11 +11515,12 @@ def test_atomic_short_max_exclusive_7_nistxml_sv_ii_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10835,11 +11532,12 @@ def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10851,11 +11549,12 @@ def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10867,11 +11566,12 @@ def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10883,11 +11583,12 @@ def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10899,11 +11600,12 @@ def test_atomic_short_max_exclusive_6_nistxml_sv_ii_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10915,11 +11617,12 @@ def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10931,11 +11634,12 @@ def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10947,11 +11651,12 @@ def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10963,11 +11668,12 @@ def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -10979,11 +11685,12 @@ def test_atomic_short_max_exclusive_5_nistxml_sv_ii_atomic_short_max_exclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -10995,11 +11702,12 @@ def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11011,11 +11719,12 @@ def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11027,11 +11736,12 @@ def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11043,11 +11753,12 @@ def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11059,11 +11770,12 @@ def test_atomic_short_min_exclusive_9_nistxml_sv_ii_atomic_short_min_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11075,11 +11787,12 @@ def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11091,11 +11804,12 @@ def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11107,11 +11821,12 @@ def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11123,11 +11838,12 @@ def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11139,11 +11855,12 @@ def test_atomic_short_min_exclusive_8_nistxml_sv_ii_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11155,11 +11872,12 @@ def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11171,11 +11889,12 @@ def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11187,11 +11906,12 @@ def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11203,11 +11923,12 @@ def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11219,11 +11940,12 @@ def test_atomic_short_min_exclusive_7_nistxml_sv_ii_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11235,11 +11957,12 @@ def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11251,11 +11974,12 @@ def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11267,11 +11991,12 @@ def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11283,11 +12008,12 @@ def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11299,11 +12025,12 @@ def test_atomic_short_min_exclusive_6_nistxml_sv_ii_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_5_nistxml_sv_ii_atomic_short_min_exclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -11315,11 +12042,12 @@ def test_atomic_short_min_exclusive_5_nistxml_sv_ii_atomic_short_min_exclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11330,11 +12058,12 @@ def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11345,11 +12074,12 @@ def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11360,11 +12090,12 @@ def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11375,11 +12106,12 @@ def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11390,11 +12122,12 @@ def test_atomic_int_enumeration_9_nistxml_sv_ii_atomic_int_enumeration_5_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11405,11 +12138,12 @@ def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11420,11 +12154,12 @@ def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11435,11 +12170,12 @@ def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11450,11 +12186,12 @@ def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11465,11 +12202,12 @@ def test_atomic_int_enumeration_8_nistxml_sv_ii_atomic_int_enumeration_4_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11480,11 +12218,12 @@ def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11495,11 +12234,12 @@ def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11510,11 +12250,12 @@ def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11525,11 +12266,12 @@ def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11540,11 +12282,12 @@ def test_atomic_int_enumeration_7_nistxml_sv_ii_atomic_int_enumeration_3_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11555,11 +12298,12 @@ def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11570,11 +12314,12 @@ def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11585,11 +12330,12 @@ def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11600,11 +12346,12 @@ def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11615,11 +12362,12 @@ def test_atomic_int_enumeration_6_nistxml_sv_ii_atomic_int_enumeration_2_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11630,11 +12378,12 @@ def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11645,11 +12394,12 @@ def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11660,11 +12410,12 @@ def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11675,11 +12426,12 @@ def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -11690,11 +12442,12 @@ def test_atomic_int_enumeration_5_nistxml_sv_ii_atomic_int_enumeration_1_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -11705,11 +12458,12 @@ def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -11720,11 +12474,12 @@ def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -11735,11 +12490,12 @@ def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -11750,11 +12506,12 @@ def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -11765,11 +12522,12 @@ def test_atomic_int_pattern_9_nistxml_sv_ii_atomic_int_pattern_5_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -11780,11 +12538,12 @@ def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -11795,11 +12554,12 @@ def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -11810,11 +12570,12 @@ def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -11825,11 +12586,12 @@ def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -11840,11 +12602,12 @@ def test_atomic_int_pattern_8_nistxml_sv_ii_atomic_int_pattern_4_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -11855,11 +12618,12 @@ def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -11870,11 +12634,12 @@ def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -11885,11 +12650,12 @@ def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -11900,11 +12666,12 @@ def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -11915,11 +12682,12 @@ def test_atomic_int_pattern_7_nistxml_sv_ii_atomic_int_pattern_3_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -11930,11 +12698,12 @@ def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -11945,11 +12714,12 @@ def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -11960,11 +12730,12 @@ def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -11975,11 +12746,12 @@ def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -11990,11 +12762,12 @@ def test_atomic_int_pattern_6_nistxml_sv_ii_atomic_int_pattern_2_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -12005,11 +12778,12 @@ def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -12020,11 +12794,12 @@ def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -12035,11 +12810,12 @@ def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -12050,11 +12826,12 @@ def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -12065,11 +12842,12 @@ def test_atomic_int_pattern_5_nistxml_sv_ii_atomic_int_pattern_1_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_9_nistxml_sv_ii_atomic_int_max_exclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12081,11 +12859,12 @@ def test_atomic_int_max_exclusive_9_nistxml_sv_ii_atomic_int_max_exclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12097,11 +12876,12 @@ def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12113,11 +12893,12 @@ def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12129,11 +12910,12 @@ def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12145,11 +12927,12 @@ def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12161,11 +12944,12 @@ def test_atomic_int_max_exclusive_8_nistxml_sv_ii_atomic_int_max_exclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12177,11 +12961,12 @@ def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12193,11 +12978,12 @@ def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12209,11 +12995,12 @@ def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12225,11 +13012,12 @@ def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12241,11 +13029,12 @@ def test_atomic_int_max_exclusive_7_nistxml_sv_ii_atomic_int_max_exclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12257,11 +13046,12 @@ def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12273,11 +13063,12 @@ def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12289,11 +13080,12 @@ def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12305,11 +13097,12 @@ def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12321,11 +13114,12 @@ def test_atomic_int_max_exclusive_6_nistxml_sv_ii_atomic_int_max_exclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12337,11 +13131,12 @@ def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12353,11 +13148,12 @@ def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12369,11 +13165,12 @@ def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12385,11 +13182,12 @@ def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -12401,11 +13199,12 @@ def test_atomic_int_max_exclusive_5_nistxml_sv_ii_atomic_int_max_exclusive_1_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12417,11 +13216,12 @@ def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12433,11 +13233,12 @@ def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12449,11 +13250,12 @@ def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12465,11 +13267,12 @@ def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12481,11 +13284,12 @@ def test_atomic_int_min_exclusive_9_nistxml_sv_ii_atomic_int_min_exclusive_5_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12497,11 +13301,12 @@ def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12513,11 +13318,12 @@ def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12529,11 +13335,12 @@ def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12545,11 +13352,12 @@ def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12561,11 +13369,12 @@ def test_atomic_int_min_exclusive_8_nistxml_sv_ii_atomic_int_min_exclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12577,11 +13386,12 @@ def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12593,11 +13403,12 @@ def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12609,11 +13420,12 @@ def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12625,11 +13437,12 @@ def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12641,11 +13454,12 @@ def test_atomic_int_min_exclusive_7_nistxml_sv_ii_atomic_int_min_exclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12657,11 +13471,12 @@ def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12673,11 +13488,12 @@ def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12689,11 +13505,12 @@ def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12705,11 +13522,12 @@ def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12721,11 +13539,12 @@ def test_atomic_int_min_exclusive_6_nistxml_sv_ii_atomic_int_min_exclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_5_nistxml_sv_ii_atomic_int_min_exclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -12737,11 +13556,12 @@ def test_atomic_int_min_exclusive_5_nistxml_sv_ii_atomic_int_min_exclusive_1_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12752,11 +13572,12 @@ def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12767,11 +13588,12 @@ def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12782,11 +13604,12 @@ def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12797,11 +13620,12 @@ def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12812,11 +13636,12 @@ def test_atomic_long_enumeration_9_nistxml_sv_ii_atomic_long_enumeration_5_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12827,11 +13652,12 @@ def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12842,11 +13668,12 @@ def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12857,11 +13684,12 @@ def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12872,11 +13700,12 @@ def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12887,11 +13716,12 @@ def test_atomic_long_enumeration_8_nistxml_sv_ii_atomic_long_enumeration_4_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12902,11 +13732,12 @@ def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12917,11 +13748,12 @@ def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12932,11 +13764,12 @@ def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12947,11 +13780,12 @@ def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12962,11 +13796,12 @@ def test_atomic_long_enumeration_7_nistxml_sv_ii_atomic_long_enumeration_3_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12977,11 +13812,12 @@ def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -12992,11 +13828,12 @@ def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13007,11 +13844,12 @@ def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13022,11 +13860,12 @@ def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13037,11 +13876,12 @@ def test_atomic_long_enumeration_6_nistxml_sv_ii_atomic_long_enumeration_2_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13052,11 +13892,12 @@ def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13067,11 +13908,12 @@ def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13082,11 +13924,12 @@ def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13097,11 +13940,12 @@ def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -13112,11 +13956,12 @@ def test_atomic_long_enumeration_5_nistxml_sv_ii_atomic_long_enumeration_1_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -13127,11 +13972,12 @@ def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -13142,11 +13988,12 @@ def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -13157,11 +14004,12 @@ def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -13172,11 +14020,12 @@ def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -13187,11 +14036,12 @@ def test_atomic_long_pattern_9_nistxml_sv_ii_atomic_long_pattern_5_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -13202,11 +14052,12 @@ def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -13217,11 +14068,12 @@ def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -13232,11 +14084,12 @@ def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -13247,11 +14100,12 @@ def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -13262,11 +14116,12 @@ def test_atomic_long_pattern_8_nistxml_sv_ii_atomic_long_pattern_4_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -13277,11 +14132,12 @@ def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -13292,11 +14148,12 @@ def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -13307,11 +14164,12 @@ def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -13322,11 +14180,12 @@ def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -13337,11 +14196,12 @@ def test_atomic_long_pattern_7_nistxml_sv_ii_atomic_long_pattern_3_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -13352,11 +14212,12 @@ def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -13367,11 +14228,12 @@ def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -13382,11 +14244,12 @@ def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -13397,11 +14260,12 @@ def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -13412,11 +14276,12 @@ def test_atomic_long_pattern_6_nistxml_sv_ii_atomic_long_pattern_2_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -13427,11 +14292,12 @@ def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -13442,11 +14308,12 @@ def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -13457,11 +14324,12 @@ def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -13472,11 +14340,12 @@ def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -13487,11 +14356,12 @@ def test_atomic_long_pattern_5_nistxml_sv_ii_atomic_long_pattern_1_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_9_nistxml_sv_ii_atomic_long_max_exclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13503,11 +14373,12 @@ def test_atomic_long_max_exclusive_9_nistxml_sv_ii_atomic_long_max_exclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13519,11 +14390,12 @@ def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13535,11 +14407,12 @@ def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13551,11 +14424,12 @@ def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13567,11 +14441,12 @@ def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13583,11 +14458,12 @@ def test_atomic_long_max_exclusive_8_nistxml_sv_ii_atomic_long_max_exclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13599,11 +14475,12 @@ def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13615,11 +14492,12 @@ def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13631,11 +14509,12 @@ def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13647,11 +14526,12 @@ def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13663,11 +14543,12 @@ def test_atomic_long_max_exclusive_7_nistxml_sv_ii_atomic_long_max_exclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13679,11 +14560,12 @@ def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13695,11 +14577,12 @@ def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13711,11 +14594,12 @@ def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13727,11 +14611,12 @@ def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13743,11 +14628,12 @@ def test_atomic_long_max_exclusive_6_nistxml_sv_ii_atomic_long_max_exclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13759,11 +14645,12 @@ def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13775,11 +14662,12 @@ def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13791,11 +14679,12 @@ def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13807,11 +14696,12 @@ def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -13823,11 +14713,12 @@ def test_atomic_long_max_exclusive_5_nistxml_sv_ii_atomic_long_max_exclusive_1_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13839,11 +14730,12 @@ def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13855,11 +14747,12 @@ def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13871,11 +14764,12 @@ def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13887,11 +14781,12 @@ def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13903,11 +14798,12 @@ def test_atomic_long_min_exclusive_9_nistxml_sv_ii_atomic_long_min_exclusive_5_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13919,11 +14815,12 @@ def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13935,11 +14832,12 @@ def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13951,11 +14849,12 @@ def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13967,11 +14866,12 @@ def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13983,11 +14883,12 @@ def test_atomic_long_min_exclusive_8_nistxml_sv_ii_atomic_long_min_exclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -13999,11 +14900,12 @@ def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14015,11 +14917,12 @@ def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14031,11 +14934,12 @@ def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14047,11 +14951,12 @@ def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14063,11 +14968,12 @@ def test_atomic_long_min_exclusive_7_nistxml_sv_ii_atomic_long_min_exclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14079,11 +14985,12 @@ def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14095,11 +15002,12 @@ def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14111,11 +15019,12 @@ def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14127,11 +15036,12 @@ def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14143,11 +15053,12 @@ def test_atomic_long_min_exclusive_6_nistxml_sv_ii_atomic_long_min_exclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_5_nistxml_sv_ii_atomic_long_min_exclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -14159,11 +15070,12 @@ def test_atomic_long_min_exclusive_5_nistxml_sv_ii_atomic_long_min_exclusive_1_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_integer_enumeration_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14174,11 +15086,12 @@ def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_integer_enumeration_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14189,11 +15102,12 @@ def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_integer_enumeration_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14204,11 +15118,12 @@ def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_integer_enumeration_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14219,11 +15134,12 @@ def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_integer_enumeration_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14234,11 +15150,12 @@ def test_atomic_negative_integer_enumeration_9_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_integer_enumeration_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14249,11 +15166,12 @@ def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_integer_enumeration_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14264,11 +15182,12 @@ def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_integer_enumeration_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14279,11 +15198,12 @@ def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_integer_enumeration_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14294,11 +15214,12 @@ def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_integer_enumeration_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14309,11 +15230,12 @@ def test_atomic_negative_integer_enumeration_8_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_integer_enumeration_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14324,11 +15246,12 @@ def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_integer_enumeration_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14339,11 +15262,12 @@ def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_integer_enumeration_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14354,11 +15278,12 @@ def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_integer_enumeration_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14369,11 +15294,12 @@ def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_integer_enumeration_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14384,11 +15310,12 @@ def test_atomic_negative_integer_enumeration_7_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_integer_enumeration_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14399,11 +15326,12 @@ def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_integer_enumeration_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14414,11 +15342,12 @@ def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_integer_enumeration_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14429,11 +15358,12 @@ def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_integer_enumeration_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14444,11 +15374,12 @@ def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_integer_enumeration_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14459,11 +15390,12 @@ def test_atomic_negative_integer_enumeration_6_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_integer_enumeration_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14474,11 +15406,12 @@ def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_integer_enumeration_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14489,11 +15422,12 @@ def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_integer_enumeration_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14504,11 +15438,12 @@ def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_integer_enumeration_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14519,11 +15454,12 @@ def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_integer_enumeration_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -14534,11 +15470,12 @@ def test_atomic_negative_integer_enumeration_5_nistxml_sv_ii_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14550,11 +15487,12 @@ def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14566,11 +15504,12 @@ def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14582,11 +15521,12 @@ def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14598,11 +15538,12 @@ def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14614,11 +15555,12 @@ def test_atomic_negative_integer_pattern_9_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14630,11 +15572,12 @@ def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14646,11 +15589,12 @@ def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14662,11 +15606,12 @@ def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14678,11 +15623,12 @@ def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14694,11 +15640,12 @@ def test_atomic_negative_integer_pattern_8_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14710,11 +15657,12 @@ def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14726,11 +15674,12 @@ def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14742,11 +15691,12 @@ def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14758,11 +15708,12 @@ def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14774,11 +15725,12 @@ def test_atomic_negative_integer_pattern_7_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14790,11 +15742,12 @@ def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14806,11 +15759,12 @@ def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14822,11 +15776,12 @@ def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14838,11 +15793,12 @@ def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14854,11 +15810,12 @@ def test_atomic_negative_integer_pattern_6_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14870,11 +15827,12 @@ def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14886,11 +15844,12 @@ def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14902,11 +15861,12 @@ def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14918,11 +15878,12 @@ def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -14934,11 +15895,12 @@ def test_atomic_negative_integer_pattern_5_nistxml_sv_ii_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_9_nistxml_sv_ii_atomic_negative_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -14950,11 +15912,12 @@ def test_atomic_negative_integer_max_exclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -14966,11 +15929,12 @@ def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -14982,11 +15946,12 @@ def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -14998,11 +15963,12 @@ def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15014,11 +15980,12 @@ def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15030,11 +15997,12 @@ def test_atomic_negative_integer_max_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15046,11 +16014,12 @@ def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15062,11 +16031,12 @@ def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15078,11 +16048,12 @@ def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15094,11 +16065,12 @@ def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15110,11 +16082,12 @@ def test_atomic_negative_integer_max_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15126,11 +16099,12 @@ def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15142,11 +16116,12 @@ def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15158,11 +16133,12 @@ def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15174,11 +16150,12 @@ def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15190,11 +16167,12 @@ def test_atomic_negative_integer_max_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15206,11 +16184,12 @@ def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_integer_max_exclusive_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15222,11 +16201,12 @@ def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_integer_max_exclusive_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15238,11 +16218,12 @@ def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_integer_max_exclusive_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15254,11 +16235,12 @@ def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_integer_max_exclusive_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -15270,11 +16252,12 @@ def test_atomic_negative_integer_max_exclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15286,11 +16269,12 @@ def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_integer_min_exclusive_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15302,11 +16286,12 @@ def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_integer_min_exclusive_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15318,11 +16303,12 @@ def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_integer_min_exclusive_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15334,11 +16320,12 @@ def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_integer_min_exclusive_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15350,11 +16337,12 @@ def test_atomic_negative_integer_min_exclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15366,11 +16354,12 @@ def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15382,11 +16371,12 @@ def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15398,11 +16388,12 @@ def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15414,11 +16405,12 @@ def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15430,11 +16422,12 @@ def test_atomic_negative_integer_min_exclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15446,11 +16439,12 @@ def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15462,11 +16456,12 @@ def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15478,11 +16473,12 @@ def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15494,11 +16490,12 @@ def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15510,11 +16507,12 @@ def test_atomic_negative_integer_min_exclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15526,11 +16524,12 @@ def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15542,11 +16541,12 @@ def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15558,11 +16558,12 @@ def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15574,11 +16575,12 @@ def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -15590,6 +16592,6 @@ def test_atomic_negative_integer_min_exclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_13000.py
+++ b/tests/test_nist_meta_13000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_5_nistxml_sv_ii_atomic_negative_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -12,11 +15,12 @@ def test_atomic_negative_integer_min_exclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_positive_integer_enumeration_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -27,11 +31,12 @@ def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_positive_integer_enumeration_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -42,11 +47,12 @@ def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_positive_integer_enumeration_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -57,11 +63,12 @@ def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_positive_integer_enumeration_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -72,11 +79,12 @@ def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_positive_integer_enumeration_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -87,11 +95,12 @@ def test_atomic_non_positive_integer_enumeration_9_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_positive_integer_enumeration_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -102,11 +111,12 @@ def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_positive_integer_enumeration_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -117,11 +127,12 @@ def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_positive_integer_enumeration_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -132,11 +143,12 @@ def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_positive_integer_enumeration_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -147,11 +159,12 @@ def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_positive_integer_enumeration_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -162,11 +175,12 @@ def test_atomic_non_positive_integer_enumeration_8_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_positive_integer_enumeration_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -177,11 +191,12 @@ def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_positive_integer_enumeration_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -192,11 +207,12 @@ def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_positive_integer_enumeration_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -207,11 +223,12 @@ def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_positive_integer_enumeration_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -222,11 +239,12 @@ def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_positive_integer_enumeration_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -237,11 +255,12 @@ def test_atomic_non_positive_integer_enumeration_7_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_positive_integer_enumeration_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -252,11 +271,12 @@ def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_positive_integer_enumeration_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -267,11 +287,12 @@ def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_positive_integer_enumeration_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -282,11 +303,12 @@ def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_positive_integer_enumeration_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -297,11 +319,12 @@ def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_positive_integer_enumeration_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -312,11 +335,12 @@ def test_atomic_non_positive_integer_enumeration_6_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_positive_integer_enumeration_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -327,11 +351,12 @@ def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_positive_integer_enumeration_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -342,11 +367,12 @@ def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_positive_integer_enumeration_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -357,11 +383,12 @@ def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_positive_integer_enumeration_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -372,11 +399,12 @@ def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_positive_integer_enumeration_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -387,11 +415,12 @@ def test_atomic_non_positive_integer_enumeration_5_nistxml_sv_ii_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -403,11 +432,12 @@ def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -419,11 +449,12 @@ def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -435,11 +466,12 @@ def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -451,11 +483,12 @@ def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -467,11 +500,12 @@ def test_atomic_non_positive_integer_pattern_9_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -483,11 +517,12 @@ def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -499,11 +534,12 @@ def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -515,11 +551,12 @@ def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -531,11 +568,12 @@ def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -547,11 +585,12 @@ def test_atomic_non_positive_integer_pattern_8_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -563,11 +602,12 @@ def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -579,11 +619,12 @@ def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -595,11 +636,12 @@ def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -611,11 +653,12 @@ def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -627,11 +670,12 @@ def test_atomic_non_positive_integer_pattern_7_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -643,11 +687,12 @@ def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -659,11 +704,12 @@ def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -675,11 +721,12 @@ def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -691,11 +738,12 @@ def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -707,11 +755,12 @@ def test_atomic_non_positive_integer_pattern_6_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -723,11 +772,12 @@ def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -739,11 +789,12 @@ def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -755,11 +806,12 @@ def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -771,11 +823,12 @@ def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -787,11 +840,12 @@ def test_atomic_non_positive_integer_pattern_5_nistxml_sv_ii_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_9_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -803,11 +857,12 @@ def test_atomic_non_positive_integer_max_exclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -819,11 +874,12 @@ def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -835,11 +891,12 @@ def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -851,11 +908,12 @@ def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -867,11 +925,12 @@ def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -883,11 +942,12 @@ def test_atomic_non_positive_integer_max_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -899,11 +959,12 @@ def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -915,11 +976,12 @@ def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -931,11 +993,12 @@ def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -947,11 +1010,12 @@ def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -963,11 +1027,12 @@ def test_atomic_non_positive_integer_max_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -979,11 +1044,12 @@ def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -995,11 +1061,12 @@ def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1011,11 +1078,12 @@ def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1027,11 +1095,12 @@ def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1043,11 +1112,12 @@ def test_atomic_non_positive_integer_max_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1059,11 +1129,12 @@ def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1075,11 +1146,12 @@ def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1091,11 +1163,12 @@ def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1107,11 +1180,12 @@ def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_exclusive_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -1123,11 +1197,12 @@ def test_atomic_non_positive_integer_max_exclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1139,11 +1214,12 @@ def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1155,11 +1231,12 @@ def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1171,11 +1248,12 @@ def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1187,11 +1265,12 @@ def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1203,11 +1282,12 @@ def test_atomic_non_positive_integer_min_exclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1219,11 +1299,12 @@ def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1235,11 +1316,12 @@ def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1251,11 +1333,12 @@ def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1267,11 +1350,12 @@ def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1283,11 +1367,12 @@ def test_atomic_non_positive_integer_min_exclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1299,11 +1384,12 @@ def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1315,11 +1401,12 @@ def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1331,11 +1418,12 @@ def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1347,11 +1435,12 @@ def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1363,11 +1452,12 @@ def test_atomic_non_positive_integer_min_exclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1379,11 +1469,12 @@ def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1395,11 +1486,12 @@ def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1411,11 +1503,12 @@ def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1427,11 +1520,12 @@ def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1443,11 +1537,12 @@ def test_atomic_non_positive_integer_min_exclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_5_nistxml_sv_ii_atomic_non_positive_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -1459,11 +1554,12 @@ def test_atomic_non_positive_integer_min_exclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1474,11 +1570,12 @@ def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1489,11 +1586,12 @@ def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1504,11 +1602,12 @@ def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1519,11 +1618,12 @@ def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1534,11 +1634,12 @@ def test_atomic_integer_enumeration_9_nistxml_sv_ii_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1549,11 +1650,12 @@ def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1564,11 +1666,12 @@ def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1579,11 +1682,12 @@ def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1594,11 +1698,12 @@ def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1609,11 +1714,12 @@ def test_atomic_integer_enumeration_8_nistxml_sv_ii_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1624,11 +1730,12 @@ def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1639,11 +1746,12 @@ def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1654,11 +1762,12 @@ def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1669,11 +1778,12 @@ def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1684,11 +1794,12 @@ def test_atomic_integer_enumeration_7_nistxml_sv_ii_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1699,11 +1810,12 @@ def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1714,11 +1826,12 @@ def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1729,11 +1842,12 @@ def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1744,11 +1858,12 @@ def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1759,11 +1874,12 @@ def test_atomic_integer_enumeration_6_nistxml_sv_ii_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1774,11 +1890,12 @@ def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1789,11 +1906,12 @@ def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1804,11 +1922,12 @@ def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1819,11 +1938,12 @@ def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -1834,11 +1954,12 @@ def test_atomic_integer_enumeration_5_nistxml_sv_ii_atomic_integer_enumeration_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -1849,11 +1970,12 @@ def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -1864,11 +1986,12 @@ def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -1879,11 +2002,12 @@ def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -1894,11 +2018,12 @@ def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -1909,11 +2034,12 @@ def test_atomic_integer_pattern_9_nistxml_sv_ii_atomic_integer_pattern_5_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -1924,11 +2050,12 @@ def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -1939,11 +2066,12 @@ def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -1954,11 +2082,12 @@ def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -1969,11 +2098,12 @@ def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -1984,11 +2114,12 @@ def test_atomic_integer_pattern_8_nistxml_sv_ii_atomic_integer_pattern_4_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -1999,11 +2130,12 @@ def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -2014,11 +2146,12 @@ def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -2029,11 +2162,12 @@ def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -2044,11 +2178,12 @@ def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -2059,11 +2194,12 @@ def test_atomic_integer_pattern_7_nistxml_sv_ii_atomic_integer_pattern_3_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -2074,11 +2210,12 @@ def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -2089,11 +2226,12 @@ def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -2104,11 +2242,12 @@ def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -2119,11 +2258,12 @@ def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -2134,11 +2274,12 @@ def test_atomic_integer_pattern_6_nistxml_sv_ii_atomic_integer_pattern_2_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -2150,11 +2291,12 @@ def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -2166,11 +2308,12 @@ def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -2182,11 +2325,12 @@ def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -2198,11 +2342,12 @@ def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -2214,11 +2359,12 @@ def test_atomic_integer_pattern_5_nistxml_sv_ii_atomic_integer_pattern_1_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_9_nistxml_sv_ii_atomic_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2230,11 +2376,12 @@ def test_atomic_integer_max_exclusive_9_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2246,11 +2393,12 @@ def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2262,11 +2410,12 @@ def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2278,11 +2427,12 @@ def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2294,11 +2444,12 @@ def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2310,11 +2461,12 @@ def test_atomic_integer_max_exclusive_8_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2326,11 +2478,12 @@ def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2342,11 +2495,12 @@ def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2358,11 +2512,12 @@ def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2374,11 +2529,12 @@ def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2390,11 +2546,12 @@ def test_atomic_integer_max_exclusive_7_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2406,11 +2563,12 @@ def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2422,11 +2580,12 @@ def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2438,11 +2597,12 @@ def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2454,11 +2614,12 @@ def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2470,11 +2631,12 @@ def test_atomic_integer_max_exclusive_6_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2486,11 +2648,12 @@ def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusive_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2502,11 +2665,12 @@ def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusive_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2518,11 +2682,12 @@ def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusive_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2534,11 +2699,12 @@ def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusive_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -2550,11 +2716,12 @@ def test_atomic_integer_max_exclusive_5_nistxml_sv_ii_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2566,11 +2733,12 @@ def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusive_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2582,11 +2750,12 @@ def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusive_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2598,11 +2767,12 @@ def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusive_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2614,11 +2784,12 @@ def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusive_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2630,11 +2801,12 @@ def test_atomic_integer_min_exclusive_9_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2646,11 +2818,12 @@ def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2662,11 +2835,12 @@ def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2678,11 +2852,12 @@ def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2694,11 +2869,12 @@ def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2710,11 +2886,12 @@ def test_atomic_integer_min_exclusive_8_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2726,11 +2903,12 @@ def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2742,11 +2920,12 @@ def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2758,11 +2937,12 @@ def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2774,11 +2954,12 @@ def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2790,11 +2971,12 @@ def test_atomic_integer_min_exclusive_7_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2806,11 +2988,12 @@ def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2822,11 +3005,12 @@ def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2838,11 +3022,12 @@ def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2854,11 +3039,12 @@ def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2870,11 +3056,12 @@ def test_atomic_integer_min_exclusive_6_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_5_nistxml_sv_ii_atomic_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -2886,11 +3073,12 @@ def test_atomic_integer_min_exclusive_5_nistxml_sv_ii_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2901,11 +3089,12 @@ def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2916,11 +3105,12 @@ def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2931,11 +3121,12 @@ def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2946,11 +3137,12 @@ def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2961,11 +3153,12 @@ def test_atomic_decimal_enumeration_9_nistxml_sv_ii_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2976,11 +3169,12 @@ def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -2991,11 +3185,12 @@ def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3006,11 +3201,12 @@ def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3021,11 +3217,12 @@ def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3036,11 +3233,12 @@ def test_atomic_decimal_enumeration_8_nistxml_sv_ii_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3051,11 +3249,12 @@ def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3066,11 +3265,12 @@ def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3081,11 +3281,12 @@ def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3096,11 +3297,12 @@ def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3111,11 +3313,12 @@ def test_atomic_decimal_enumeration_7_nistxml_sv_ii_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3126,11 +3329,12 @@ def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3141,11 +3345,12 @@ def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3156,11 +3361,12 @@ def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3171,11 +3377,12 @@ def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3186,11 +3393,12 @@ def test_atomic_decimal_enumeration_6_nistxml_sv_ii_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3201,11 +3409,12 @@ def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3216,11 +3425,12 @@ def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3231,11 +3441,12 @@ def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3246,11 +3457,12 @@ def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -3261,11 +3473,12 @@ def test_atomic_decimal_enumeration_5_nistxml_sv_ii_atomic_decimal_enumeration_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3277,11 +3490,12 @@ def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3293,11 +3507,12 @@ def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3309,11 +3524,12 @@ def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3325,11 +3541,12 @@ def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3341,11 +3558,12 @@ def test_atomic_decimal_pattern_9_nistxml_sv_ii_atomic_decimal_pattern_5_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3357,11 +3575,12 @@ def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3373,11 +3592,12 @@ def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3389,11 +3609,12 @@ def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3405,11 +3626,12 @@ def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3421,11 +3643,12 @@ def test_atomic_decimal_pattern_8_nistxml_sv_ii_atomic_decimal_pattern_4_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3437,11 +3660,12 @@ def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3453,11 +3677,12 @@ def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3469,11 +3694,12 @@ def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3485,11 +3711,12 @@ def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3501,11 +3728,12 @@ def test_atomic_decimal_pattern_7_nistxml_sv_ii_atomic_decimal_pattern_3_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3517,11 +3745,12 @@ def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3533,11 +3762,12 @@ def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3549,11 +3779,12 @@ def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3565,11 +3796,12 @@ def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -3581,11 +3813,12 @@ def test_atomic_decimal_pattern_6_nistxml_sv_ii_atomic_decimal_pattern_2_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -3596,11 +3829,12 @@ def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -3611,11 +3845,12 @@ def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -3626,11 +3861,12 @@ def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -3641,11 +3877,12 @@ def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -3656,11 +3893,12 @@ def test_atomic_decimal_pattern_5_nistxml_sv_ii_atomic_decimal_pattern_1_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_9_nistxml_sv_ii_atomic_decimal_max_exclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3672,11 +3910,12 @@ def test_atomic_decimal_max_exclusive_9_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3688,11 +3927,12 @@ def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3704,11 +3944,12 @@ def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3720,11 +3961,12 @@ def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3736,11 +3978,12 @@ def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3752,11 +3995,12 @@ def test_atomic_decimal_max_exclusive_8_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3768,11 +4012,12 @@ def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3784,11 +4029,12 @@ def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3800,11 +4046,12 @@ def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3816,11 +4063,12 @@ def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3832,11 +4080,12 @@ def test_atomic_decimal_max_exclusive_7_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3848,11 +4097,12 @@ def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3864,11 +4114,12 @@ def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3880,11 +4131,12 @@ def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3896,11 +4148,12 @@ def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3912,11 +4165,12 @@ def test_atomic_decimal_max_exclusive_6_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3928,11 +4182,12 @@ def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusive_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3944,11 +4199,12 @@ def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusive_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3960,11 +4216,12 @@ def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusive_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3976,11 +4233,12 @@ def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusive_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -3992,11 +4250,12 @@ def test_atomic_decimal_max_exclusive_5_nistxml_sv_ii_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxExclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4008,11 +4267,12 @@ def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusive_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4024,11 +4284,12 @@ def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusive_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4040,11 +4301,12 @@ def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusive_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4056,11 +4318,12 @@ def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusive_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4072,11 +4335,12 @@ def test_atomic_decimal_min_exclusive_9_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4088,11 +4352,12 @@ def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4104,11 +4369,12 @@ def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4120,11 +4386,12 @@ def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4136,11 +4403,12 @@ def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4152,11 +4420,12 @@ def test_atomic_decimal_min_exclusive_8_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4168,11 +4437,12 @@ def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4184,11 +4454,12 @@ def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4200,11 +4471,12 @@ def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4216,11 +4488,12 @@ def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4232,11 +4505,12 @@ def test_atomic_decimal_min_exclusive_7_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4248,11 +4522,12 @@ def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4264,11 +4539,12 @@ def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4280,11 +4556,12 @@ def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4296,11 +4573,12 @@ def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4312,11 +4590,12 @@ def test_atomic_decimal_min_exclusive_6_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_5_nistxml_sv_ii_atomic_decimal_min_exclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -4328,11 +4607,12 @@ def test_atomic_decimal_min_exclusive_5_nistxml_sv_ii_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minExclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4344,11 +4624,12 @@ def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusive_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4360,11 +4641,12 @@ def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusive_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4376,11 +4658,12 @@ def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusive_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4392,11 +4675,12 @@ def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusive_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4408,11 +4692,12 @@ def test_atomic_g_month_max_inclusive_9_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4424,11 +4709,12 @@ def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4440,11 +4726,12 @@ def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4456,11 +4743,12 @@ def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4472,11 +4760,12 @@ def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4488,11 +4777,12 @@ def test_atomic_g_month_max_inclusive_8_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4504,11 +4794,12 @@ def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4520,11 +4811,12 @@ def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4536,11 +4828,12 @@ def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4552,11 +4845,12 @@ def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4568,11 +4862,12 @@ def test_atomic_g_month_max_inclusive_7_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4584,11 +4879,12 @@ def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4600,11 +4896,12 @@ def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4616,11 +4913,12 @@ def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4632,11 +4930,12 @@ def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4648,11 +4947,12 @@ def test_atomic_g_month_max_inclusive_6_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4664,11 +4964,12 @@ def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusive_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4680,11 +4981,12 @@ def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusive_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4696,11 +4998,12 @@ def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusive_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4712,11 +5015,12 @@ def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusive_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -4728,11 +5032,12 @@ def test_atomic_g_month_max_inclusive_5_nistxml_sv_ii_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusive_6_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4744,11 +5049,12 @@ def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusive_6_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4760,11 +5066,12 @@ def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusive_6_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4776,11 +5083,12 @@ def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusive_6_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4792,11 +5100,12 @@ def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusive_6_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4808,11 +5117,12 @@ def test_atomic_g_month_min_inclusive_9_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4824,11 +5134,12 @@ def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusive_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4840,11 +5151,12 @@ def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusive_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4856,11 +5168,12 @@ def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusive_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4872,11 +5185,12 @@ def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusive_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4888,11 +5202,12 @@ def test_atomic_g_month_min_inclusive_8_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4904,11 +5219,12 @@ def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4920,11 +5236,12 @@ def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4936,11 +5253,12 @@ def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4952,11 +5270,12 @@ def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4968,11 +5287,12 @@ def test_atomic_g_month_min_inclusive_7_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -4984,11 +5304,12 @@ def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5000,11 +5321,12 @@ def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5016,11 +5338,12 @@ def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5032,11 +5355,12 @@ def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5048,11 +5372,12 @@ def test_atomic_g_month_min_inclusive_6_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5064,11 +5389,12 @@ def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5080,11 +5406,12 @@ def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5096,11 +5423,12 @@ def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5112,11 +5440,12 @@ def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -5128,11 +5457,12 @@ def test_atomic_g_month_min_inclusive_5_nistxml_sv_ii_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-II-atomic-gMonth-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---12.
@@ -5143,11 +5473,12 @@ def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---12.
@@ -5158,11 +5489,12 @@ def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---12.
@@ -5173,11 +5505,12 @@ def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---12.
@@ -5188,11 +5521,12 @@ def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---12.
@@ -5203,11 +5537,12 @@ def test_atomic_g_day_max_inclusive_9_nistxml_sv_ii_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5218,11 +5553,12 @@ def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5233,11 +5569,12 @@ def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5248,11 +5585,12 @@ def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5263,11 +5601,12 @@ def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5278,11 +5617,12 @@ def test_atomic_g_day_max_inclusive_8_nistxml_sv_ii_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5293,11 +5633,12 @@ def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5308,11 +5649,12 @@ def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5323,11 +5665,12 @@ def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5338,11 +5681,12 @@ def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---05.
@@ -5353,11 +5697,12 @@ def test_atomic_g_day_max_inclusive_7_nistxml_sv_ii_atomic_g_day_max_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_6_nistxml_sv_ii_atomic_g_day_max_inclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---30.
@@ -5368,11 +5713,12 @@ def test_atomic_g_day_max_inclusive_6_nistxml_sv_ii_atomic_g_day_max_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -5383,11 +5729,12 @@ def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -5398,11 +5745,12 @@ def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -5413,11 +5761,12 @@ def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -5428,11 +5777,12 @@ def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -5443,11 +5793,12 @@ def test_atomic_g_day_max_inclusive_5_nistxml_sv_ii_atomic_g_day_max_inclusive_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---31.
@@ -5458,11 +5809,12 @@ def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---31.
@@ -5473,11 +5825,12 @@ def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---31.
@@ -5488,11 +5841,12 @@ def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---31.
@@ -5503,11 +5857,12 @@ def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---31.
@@ -5518,11 +5873,12 @@ def test_atomic_g_day_min_inclusive_8_nistxml_sv_ii_atomic_g_day_min_inclusive_6
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -5533,11 +5889,12 @@ def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -5548,11 +5905,12 @@ def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -5563,11 +5921,12 @@ def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -5578,11 +5937,12 @@ def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -5593,11 +5953,12 @@ def test_atomic_g_day_min_inclusive_7_nistxml_sv_ii_atomic_g_day_min_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---05.
@@ -5608,11 +5969,12 @@ def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---05.
@@ -5623,11 +5985,12 @@ def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---05.
@@ -5638,11 +6001,12 @@ def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---05.
@@ -5653,11 +6017,12 @@ def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---05.
@@ -5668,11 +6033,12 @@ def test_atomic_g_day_min_inclusive_6_nistxml_sv_ii_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---11.
@@ -5683,11 +6049,12 @@ def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---11.
@@ -5698,11 +6065,12 @@ def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---11.
@@ -5713,11 +6081,12 @@ def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---11.
@@ -5728,11 +6097,12 @@ def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---11.
@@ -5743,11 +6113,12 @@ def test_atomic_g_day_min_inclusive_5_nistxml_sv_ii_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-II-atomic-gDay-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max_inclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5759,11 +6130,12 @@ def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max_inclusive_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5775,11 +6147,12 @@ def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max_inclusive_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5791,11 +6164,12 @@ def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max_inclusive_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5807,11 +6181,12 @@ def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max_inclusive_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5823,11 +6198,12 @@ def test_atomic_g_month_day_max_inclusive_9_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max_inclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5839,11 +6215,12 @@ def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max_inclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5855,11 +6232,12 @@ def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max_inclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5871,11 +6249,12 @@ def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max_inclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5887,11 +6266,12 @@ def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max_inclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5903,11 +6283,12 @@ def test_atomic_g_month_day_max_inclusive_8_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max_inclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5919,11 +6300,12 @@ def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max_inclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5935,11 +6317,12 @@ def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max_inclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5951,11 +6334,12 @@ def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max_inclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5967,11 +6351,12 @@ def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max_inclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5983,11 +6368,12 @@ def test_atomic_g_month_day_max_inclusive_7_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max_inclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -5999,11 +6385,12 @@ def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max_inclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6015,11 +6402,12 @@ def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max_inclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6031,11 +6419,12 @@ def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max_inclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6047,11 +6436,12 @@ def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max_inclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6063,11 +6453,12 @@ def test_atomic_g_month_day_max_inclusive_6_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max_inclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6079,11 +6470,12 @@ def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max_inclusive_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6095,11 +6487,12 @@ def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max_inclusive_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6111,11 +6504,12 @@ def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max_inclusive_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6127,11 +6521,12 @@ def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max_inclusive_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -6143,11 +6538,12 @@ def test_atomic_g_month_day_max_inclusive_5_nistxml_sv_ii_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min_inclusive_6_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6159,11 +6555,12 @@ def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min_inclusive_6_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6175,11 +6572,12 @@ def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min_inclusive_6_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6191,11 +6589,12 @@ def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min_inclusive_6_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6207,11 +6606,12 @@ def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min_inclusive_6_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6223,11 +6623,12 @@ def test_atomic_g_month_day_min_inclusive_9_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min_inclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6239,11 +6640,12 @@ def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min_inclusive_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6255,11 +6657,12 @@ def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min_inclusive_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6271,11 +6674,12 @@ def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min_inclusive_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6287,11 +6691,12 @@ def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min_inclusive_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6303,11 +6708,12 @@ def test_atomic_g_month_day_min_inclusive_8_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min_inclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6319,11 +6725,12 @@ def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min_inclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6335,11 +6742,12 @@ def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min_inclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6351,11 +6759,12 @@ def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min_inclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6367,11 +6776,12 @@ def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min_inclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6383,11 +6793,12 @@ def test_atomic_g_month_day_min_inclusive_7_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min_inclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6399,11 +6810,12 @@ def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min_inclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6415,11 +6827,12 @@ def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min_inclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6431,11 +6844,12 @@ def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min_inclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6447,11 +6861,12 @@ def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min_inclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6463,11 +6878,12 @@ def test_atomic_g_month_day_min_inclusive_6_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min_inclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6479,11 +6895,12 @@ def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min_inclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6495,11 +6912,12 @@ def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min_inclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6511,11 +6929,12 @@ def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min_inclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6527,11 +6946,12 @@ def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min_inclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -6543,11 +6963,12 @@ def test_atomic_g_month_day_min_inclusive_5_nistxml_sv_ii_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-II-atomic-gMonthDay-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1982.
@@ -6558,11 +6979,12 @@ def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1982.
@@ -6573,11 +6995,12 @@ def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1982.
@@ -6588,11 +7011,12 @@ def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1982.
@@ -6603,11 +7027,12 @@ def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1982.
@@ -6618,11 +7043,12 @@ def test_atomic_g_year_max_inclusive_9_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1985.
@@ -6633,11 +7059,12 @@ def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1985.
@@ -6648,11 +7075,12 @@ def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1985.
@@ -6663,11 +7091,12 @@ def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1985.
@@ -6678,11 +7107,12 @@ def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1985.
@@ -6693,11 +7123,12 @@ def test_atomic_g_year_max_inclusive_8_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1993.
@@ -6708,11 +7139,12 @@ def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1993.
@@ -6723,11 +7155,12 @@ def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1993.
@@ -6738,11 +7171,12 @@ def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1993.
@@ -6753,11 +7187,12 @@ def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1993.
@@ -6768,11 +7203,12 @@ def test_atomic_g_year_max_inclusive_7_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1978.
@@ -6783,11 +7219,12 @@ def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1978.
@@ -6798,11 +7235,12 @@ def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1978.
@@ -6813,11 +7251,12 @@ def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1978.
@@ -6828,11 +7267,12 @@ def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1978.
@@ -6843,11 +7283,12 @@ def test_atomic_g_year_max_inclusive_6_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1970.
@@ -6858,11 +7299,12 @@ def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1970.
@@ -6873,11 +7315,12 @@ def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1970.
@@ -6888,11 +7331,12 @@ def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1970.
@@ -6903,11 +7347,12 @@ def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1970.
@@ -6918,11 +7363,12 @@ def test_atomic_g_year_max_inclusive_5_nistxml_sv_ii_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive_6_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2030.
@@ -6933,11 +7379,12 @@ def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive_6_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2030.
@@ -6948,11 +7395,12 @@ def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive_6_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2030.
@@ -6963,11 +7411,12 @@ def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive_6_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2030.
@@ -6978,11 +7427,12 @@ def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive_6_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2030.
@@ -6993,11 +7443,12 @@ def test_atomic_g_year_min_inclusive_9_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1980.
@@ -7008,11 +7459,12 @@ def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1980.
@@ -7023,11 +7475,12 @@ def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1980.
@@ -7038,11 +7491,12 @@ def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1980.
@@ -7053,11 +7507,12 @@ def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1980.
@@ -7068,11 +7523,12 @@ def test_atomic_g_year_min_inclusive_8_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2017.
@@ -7083,11 +7539,12 @@ def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2017.
@@ -7098,11 +7555,12 @@ def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2017.
@@ -7113,11 +7571,12 @@ def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2017.
@@ -7128,11 +7587,12 @@ def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2017.
@@ -7143,11 +7603,12 @@ def test_atomic_g_year_min_inclusive_7_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7158,11 +7619,12 @@ def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7173,11 +7635,12 @@ def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7188,11 +7651,12 @@ def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7203,11 +7667,12 @@ def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7218,11 +7683,12 @@ def test_atomic_g_year_min_inclusive_6_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7233,11 +7699,12 @@ def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7248,11 +7715,12 @@ def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7263,11 +7731,12 @@ def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7278,11 +7747,12 @@ def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2019.
@@ -7293,11 +7763,12 @@ def test_atomic_g_year_min_inclusive_5_nistxml_sv_ii_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-II-atomic-gYear-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_max_inclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7309,11 +7780,12 @@ def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_max_inclusive_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7325,11 +7797,12 @@ def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_max_inclusive_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7341,11 +7814,12 @@ def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_max_inclusive_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7357,11 +7831,12 @@ def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_max_inclusive_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7373,11 +7848,12 @@ def test_atomic_g_year_month_max_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_max_inclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7389,11 +7865,12 @@ def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_max_inclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7405,11 +7882,12 @@ def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_max_inclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7421,11 +7899,12 @@ def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_max_inclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7437,11 +7916,12 @@ def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_max_inclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7453,11 +7933,12 @@ def test_atomic_g_year_month_max_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_max_inclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7469,11 +7950,12 @@ def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_max_inclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7485,11 +7967,12 @@ def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_max_inclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7501,11 +7984,12 @@ def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_max_inclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7517,11 +8001,12 @@ def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_max_inclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7533,11 +8018,12 @@ def test_atomic_g_year_month_max_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_max_inclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7549,11 +8035,12 @@ def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_max_inclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7565,11 +8052,12 @@ def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_max_inclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7581,11 +8069,12 @@ def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_max_inclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7597,11 +8086,12 @@ def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_max_inclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7613,11 +8103,12 @@ def test_atomic_g_year_month_max_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_max_inclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7629,11 +8120,12 @@ def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_max_inclusive_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7645,11 +8137,12 @@ def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_max_inclusive_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7661,11 +8154,12 @@ def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_max_inclusive_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7677,11 +8171,12 @@ def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_max_inclusive_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -7693,11 +8188,12 @@ def test_atomic_g_year_month_max_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_min_inclusive_6_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7709,11 +8205,12 @@ def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_min_inclusive_6_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7725,11 +8222,12 @@ def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_min_inclusive_6_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7741,11 +8239,12 @@ def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_min_inclusive_6_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7757,11 +8256,12 @@ def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_min_inclusive_6_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7773,11 +8273,12 @@ def test_atomic_g_year_month_min_inclusive_9_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_min_inclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7789,11 +8290,12 @@ def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_min_inclusive_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7805,11 +8307,12 @@ def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_min_inclusive_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7821,11 +8324,12 @@ def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_min_inclusive_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7837,11 +8341,12 @@ def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_min_inclusive_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7853,11 +8358,12 @@ def test_atomic_g_year_month_min_inclusive_8_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_min_inclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7869,11 +8375,12 @@ def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_min_inclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7885,11 +8392,12 @@ def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_min_inclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7901,11 +8409,12 @@ def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_min_inclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7917,11 +8426,12 @@ def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_min_inclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7933,11 +8443,12 @@ def test_atomic_g_year_month_min_inclusive_7_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_min_inclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7949,11 +8460,12 @@ def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_min_inclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7965,11 +8477,12 @@ def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_min_inclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7981,11 +8494,12 @@ def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_min_inclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -7997,11 +8511,12 @@ def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_min_inclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -8013,11 +8528,12 @@ def test_atomic_g_year_month_min_inclusive_6_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_min_inclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -8029,11 +8545,12 @@ def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_min_inclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -8045,11 +8562,12 @@ def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_min_inclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -8061,11 +8579,12 @@ def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_min_inclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -8077,11 +8596,12 @@ def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_min_inclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -8093,11 +8613,12 @@ def test_atomic_g_year_month_min_inclusive_5_nistxml_sv_ii_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-II-atomic-gYearMonth-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8109,11 +8630,12 @@ def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8125,11 +8647,12 @@ def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8141,11 +8664,12 @@ def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8157,11 +8681,12 @@ def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8173,11 +8698,12 @@ def test_atomic_date_max_inclusive_9_nistxml_sv_ii_atomic_date_max_inclusive_5_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8189,11 +8715,12 @@ def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8205,11 +8732,12 @@ def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8221,11 +8749,12 @@ def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8237,11 +8766,12 @@ def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8253,11 +8783,12 @@ def test_atomic_date_max_inclusive_8_nistxml_sv_ii_atomic_date_max_inclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8269,11 +8800,12 @@ def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8285,11 +8817,12 @@ def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8301,11 +8834,12 @@ def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8317,11 +8851,12 @@ def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8333,11 +8868,12 @@ def test_atomic_date_max_inclusive_7_nistxml_sv_ii_atomic_date_max_inclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8349,11 +8885,12 @@ def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8365,11 +8902,12 @@ def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8381,11 +8919,12 @@ def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8397,11 +8936,12 @@ def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8413,11 +8953,12 @@ def test_atomic_date_max_inclusive_6_nistxml_sv_ii_atomic_date_max_inclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8429,11 +8970,12 @@ def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8445,11 +8987,12 @@ def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8461,11 +9004,12 @@ def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8477,11 +9021,12 @@ def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -8493,11 +9038,12 @@ def test_atomic_date_max_inclusive_5_nistxml_sv_ii_atomic_date_max_inclusive_1_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8509,11 +9055,12 @@ def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8525,11 +9072,12 @@ def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8541,11 +9089,12 @@ def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8557,11 +9106,12 @@ def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8573,11 +9123,12 @@ def test_atomic_date_min_inclusive_9_nistxml_sv_ii_atomic_date_min_inclusive_6_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8589,11 +9140,12 @@ def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8605,11 +9157,12 @@ def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8621,11 +9174,12 @@ def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8637,11 +9191,12 @@ def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8653,11 +9208,12 @@ def test_atomic_date_min_inclusive_8_nistxml_sv_ii_atomic_date_min_inclusive_5_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8669,11 +9225,12 @@ def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8685,11 +9242,12 @@ def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8701,11 +9259,12 @@ def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8717,11 +9276,12 @@ def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8733,11 +9293,12 @@ def test_atomic_date_min_inclusive_7_nistxml_sv_ii_atomic_date_min_inclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8749,11 +9310,12 @@ def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8765,11 +9327,12 @@ def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8781,11 +9344,12 @@ def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8797,11 +9361,12 @@ def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8813,11 +9378,12 @@ def test_atomic_date_min_inclusive_6_nistxml_sv_ii_atomic_date_min_inclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8829,11 +9395,12 @@ def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8845,11 +9412,12 @@ def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8861,11 +9429,12 @@ def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8877,11 +9446,12 @@ def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -8893,11 +9463,12 @@ def test_atomic_date_min_inclusive_5_nistxml_sv_ii_atomic_date_min_inclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-II-atomic-date-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -8909,11 +9480,12 @@ def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -8925,11 +9497,12 @@ def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -8941,11 +9514,12 @@ def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -8957,11 +9531,12 @@ def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -8973,11 +9548,12 @@ def test_atomic_time_max_inclusive_9_nistxml_sv_ii_atomic_time_max_inclusive_5_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -8989,11 +9565,12 @@ def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9005,11 +9582,12 @@ def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9021,11 +9599,12 @@ def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9037,11 +9616,12 @@ def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9053,11 +9633,12 @@ def test_atomic_time_max_inclusive_8_nistxml_sv_ii_atomic_time_max_inclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9069,11 +9650,12 @@ def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9085,11 +9667,12 @@ def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9101,11 +9684,12 @@ def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9117,11 +9701,12 @@ def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9133,11 +9718,12 @@ def test_atomic_time_max_inclusive_7_nistxml_sv_ii_atomic_time_max_inclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9149,11 +9735,12 @@ def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9165,11 +9752,12 @@ def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9181,11 +9769,12 @@ def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9197,11 +9786,12 @@ def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9213,11 +9803,12 @@ def test_atomic_time_max_inclusive_6_nistxml_sv_ii_atomic_time_max_inclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9229,11 +9820,12 @@ def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9245,11 +9837,12 @@ def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9261,11 +9854,12 @@ def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9277,11 +9871,12 @@ def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -9293,11 +9888,12 @@ def test_atomic_time_max_inclusive_5_nistxml_sv_ii_atomic_time_max_inclusive_1_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9309,11 +9905,12 @@ def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9325,11 +9922,12 @@ def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9341,11 +9939,12 @@ def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9357,11 +9956,12 @@ def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9373,11 +9973,12 @@ def test_atomic_time_min_inclusive_9_nistxml_sv_ii_atomic_time_min_inclusive_6_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9389,11 +9990,12 @@ def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9405,11 +10007,12 @@ def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9421,11 +10024,12 @@ def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9437,11 +10041,12 @@ def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9453,11 +10058,12 @@ def test_atomic_time_min_inclusive_8_nistxml_sv_ii_atomic_time_min_inclusive_5_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9469,11 +10075,12 @@ def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9485,11 +10092,12 @@ def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9501,11 +10109,12 @@ def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9517,11 +10126,12 @@ def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9533,11 +10143,12 @@ def test_atomic_time_min_inclusive_7_nistxml_sv_ii_atomic_time_min_inclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9549,11 +10160,12 @@ def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9565,11 +10177,12 @@ def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9581,11 +10194,12 @@ def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9597,11 +10211,12 @@ def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9613,11 +10228,12 @@ def test_atomic_time_min_inclusive_6_nistxml_sv_ii_atomic_time_min_inclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9629,11 +10245,12 @@ def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9645,11 +10262,12 @@ def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9661,11 +10279,12 @@ def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9677,11 +10296,12 @@ def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -9693,11 +10313,12 @@ def test_atomic_time_min_inclusive_5_nistxml_sv_ii_atomic_time_min_inclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-II-atomic-time-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9709,11 +10330,12 @@ def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inclusive_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9725,11 +10347,12 @@ def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inclusive_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9741,11 +10364,12 @@ def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inclusive_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9757,11 +10381,12 @@ def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inclusive_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9773,11 +10398,12 @@ def test_atomic_date_time_max_inclusive_9_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9789,11 +10415,12 @@ def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9805,11 +10432,12 @@ def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9821,11 +10449,12 @@ def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9837,11 +10466,12 @@ def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9853,11 +10483,12 @@ def test_atomic_date_time_max_inclusive_8_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9869,11 +10500,12 @@ def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9885,11 +10517,12 @@ def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9901,11 +10534,12 @@ def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9917,11 +10551,12 @@ def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9933,11 +10568,12 @@ def test_atomic_date_time_max_inclusive_7_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9949,11 +10585,12 @@ def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9965,11 +10602,12 @@ def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9981,11 +10619,12 @@ def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -9997,11 +10636,12 @@ def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -10013,11 +10653,12 @@ def test_atomic_date_time_max_inclusive_6_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -10029,11 +10670,12 @@ def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inclusive_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -10045,11 +10687,12 @@ def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inclusive_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -10061,11 +10704,12 @@ def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inclusive_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -10077,11 +10721,12 @@ def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inclusive_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -10093,11 +10738,12 @@ def test_atomic_date_time_max_inclusive_5_nistxml_sv_ii_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inclusive_6_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10109,11 +10755,12 @@ def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inclusive_6_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10125,11 +10772,12 @@ def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inclusive_6_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10141,11 +10789,12 @@ def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inclusive_6_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10157,11 +10806,12 @@ def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inclusive_6_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10173,11 +10823,12 @@ def test_atomic_date_time_min_inclusive_9_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10189,11 +10840,12 @@ def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inclusive_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10205,11 +10857,12 @@ def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inclusive_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10221,11 +10874,12 @@ def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inclusive_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10237,11 +10891,12 @@ def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inclusive_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10253,11 +10908,12 @@ def test_atomic_date_time_min_inclusive_8_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10269,11 +10925,12 @@ def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10285,11 +10942,12 @@ def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10301,11 +10959,12 @@ def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10317,11 +10976,12 @@ def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10333,11 +10993,12 @@ def test_atomic_date_time_min_inclusive_7_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10349,11 +11010,12 @@ def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10365,11 +11027,12 @@ def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10381,11 +11044,12 @@ def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10397,11 +11061,12 @@ def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10413,11 +11078,12 @@ def test_atomic_date_time_min_inclusive_6_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10429,11 +11095,12 @@ def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10445,11 +11112,12 @@ def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10461,11 +11129,12 @@ def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10477,11 +11146,12 @@ def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -10493,11 +11163,12 @@ def test_atomic_date_time_min_inclusive_5_nistxml_sv_ii_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-II-atomic-dateTime-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10509,11 +11180,12 @@ def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclusive_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10525,11 +11197,12 @@ def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclusive_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10541,11 +11214,12 @@ def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclusive_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10557,11 +11231,12 @@ def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclusive_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10573,11 +11248,12 @@ def test_atomic_duration_max_inclusive_9_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10589,11 +11265,12 @@ def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10605,11 +11282,12 @@ def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10621,11 +11299,12 @@ def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10637,11 +11316,12 @@ def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10653,11 +11333,12 @@ def test_atomic_duration_max_inclusive_8_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10669,11 +11350,12 @@ def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10685,11 +11367,12 @@ def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10701,11 +11384,12 @@ def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10717,11 +11401,12 @@ def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10733,11 +11418,12 @@ def test_atomic_duration_max_inclusive_7_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10749,11 +11435,12 @@ def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10765,11 +11452,12 @@ def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10781,11 +11469,12 @@ def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10797,11 +11486,12 @@ def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10813,11 +11503,12 @@ def test_atomic_duration_max_inclusive_6_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10829,11 +11520,12 @@ def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclusive_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10845,11 +11537,12 @@ def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclusive_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10861,11 +11554,12 @@ def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclusive_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10877,11 +11571,12 @@ def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclusive_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10893,11 +11588,12 @@ def test_atomic_duration_max_inclusive_5_nistxml_sv_ii_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclusive_6_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10909,11 +11605,12 @@ def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclusive_6_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10925,11 +11622,12 @@ def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclusive_6_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10941,11 +11639,12 @@ def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclusive_6_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10957,11 +11656,12 @@ def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclusive_6_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10973,11 +11673,12 @@ def test_atomic_duration_min_inclusive_9_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10989,11 +11690,12 @@ def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclusive_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11005,11 +11707,12 @@ def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclusive_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11021,11 +11724,12 @@ def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclusive_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11037,11 +11741,12 @@ def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclusive_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11053,11 +11758,12 @@ def test_atomic_duration_min_inclusive_8_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11069,11 +11775,12 @@ def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11085,11 +11792,12 @@ def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11101,11 +11809,12 @@ def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11117,11 +11826,12 @@ def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11133,11 +11843,12 @@ def test_atomic_duration_min_inclusive_7_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11149,11 +11860,12 @@ def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11165,11 +11877,12 @@ def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11181,11 +11894,12 @@ def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11197,11 +11911,12 @@ def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11213,11 +11928,12 @@ def test_atomic_duration_min_inclusive_6_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11229,11 +11945,12 @@ def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11245,11 +11962,12 @@ def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11261,11 +11979,12 @@ def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11277,11 +11996,12 @@ def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11293,11 +12013,12 @@ def test_atomic_duration_min_inclusive_5_nistxml_sv_ii_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-II-atomic-duration-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_integer_total_digits_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11309,11 +12030,12 @@ def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_integer_total_digits_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11325,11 +12047,12 @@ def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_integer_total_digits_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11341,11 +12064,12 @@ def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_integer_total_digits_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11357,11 +12081,12 @@ def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_integer_total_digits_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11373,11 +12098,12 @@ def test_atomic_positive_integer_total_digits_9_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_integer_total_digits_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11389,11 +12115,12 @@ def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_integer_total_digits_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11405,11 +12132,12 @@ def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_integer_total_digits_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11421,11 +12149,12 @@ def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_integer_total_digits_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11437,11 +12166,12 @@ def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_integer_total_digits_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11453,11 +12183,12 @@ def test_atomic_positive_integer_total_digits_8_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_integer_total_digits_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11469,11 +12200,12 @@ def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_integer_total_digits_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11485,11 +12217,12 @@ def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_integer_total_digits_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11501,11 +12234,12 @@ def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_integer_total_digits_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11517,11 +12251,12 @@ def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_integer_total_digits_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11533,11 +12268,12 @@ def test_atomic_positive_integer_total_digits_7_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_integer_total_digits_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11549,11 +12285,12 @@ def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_integer_total_digits_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11565,11 +12302,12 @@ def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_integer_total_digits_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11581,11 +12319,12 @@ def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_integer_total_digits_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11597,11 +12336,12 @@ def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_integer_total_digits_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11613,11 +12353,12 @@ def test_atomic_positive_integer_total_digits_6_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_integer_total_digits_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11629,11 +12370,12 @@ def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_integer_total_digits_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11645,11 +12387,12 @@ def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_integer_total_digits_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11661,11 +12404,12 @@ def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_integer_total_digits_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11677,11 +12421,12 @@ def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_integer_total_digits_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -11693,11 +12438,12 @@ def test_atomic_positive_integer_total_digits_5_nistxml_sv_ii_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11709,11 +12455,12 @@ def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11725,11 +12472,12 @@ def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11741,11 +12489,12 @@ def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11757,11 +12506,12 @@ def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11773,11 +12523,12 @@ def test_atomic_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11789,11 +12540,12 @@ def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11805,11 +12557,12 @@ def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11821,11 +12574,12 @@ def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11837,11 +12591,12 @@ def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11853,11 +12608,12 @@ def test_atomic_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11869,11 +12625,12 @@ def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11885,11 +12642,12 @@ def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11901,11 +12659,12 @@ def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11917,11 +12676,12 @@ def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11933,11 +12693,12 @@ def test_atomic_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11949,11 +12710,12 @@ def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11965,11 +12727,12 @@ def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11981,11 +12744,12 @@ def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -11997,11 +12761,12 @@ def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -12013,11 +12778,12 @@ def test_atomic_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -12029,11 +12795,12 @@ def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_integer_max_inclusive_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -12045,11 +12812,12 @@ def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_integer_max_inclusive_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -12061,11 +12829,12 @@ def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_integer_max_inclusive_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -12077,11 +12846,12 @@ def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_integer_max_inclusive_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -12093,11 +12863,12 @@ def test_atomic_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_integer_min_inclusive_6_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12109,11 +12880,12 @@ def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_integer_min_inclusive_6_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12125,11 +12897,12 @@ def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_integer_min_inclusive_6_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12141,11 +12914,12 @@ def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_integer_min_inclusive_6_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12157,11 +12931,12 @@ def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_integer_min_inclusive_6_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12173,11 +12948,12 @@ def test_atomic_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12189,11 +12965,12 @@ def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_integer_min_inclusive_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12205,11 +12982,12 @@ def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_integer_min_inclusive_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12221,11 +12999,12 @@ def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_integer_min_inclusive_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12237,11 +13016,12 @@ def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_integer_min_inclusive_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12253,11 +13033,12 @@ def test_atomic_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12269,11 +13050,12 @@ def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12285,11 +13067,12 @@ def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12301,11 +13084,12 @@ def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12317,11 +13101,12 @@ def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12333,11 +13118,12 @@ def test_atomic_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12349,11 +13135,12 @@ def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12365,11 +13152,12 @@ def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12381,11 +13169,12 @@ def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12397,11 +13186,12 @@ def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12413,11 +13203,12 @@ def test_atomic_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12429,11 +13220,12 @@ def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12445,11 +13237,12 @@ def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12461,11 +13254,12 @@ def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12477,11 +13271,12 @@ def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -12493,11 +13288,12 @@ def test_atomic_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-II-atomic-positiveInteger-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12509,11 +13305,12 @@ def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12525,11 +13322,12 @@ def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12541,11 +13339,12 @@ def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12557,11 +13356,12 @@ def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12573,11 +13373,12 @@ def test_atomic_unsigned_byte_total_digits_4_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12589,11 +13390,12 @@ def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12605,11 +13407,12 @@ def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12621,11 +13424,12 @@ def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12637,11 +13441,12 @@ def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -12653,11 +13458,12 @@ def test_atomic_unsigned_byte_total_digits_3_nistxml_sv_ii_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12669,11 +13475,12 @@ def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12685,11 +13492,12 @@ def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12701,11 +13509,12 @@ def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12717,11 +13526,12 @@ def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12733,11 +13543,12 @@ def test_atomic_unsigned_byte_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12749,11 +13560,12 @@ def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12765,11 +13577,12 @@ def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12781,11 +13594,12 @@ def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12797,11 +13611,12 @@ def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12813,11 +13628,12 @@ def test_atomic_unsigned_byte_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12829,11 +13645,12 @@ def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12845,11 +13662,12 @@ def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12861,11 +13679,12 @@ def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12877,11 +13696,12 @@ def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12893,11 +13713,12 @@ def test_atomic_unsigned_byte_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12909,11 +13730,12 @@ def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12925,11 +13747,12 @@ def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12941,11 +13764,12 @@ def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12957,11 +13781,12 @@ def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12973,11 +13798,12 @@ def test_atomic_unsigned_byte_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -12989,11 +13815,12 @@ def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -13005,11 +13832,12 @@ def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -13021,11 +13849,12 @@ def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -13037,11 +13866,12 @@ def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_max_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -13053,11 +13883,12 @@ def test_atomic_unsigned_byte_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_6_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13069,11 +13900,12 @@ def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_6_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13085,11 +13917,12 @@ def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_6_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13101,11 +13934,12 @@ def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_6_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13117,11 +13951,12 @@ def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_6_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13133,11 +13968,12 @@ def test_atomic_unsigned_byte_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13149,11 +13985,12 @@ def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13165,11 +14002,12 @@ def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13181,11 +14019,12 @@ def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13197,11 +14036,12 @@ def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13213,11 +14053,12 @@ def test_atomic_unsigned_byte_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13229,11 +14070,12 @@ def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13245,11 +14087,12 @@ def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13261,11 +14104,12 @@ def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13277,11 +14121,12 @@ def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13293,11 +14138,12 @@ def test_atomic_unsigned_byte_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13309,11 +14155,12 @@ def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13325,11 +14172,12 @@ def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13341,11 +14189,12 @@ def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13357,11 +14206,12 @@ def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13373,11 +14223,12 @@ def test_atomic_unsigned_byte_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13389,11 +14240,12 @@ def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13405,11 +14257,12 @@ def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13421,11 +14274,12 @@ def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13437,11 +14291,12 @@ def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -13453,11 +14308,12 @@ def test_atomic_unsigned_byte_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-II-atomic-unsignedByte-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_short_total_digits_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13469,11 +14325,12 @@ def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_short_total_digits_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13485,11 +14342,12 @@ def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_short_total_digits_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13501,11 +14359,12 @@ def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_short_total_digits_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13517,11 +14376,12 @@ def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_short_total_digits_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13533,11 +14393,12 @@ def test_atomic_unsigned_short_total_digits_8_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_short_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13549,11 +14410,12 @@ def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_short_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13565,11 +14427,12 @@ def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_short_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13581,11 +14444,12 @@ def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_short_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13597,11 +14461,12 @@ def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_short_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13613,11 +14478,12 @@ def test_atomic_unsigned_short_total_digits_7_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_short_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13629,11 +14495,12 @@ def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_short_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13645,11 +14512,12 @@ def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_short_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13661,11 +14529,12 @@ def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_short_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13677,11 +14546,12 @@ def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_short_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13693,11 +14563,12 @@ def test_atomic_unsigned_short_total_digits_6_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_short_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13709,11 +14580,12 @@ def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_short_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13725,11 +14597,12 @@ def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_short_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13741,11 +14614,12 @@ def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_short_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13757,11 +14631,12 @@ def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_short_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -13773,11 +14648,12 @@ def test_atomic_unsigned_short_total_digits_5_nistxml_sv_ii_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13789,11 +14665,12 @@ def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13805,11 +14682,12 @@ def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13821,11 +14699,12 @@ def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13837,11 +14716,12 @@ def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13853,11 +14733,12 @@ def test_atomic_unsigned_short_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13869,11 +14750,12 @@ def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13885,11 +14767,12 @@ def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13901,11 +14784,12 @@ def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13917,11 +14801,12 @@ def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13933,11 +14818,12 @@ def test_atomic_unsigned_short_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13949,11 +14835,12 @@ def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13965,11 +14852,12 @@ def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13981,11 +14869,12 @@ def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -13997,11 +14886,12 @@ def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14013,11 +14903,12 @@ def test_atomic_unsigned_short_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14029,11 +14920,12 @@ def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14045,11 +14937,12 @@ def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14061,11 +14954,12 @@ def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14077,11 +14971,12 @@ def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14093,11 +14988,12 @@ def test_atomic_unsigned_short_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14109,11 +15005,12 @@ def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14125,11 +15022,12 @@ def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14141,11 +15039,12 @@ def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14157,11 +15056,12 @@ def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_max_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -14173,11 +15073,12 @@ def test_atomic_unsigned_short_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_6_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14189,11 +15090,12 @@ def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_6_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14205,11 +15107,12 @@ def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_6_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14221,11 +15124,12 @@ def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_6_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14237,11 +15141,12 @@ def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_6_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14253,11 +15158,12 @@ def test_atomic_unsigned_short_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14269,11 +15175,12 @@ def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14285,11 +15192,12 @@ def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14301,11 +15209,12 @@ def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14317,11 +15226,12 @@ def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14333,11 +15243,12 @@ def test_atomic_unsigned_short_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14349,11 +15260,12 @@ def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14365,11 +15277,12 @@ def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14381,11 +15294,12 @@ def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14397,11 +15311,12 @@ def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14413,11 +15328,12 @@ def test_atomic_unsigned_short_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14429,11 +15345,12 @@ def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14445,11 +15362,12 @@ def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14461,11 +15379,12 @@ def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14477,11 +15396,12 @@ def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14493,11 +15413,12 @@ def test_atomic_unsigned_short_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14509,11 +15430,12 @@ def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14525,11 +15447,12 @@ def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14541,11 +15464,12 @@ def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14557,11 +15481,12 @@ def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_short_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -14573,11 +15498,12 @@ def test_atomic_unsigned_short_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-II-atomic-unsignedShort-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_total_digits_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14589,11 +15515,12 @@ def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_total_digits_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14605,11 +15532,12 @@ def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_total_digits_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14621,11 +15549,12 @@ def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_total_digits_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14637,11 +15566,12 @@ def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_total_digits_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14653,11 +15583,12 @@ def test_atomic_unsigned_int_total_digits_9_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_total_digits_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14669,11 +15600,12 @@ def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_total_digits_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14685,11 +15617,12 @@ def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_total_digits_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14701,11 +15634,12 @@ def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_total_digits_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14717,11 +15651,12 @@ def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_total_digits_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14733,11 +15668,12 @@ def test_atomic_unsigned_int_total_digits_8_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14749,11 +15685,12 @@ def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14765,11 +15702,12 @@ def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14781,11 +15719,12 @@ def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14797,11 +15736,12 @@ def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14813,11 +15753,12 @@ def test_atomic_unsigned_int_total_digits_7_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14829,11 +15770,12 @@ def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14845,11 +15787,12 @@ def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14861,11 +15804,12 @@ def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14877,11 +15821,12 @@ def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14893,11 +15838,12 @@ def test_atomic_unsigned_int_total_digits_6_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14909,11 +15855,12 @@ def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14925,11 +15872,12 @@ def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14941,11 +15889,12 @@ def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14957,11 +15906,12 @@ def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -14973,11 +15923,12 @@ def test_atomic_unsigned_int_total_digits_5_nistxml_sv_ii_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -14989,11 +15940,12 @@ def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15005,11 +15957,12 @@ def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15021,11 +15974,12 @@ def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15037,11 +15991,12 @@ def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15053,11 +16008,12 @@ def test_atomic_unsigned_int_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15069,11 +16025,12 @@ def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15085,11 +16042,12 @@ def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15101,11 +16059,12 @@ def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15117,11 +16076,12 @@ def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15133,11 +16093,12 @@ def test_atomic_unsigned_int_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15149,11 +16110,12 @@ def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15165,11 +16127,12 @@ def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15181,11 +16144,12 @@ def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15197,11 +16161,12 @@ def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15213,11 +16178,12 @@ def test_atomic_unsigned_int_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15229,11 +16195,12 @@ def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15245,11 +16212,12 @@ def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15261,11 +16229,12 @@ def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15277,11 +16246,12 @@ def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15293,11 +16263,12 @@ def test_atomic_unsigned_int_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15309,11 +16280,12 @@ def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15325,11 +16297,12 @@ def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15341,11 +16314,12 @@ def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15357,11 +16331,12 @@ def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_max_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -15373,11 +16348,12 @@ def test_atomic_unsigned_int_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_6_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15389,11 +16365,12 @@ def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_6_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15405,11 +16382,12 @@ def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_6_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15421,11 +16399,12 @@ def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_6_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15437,11 +16416,12 @@ def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_6_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15453,11 +16433,12 @@ def test_atomic_unsigned_int_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15469,11 +16450,12 @@ def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15485,11 +16467,12 @@ def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15501,11 +16484,12 @@ def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15517,11 +16501,12 @@ def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15533,11 +16518,12 @@ def test_atomic_unsigned_int_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15549,11 +16535,12 @@ def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15565,11 +16552,12 @@ def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15581,11 +16569,12 @@ def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15597,11 +16586,12 @@ def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15613,11 +16603,12 @@ def test_atomic_unsigned_int_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15629,11 +16620,12 @@ def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15645,11 +16637,12 @@ def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15661,11 +16654,12 @@ def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15677,11 +16671,12 @@ def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15693,11 +16688,12 @@ def test_atomic_unsigned_int_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15709,11 +16705,12 @@ def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15725,11 +16722,12 @@ def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15741,11 +16739,12 @@ def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15757,11 +16756,12 @@ def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -15773,11 +16773,12 @@ def test_atomic_unsigned_int_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-II-atomic-unsignedInt-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_total_digits_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -15789,11 +16790,12 @@ def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_total_digits_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -15805,6 +16807,6 @@ def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_14000.py
+++ b/tests/test_nist_meta_14000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_total_digits_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -12,11 +15,12 @@ def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_total_digits_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -28,11 +32,12 @@ def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_total_digits_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -44,11 +49,12 @@ def test_atomic_unsigned_long_total_digits_9_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_total_digits_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -60,11 +66,12 @@ def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_total_digits_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -76,11 +83,12 @@ def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_total_digits_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -92,11 +100,12 @@ def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_total_digits_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -108,11 +117,12 @@ def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_total_digits_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -124,11 +134,12 @@ def test_atomic_unsigned_long_total_digits_8_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -140,11 +151,12 @@ def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -156,11 +168,12 @@ def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -172,11 +185,12 @@ def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -188,11 +202,12 @@ def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -204,11 +219,12 @@ def test_atomic_unsigned_long_total_digits_7_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -220,11 +236,12 @@ def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -236,11 +253,12 @@ def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -252,11 +270,12 @@ def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -268,11 +287,12 @@ def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -284,11 +304,12 @@ def test_atomic_unsigned_long_total_digits_6_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -300,11 +321,12 @@ def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -316,11 +338,12 @@ def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -332,11 +355,12 @@ def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -348,11 +372,12 @@ def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -364,11 +389,12 @@ def test_atomic_unsigned_long_total_digits_5_nistxml_sv_ii_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -380,11 +406,12 @@ def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -396,11 +423,12 @@ def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -412,11 +440,12 @@ def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -428,11 +457,12 @@ def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -444,11 +474,12 @@ def test_atomic_unsigned_long_max_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -460,11 +491,12 @@ def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -476,11 +508,12 @@ def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -492,11 +525,12 @@ def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -508,11 +542,12 @@ def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -524,11 +559,12 @@ def test_atomic_unsigned_long_max_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -540,11 +576,12 @@ def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -556,11 +593,12 @@ def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -572,11 +610,12 @@ def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -588,11 +627,12 @@ def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -604,11 +644,12 @@ def test_atomic_unsigned_long_max_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -620,11 +661,12 @@ def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -636,11 +678,12 @@ def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -652,11 +695,12 @@ def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -668,11 +712,12 @@ def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -684,11 +729,12 @@ def test_atomic_unsigned_long_max_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -700,11 +746,12 @@ def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -716,11 +763,12 @@ def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -732,11 +780,12 @@ def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -748,11 +797,12 @@ def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_max_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -764,11 +814,12 @@ def test_atomic_unsigned_long_max_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_6_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -780,11 +831,12 @@ def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_6_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -796,11 +848,12 @@ def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_6_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -812,11 +865,12 @@ def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_6_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -828,11 +882,12 @@ def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_6_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -844,11 +899,12 @@ def test_atomic_unsigned_long_min_inclusive_9_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -860,11 +916,12 @@ def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -876,11 +933,12 @@ def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -892,11 +950,12 @@ def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -908,11 +967,12 @@ def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -924,11 +984,12 @@ def test_atomic_unsigned_long_min_inclusive_8_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -940,11 +1001,12 @@ def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -956,11 +1018,12 @@ def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -972,11 +1035,12 @@ def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -988,11 +1052,12 @@ def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1004,11 +1069,12 @@ def test_atomic_unsigned_long_min_inclusive_7_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1020,11 +1086,12 @@ def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1036,11 +1103,12 @@ def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1052,11 +1120,12 @@ def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1068,11 +1137,12 @@ def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1084,11 +1154,12 @@ def test_atomic_unsigned_long_min_inclusive_6_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1100,11 +1171,12 @@ def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1116,11 +1188,12 @@ def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1132,11 +1205,12 @@ def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1148,11 +1222,12 @@ def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -1164,11 +1239,12 @@ def test_atomic_unsigned_long_min_inclusive_5_nistxml_sv_ii_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-II-atomic-unsignedLong-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_negative_integer_total_digits_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1180,11 +1256,12 @@ def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_negative_integer_total_digits_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1196,11 +1273,12 @@ def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_negative_integer_total_digits_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1212,11 +1290,12 @@ def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_negative_integer_total_digits_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1228,11 +1307,12 @@ def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_negative_integer_total_digits_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1244,11 +1324,12 @@ def test_atomic_non_negative_integer_total_digits_9_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_negative_integer_total_digits_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1260,11 +1341,12 @@ def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_negative_integer_total_digits_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1276,11 +1358,12 @@ def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_negative_integer_total_digits_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1292,11 +1375,12 @@ def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_negative_integer_total_digits_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1308,11 +1392,12 @@ def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_negative_integer_total_digits_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1324,11 +1409,12 @@ def test_atomic_non_negative_integer_total_digits_8_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_negative_integer_total_digits_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1340,11 +1426,12 @@ def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_negative_integer_total_digits_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1356,11 +1443,12 @@ def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_negative_integer_total_digits_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1372,11 +1460,12 @@ def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_negative_integer_total_digits_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1388,11 +1477,12 @@ def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_negative_integer_total_digits_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1404,11 +1494,12 @@ def test_atomic_non_negative_integer_total_digits_7_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_negative_integer_total_digits_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1420,11 +1511,12 @@ def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_negative_integer_total_digits_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1436,11 +1528,12 @@ def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_negative_integer_total_digits_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1452,11 +1545,12 @@ def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_negative_integer_total_digits_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1468,11 +1562,12 @@ def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_negative_integer_total_digits_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1484,11 +1579,12 @@ def test_atomic_non_negative_integer_total_digits_6_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_negative_integer_total_digits_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1500,11 +1596,12 @@ def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_negative_integer_total_digits_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1516,11 +1613,12 @@ def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_negative_integer_total_digits_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1532,11 +1630,12 @@ def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_negative_integer_total_digits_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1548,11 +1647,12 @@ def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_negative_integer_total_digits_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -1564,11 +1664,12 @@ def test_atomic_non_negative_integer_total_digits_5_nistxml_sv_ii_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1580,11 +1681,12 @@ def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1596,11 +1698,12 @@ def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1612,11 +1715,12 @@ def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1628,11 +1732,12 @@ def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1644,11 +1749,12 @@ def test_atomic_non_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1660,11 +1766,12 @@ def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1676,11 +1783,12 @@ def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1692,11 +1800,12 @@ def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1708,11 +1817,12 @@ def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1724,11 +1834,12 @@ def test_atomic_non_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1740,11 +1851,12 @@ def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1756,11 +1868,12 @@ def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1772,11 +1885,12 @@ def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1788,11 +1902,12 @@ def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1804,11 +1919,12 @@ def test_atomic_non_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1820,11 +1936,12 @@ def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1836,11 +1953,12 @@ def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1852,11 +1970,12 @@ def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1868,11 +1987,12 @@ def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1884,11 +2004,12 @@ def test_atomic_non_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1900,11 +2021,12 @@ def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1916,11 +2038,12 @@ def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1932,11 +2055,12 @@ def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1948,11 +2072,12 @@ def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_max_inclusive_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -1964,11 +2089,12 @@ def test_atomic_non_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_6_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -1980,11 +2106,12 @@ def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_6_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -1996,11 +2123,12 @@ def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_6_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2012,11 +2140,12 @@ def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_6_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2028,11 +2157,12 @@ def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_6_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2044,11 +2174,12 @@ def test_atomic_non_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2060,11 +2191,12 @@ def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2076,11 +2208,12 @@ def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2092,11 +2225,12 @@ def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2108,11 +2242,12 @@ def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2124,11 +2259,12 @@ def test_atomic_non_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2140,11 +2276,12 @@ def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2156,11 +2293,12 @@ def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2172,11 +2310,12 @@ def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2188,11 +2327,12 @@ def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2204,11 +2344,12 @@ def test_atomic_non_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2220,11 +2361,12 @@ def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2236,11 +2378,12 @@ def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2252,11 +2395,12 @@ def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2268,11 +2412,12 @@ def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2284,11 +2429,12 @@ def test_atomic_non_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2300,11 +2446,12 @@ def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2316,11 +2463,12 @@ def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2332,11 +2480,12 @@ def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2348,11 +2497,12 @@ def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_negative_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -2364,11 +2514,12 @@ def test_atomic_non_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-atomic-nonNegativeInteger-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -2379,11 +2530,12 @@ def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -2394,11 +2546,12 @@ def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_2(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -2409,11 +2562,12 @@ def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_3(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -2424,11 +2578,12 @@ def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_4(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -2439,11 +2594,12 @@ def test_atomic_byte_total_digits_4_nistxml_sv_ii_atomic_byte_total_digits_2_5(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -2454,11 +2610,12 @@ def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -2469,11 +2626,12 @@ def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_2(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -2484,11 +2642,12 @@ def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_3(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -2499,11 +2658,12 @@ def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_4(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -2514,11 +2674,12 @@ def test_atomic_byte_total_digits_3_nistxml_sv_ii_atomic_byte_total_digits_1_5(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -100.
@@ -2529,11 +2690,12 @@ def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -100.
@@ -2544,11 +2706,12 @@ def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -100.
@@ -2559,11 +2722,12 @@ def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -100.
@@ -2574,11 +2738,12 @@ def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -100.
@@ -2589,11 +2754,12 @@ def test_atomic_byte_max_inclusive_9_nistxml_sv_ii_atomic_byte_max_inclusive_5_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -91.
@@ -2604,11 +2770,12 @@ def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -91.
@@ -2619,11 +2786,12 @@ def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -91.
@@ -2634,11 +2802,12 @@ def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -91.
@@ -2649,11 +2818,12 @@ def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -91.
@@ -2664,11 +2834,12 @@ def test_atomic_byte_max_inclusive_8_nistxml_sv_ii_atomic_byte_max_inclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -93.
@@ -2679,11 +2850,12 @@ def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -93.
@@ -2694,11 +2866,12 @@ def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -93.
@@ -2709,11 +2882,12 @@ def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -93.
@@ -2724,11 +2898,12 @@ def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -93.
@@ -2739,11 +2914,12 @@ def test_atomic_byte_max_inclusive_7_nistxml_sv_ii_atomic_byte_max_inclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 122.
@@ -2754,11 +2930,12 @@ def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 122.
@@ -2769,11 +2946,12 @@ def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 122.
@@ -2784,11 +2962,12 @@ def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 122.
@@ -2799,11 +2978,12 @@ def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 122.
@@ -2814,11 +2994,12 @@ def test_atomic_byte_max_inclusive_6_nistxml_sv_ii_atomic_byte_max_inclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -128.
@@ -2829,11 +3010,12 @@ def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -128.
@@ -2844,11 +3026,12 @@ def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -128.
@@ -2859,11 +3042,12 @@ def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -128.
@@ -2874,11 +3058,12 @@ def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -128.
@@ -2889,11 +3074,12 @@ def test_atomic_byte_max_inclusive_5_nistxml_sv_ii_atomic_byte_max_inclusive_1_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 127.
@@ -2904,11 +3090,12 @@ def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 127.
@@ -2919,11 +3106,12 @@ def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 127.
@@ -2934,11 +3122,12 @@ def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 127.
@@ -2949,11 +3138,12 @@ def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 127.
@@ -2964,11 +3154,12 @@ def test_atomic_byte_min_inclusive_9_nistxml_sv_ii_atomic_byte_min_inclusive_6_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 19.
@@ -2979,11 +3170,12 @@ def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 19.
@@ -2994,11 +3186,12 @@ def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 19.
@@ -3009,11 +3202,12 @@ def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 19.
@@ -3024,11 +3218,12 @@ def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 19.
@@ -3039,11 +3234,12 @@ def test_atomic_byte_min_inclusive_8_nistxml_sv_ii_atomic_byte_min_inclusive_5_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -107.
@@ -3054,11 +3250,12 @@ def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -107.
@@ -3069,11 +3266,12 @@ def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -107.
@@ -3084,11 +3282,12 @@ def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -107.
@@ -3099,11 +3298,12 @@ def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -107.
@@ -3114,11 +3314,12 @@ def test_atomic_byte_min_inclusive_7_nistxml_sv_ii_atomic_byte_min_inclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 0.
@@ -3129,11 +3330,12 @@ def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 0.
@@ -3144,11 +3346,12 @@ def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 0.
@@ -3159,11 +3362,12 @@ def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 0.
@@ -3174,11 +3378,12 @@ def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 0.
@@ -3189,11 +3394,12 @@ def test_atomic_byte_min_inclusive_6_nistxml_sv_ii_atomic_byte_min_inclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -17.
@@ -3204,11 +3410,12 @@ def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -17.
@@ -3219,11 +3426,12 @@ def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -17.
@@ -3234,11 +3442,12 @@ def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -17.
@@ -3249,11 +3458,12 @@ def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -17.
@@ -3264,11 +3474,12 @@ def test_atomic_byte_min_inclusive_5_nistxml_sv_ii_atomic_byte_min_inclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-II-atomic-byte-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -3279,11 +3490,12 @@ def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -3294,11 +3506,12 @@ def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -3309,11 +3522,12 @@ def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -3324,11 +3538,12 @@ def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -3339,11 +3554,12 @@ def test_atomic_short_total_digits_8_nistxml_sv_ii_atomic_short_total_digits_4_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -3354,11 +3570,12 @@ def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -3369,11 +3586,12 @@ def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -3384,11 +3602,12 @@ def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -3399,11 +3618,12 @@ def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -3414,11 +3634,12 @@ def test_atomic_short_total_digits_7_nistxml_sv_ii_atomic_short_total_digits_3_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -3429,11 +3650,12 @@ def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -3444,11 +3666,12 @@ def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -3459,11 +3682,12 @@ def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -3474,11 +3698,12 @@ def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -3489,11 +3714,12 @@ def test_atomic_short_total_digits_6_nistxml_sv_ii_atomic_short_total_digits_2_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -3504,11 +3730,12 @@ def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -3519,11 +3746,12 @@ def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -3534,11 +3762,12 @@ def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -3549,11 +3778,12 @@ def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -3564,11 +3794,12 @@ def test_atomic_short_total_digits_5_nistxml_sv_ii_atomic_short_total_digits_1_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2651.
@@ -3579,11 +3810,12 @@ def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2651.
@@ -3594,11 +3826,12 @@ def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2651.
@@ -3609,11 +3842,12 @@ def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2651.
@@ -3624,11 +3858,12 @@ def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2651.
@@ -3639,11 +3874,12 @@ def test_atomic_short_max_inclusive_9_nistxml_sv_ii_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3655,11 +3891,12 @@ def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3671,11 +3908,12 @@ def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3687,11 +3925,12 @@ def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3703,11 +3942,12 @@ def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3719,11 +3959,12 @@ def test_atomic_short_max_inclusive_8_nistxml_sv_ii_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3735,11 +3976,12 @@ def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3751,11 +3993,12 @@ def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3767,11 +4010,12 @@ def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3783,11 +4027,12 @@ def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3799,11 +4044,12 @@ def test_atomic_short_max_inclusive_7_nistxml_sv_ii_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3815,11 +4061,12 @@ def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3831,11 +4078,12 @@ def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3847,11 +4095,12 @@ def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3863,11 +4112,12 @@ def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3879,11 +4129,12 @@ def test_atomic_short_max_inclusive_6_nistxml_sv_ii_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3895,11 +4146,12 @@ def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3911,11 +4163,12 @@ def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3927,11 +4180,12 @@ def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3943,11 +4197,12 @@ def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -3959,11 +4214,12 @@ def test_atomic_short_max_inclusive_5_nistxml_sv_ii_atomic_short_max_inclusive_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -3975,11 +4231,12 @@ def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -3991,11 +4248,12 @@ def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4007,11 +4265,12 @@ def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4023,11 +4282,12 @@ def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4039,11 +4299,12 @@ def test_atomic_short_min_inclusive_9_nistxml_sv_ii_atomic_short_min_inclusive_6
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4055,11 +4316,12 @@ def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4071,11 +4333,12 @@ def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4087,11 +4350,12 @@ def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4103,11 +4367,12 @@ def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4119,11 +4384,12 @@ def test_atomic_short_min_inclusive_8_nistxml_sv_ii_atomic_short_min_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4135,11 +4401,12 @@ def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4151,11 +4418,12 @@ def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4167,11 +4435,12 @@ def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4183,11 +4452,12 @@ def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4199,11 +4469,12 @@ def test_atomic_short_min_inclusive_7_nistxml_sv_ii_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4215,11 +4486,12 @@ def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4231,11 +4503,12 @@ def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4247,11 +4520,12 @@ def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4263,11 +4537,12 @@ def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4279,11 +4554,12 @@ def test_atomic_short_min_inclusive_6_nistxml_sv_ii_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4295,11 +4571,12 @@ def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4311,11 +4588,12 @@ def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4327,11 +4605,12 @@ def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4343,11 +4622,12 @@ def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -4359,11 +4639,12 @@ def test_atomic_short_min_inclusive_5_nistxml_sv_ii_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-II-atomic-short-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -4374,11 +4655,12 @@ def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -4389,11 +4671,12 @@ def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -4404,11 +4687,12 @@ def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -4419,11 +4703,12 @@ def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -4434,11 +4719,12 @@ def test_atomic_int_total_digits_9_nistxml_sv_ii_atomic_int_total_digits_5_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 4.
@@ -4449,11 +4735,12 @@ def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 4.
@@ -4464,11 +4751,12 @@ def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 4.
@@ -4479,11 +4767,12 @@ def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 4.
@@ -4494,11 +4783,12 @@ def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 4.
@@ -4509,11 +4799,12 @@ def test_atomic_int_total_digits_8_nistxml_sv_ii_atomic_int_total_digits_4_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -4524,11 +4815,12 @@ def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -4539,11 +4831,12 @@ def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -4554,11 +4847,12 @@ def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -4569,11 +4863,12 @@ def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -4584,11 +4879,12 @@ def test_atomic_int_total_digits_7_nistxml_sv_ii_atomic_int_total_digits_3_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 2.
@@ -4599,11 +4895,12 @@ def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 2.
@@ -4614,11 +4911,12 @@ def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 2.
@@ -4629,11 +4927,12 @@ def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 2.
@@ -4644,11 +4943,12 @@ def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 2.
@@ -4659,11 +4959,12 @@ def test_atomic_int_total_digits_6_nistxml_sv_ii_atomic_int_total_digits_2_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4674,11 +4975,12 @@ def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4689,11 +4991,12 @@ def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4704,11 +5007,12 @@ def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4719,11 +5023,12 @@ def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4734,11 +5039,12 @@ def test_atomic_int_total_digits_5_nistxml_sv_ii_atomic_int_total_digits_1_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4750,11 +5056,12 @@ def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4766,11 +5073,12 @@ def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4782,11 +5090,12 @@ def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4798,11 +5107,12 @@ def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4814,11 +5124,12 @@ def test_atomic_int_max_inclusive_9_nistxml_sv_ii_atomic_int_max_inclusive_5_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4830,11 +5141,12 @@ def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4846,11 +5158,12 @@ def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4862,11 +5175,12 @@ def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4878,11 +5192,12 @@ def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4894,11 +5209,12 @@ def test_atomic_int_max_inclusive_8_nistxml_sv_ii_atomic_int_max_inclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4910,11 +5226,12 @@ def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4926,11 +5243,12 @@ def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4942,11 +5260,12 @@ def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4958,11 +5277,12 @@ def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4974,11 +5294,12 @@ def test_atomic_int_max_inclusive_7_nistxml_sv_ii_atomic_int_max_inclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4990,11 +5311,12 @@ def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5006,11 +5328,12 @@ def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5022,11 +5345,12 @@ def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5038,11 +5362,12 @@ def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5054,11 +5379,12 @@ def test_atomic_int_max_inclusive_6_nistxml_sv_ii_atomic_int_max_inclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5070,11 +5396,12 @@ def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5086,11 +5413,12 @@ def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5102,11 +5430,12 @@ def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5118,11 +5447,12 @@ def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -5134,11 +5464,12 @@ def test_atomic_int_max_inclusive_5_nistxml_sv_ii_atomic_int_max_inclusive_1_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5150,11 +5481,12 @@ def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5166,11 +5498,12 @@ def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5182,11 +5515,12 @@ def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5198,11 +5532,12 @@ def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5214,11 +5549,12 @@ def test_atomic_int_min_inclusive_9_nistxml_sv_ii_atomic_int_min_inclusive_6_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5230,11 +5566,12 @@ def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5246,11 +5583,12 @@ def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5262,11 +5600,12 @@ def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5278,11 +5617,12 @@ def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5294,11 +5634,12 @@ def test_atomic_int_min_inclusive_8_nistxml_sv_ii_atomic_int_min_inclusive_5_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5310,11 +5651,12 @@ def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5326,11 +5668,12 @@ def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5342,11 +5685,12 @@ def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5358,11 +5702,12 @@ def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5374,11 +5719,12 @@ def test_atomic_int_min_inclusive_7_nistxml_sv_ii_atomic_int_min_inclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5390,11 +5736,12 @@ def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5406,11 +5753,12 @@ def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5422,11 +5770,12 @@ def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5438,11 +5787,12 @@ def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5454,11 +5804,12 @@ def test_atomic_int_min_inclusive_6_nistxml_sv_ii_atomic_int_min_inclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5470,11 +5821,12 @@ def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5486,11 +5838,12 @@ def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5502,11 +5855,12 @@ def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5518,11 +5872,12 @@ def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5534,11 +5889,12 @@ def test_atomic_int_min_inclusive_5_nistxml_sv_ii_atomic_int_min_inclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-II-atomic-int-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -5549,11 +5905,12 @@ def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -5564,11 +5921,12 @@ def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -5579,11 +5937,12 @@ def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -5594,11 +5953,12 @@ def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -5609,11 +5969,12 @@ def test_atomic_long_total_digits_9_nistxml_sv_ii_atomic_long_total_digits_5_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 10.
@@ -5624,11 +5985,12 @@ def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 10.
@@ -5639,11 +6001,12 @@ def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 10.
@@ -5654,11 +6017,12 @@ def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 10.
@@ -5669,11 +6033,12 @@ def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 10.
@@ -5684,11 +6049,12 @@ def test_atomic_long_total_digits_8_nistxml_sv_ii_atomic_long_total_digits_4_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 7.
@@ -5699,11 +6065,12 @@ def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 7.
@@ -5714,11 +6081,12 @@ def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 7.
@@ -5729,11 +6097,12 @@ def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 7.
@@ -5744,11 +6113,12 @@ def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 7.
@@ -5759,11 +6129,12 @@ def test_atomic_long_total_digits_7_nistxml_sv_ii_atomic_long_total_digits_3_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 4.
@@ -5774,11 +6145,12 @@ def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 4.
@@ -5789,11 +6161,12 @@ def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 4.
@@ -5804,11 +6177,12 @@ def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 4.
@@ -5819,11 +6193,12 @@ def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 4.
@@ -5834,11 +6209,12 @@ def test_atomic_long_total_digits_6_nistxml_sv_ii_atomic_long_total_digits_2_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -5849,11 +6225,12 @@ def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -5864,11 +6241,12 @@ def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -5879,11 +6257,12 @@ def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -5894,11 +6273,12 @@ def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -5909,11 +6289,12 @@ def test_atomic_long_total_digits_5_nistxml_sv_ii_atomic_long_total_digits_1_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -5925,11 +6306,12 @@ def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -5941,11 +6323,12 @@ def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -5957,11 +6340,12 @@ def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -5973,11 +6357,12 @@ def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -5989,11 +6374,12 @@ def test_atomic_long_max_inclusive_9_nistxml_sv_ii_atomic_long_max_inclusive_5_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6005,11 +6391,12 @@ def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6021,11 +6408,12 @@ def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6037,11 +6425,12 @@ def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6053,11 +6442,12 @@ def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6069,11 +6459,12 @@ def test_atomic_long_max_inclusive_8_nistxml_sv_ii_atomic_long_max_inclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6085,11 +6476,12 @@ def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6101,11 +6493,12 @@ def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6117,11 +6510,12 @@ def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6133,11 +6527,12 @@ def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6149,11 +6544,12 @@ def test_atomic_long_max_inclusive_7_nistxml_sv_ii_atomic_long_max_inclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6165,11 +6561,12 @@ def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6181,11 +6578,12 @@ def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6197,11 +6595,12 @@ def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6213,11 +6612,12 @@ def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6229,11 +6629,12 @@ def test_atomic_long_max_inclusive_6_nistxml_sv_ii_atomic_long_max_inclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6245,11 +6646,12 @@ def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6261,11 +6663,12 @@ def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6277,11 +6680,12 @@ def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6293,11 +6697,12 @@ def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6309,11 +6714,12 @@ def test_atomic_long_max_inclusive_5_nistxml_sv_ii_atomic_long_max_inclusive_1_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6325,11 +6731,12 @@ def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6341,11 +6748,12 @@ def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6357,11 +6765,12 @@ def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6373,11 +6782,12 @@ def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6389,11 +6799,12 @@ def test_atomic_long_min_inclusive_9_nistxml_sv_ii_atomic_long_min_inclusive_6_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6405,11 +6816,12 @@ def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6421,11 +6833,12 @@ def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6437,11 +6850,12 @@ def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6453,11 +6867,12 @@ def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6469,11 +6884,12 @@ def test_atomic_long_min_inclusive_8_nistxml_sv_ii_atomic_long_min_inclusive_5_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6485,11 +6901,12 @@ def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6501,11 +6918,12 @@ def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6517,11 +6935,12 @@ def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6533,11 +6952,12 @@ def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6549,11 +6969,12 @@ def test_atomic_long_min_inclusive_7_nistxml_sv_ii_atomic_long_min_inclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6565,11 +6986,12 @@ def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6581,11 +7003,12 @@ def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6597,11 +7020,12 @@ def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6613,11 +7037,12 @@ def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6629,11 +7054,12 @@ def test_atomic_long_min_inclusive_6_nistxml_sv_ii_atomic_long_min_inclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6645,11 +7071,12 @@ def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6661,11 +7088,12 @@ def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6677,11 +7105,12 @@ def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6693,11 +7122,12 @@ def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -6709,11 +7139,12 @@ def test_atomic_long_min_inclusive_5_nistxml_sv_ii_atomic_long_min_inclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-II-atomic-long-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_integer_total_digits_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6725,11 +7156,12 @@ def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_integer_total_digits_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6741,11 +7173,12 @@ def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_integer_total_digits_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6757,11 +7190,12 @@ def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_integer_total_digits_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6773,11 +7207,12 @@ def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_integer_total_digits_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6789,11 +7224,12 @@ def test_atomic_negative_integer_total_digits_9_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_integer_total_digits_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6805,11 +7241,12 @@ def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_integer_total_digits_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6821,11 +7258,12 @@ def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_integer_total_digits_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6837,11 +7275,12 @@ def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_integer_total_digits_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6853,11 +7292,12 @@ def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_integer_total_digits_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6869,11 +7309,12 @@ def test_atomic_negative_integer_total_digits_8_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_integer_total_digits_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6885,11 +7326,12 @@ def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_integer_total_digits_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6901,11 +7343,12 @@ def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_integer_total_digits_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6917,11 +7360,12 @@ def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_integer_total_digits_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6933,11 +7377,12 @@ def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_integer_total_digits_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6949,11 +7394,12 @@ def test_atomic_negative_integer_total_digits_7_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_integer_total_digits_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6965,11 +7411,12 @@ def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_integer_total_digits_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6981,11 +7428,12 @@ def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_integer_total_digits_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -6997,11 +7445,12 @@ def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_integer_total_digits_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7013,11 +7462,12 @@ def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_integer_total_digits_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7029,11 +7479,12 @@ def test_atomic_negative_integer_total_digits_6_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_integer_total_digits_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7045,11 +7496,12 @@ def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_integer_total_digits_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7061,11 +7513,12 @@ def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_integer_total_digits_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7077,11 +7530,12 @@ def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_integer_total_digits_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7093,11 +7547,12 @@ def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_integer_total_digits_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -7109,11 +7564,12 @@ def test_atomic_negative_integer_total_digits_5_nistxml_sv_ii_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7125,11 +7581,12 @@ def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7141,11 +7598,12 @@ def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7157,11 +7615,12 @@ def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7173,11 +7632,12 @@ def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7189,11 +7649,12 @@ def test_atomic_negative_integer_max_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7205,11 +7666,12 @@ def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7221,11 +7683,12 @@ def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7237,11 +7700,12 @@ def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7253,11 +7717,12 @@ def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7269,11 +7734,12 @@ def test_atomic_negative_integer_max_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7285,11 +7751,12 @@ def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7301,11 +7768,12 @@ def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7317,11 +7785,12 @@ def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7333,11 +7802,12 @@ def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7349,11 +7819,12 @@ def test_atomic_negative_integer_max_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7365,11 +7836,12 @@ def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7381,11 +7853,12 @@ def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7397,11 +7870,12 @@ def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7413,11 +7887,12 @@ def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7429,11 +7904,12 @@ def test_atomic_negative_integer_max_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7445,11 +7921,12 @@ def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_integer_max_inclusive_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7461,11 +7938,12 @@ def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_integer_max_inclusive_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7477,11 +7955,12 @@ def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_integer_max_inclusive_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7493,11 +7972,12 @@ def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_integer_max_inclusive_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -7509,11 +7989,12 @@ def test_atomic_negative_integer_max_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_integer_min_inclusive_6_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7525,11 +8006,12 @@ def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_integer_min_inclusive_6_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7541,11 +8023,12 @@ def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_integer_min_inclusive_6_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7557,11 +8040,12 @@ def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_integer_min_inclusive_6_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7573,11 +8057,12 @@ def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_integer_min_inclusive_6_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7589,11 +8074,12 @@ def test_atomic_negative_integer_min_inclusive_9_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7605,11 +8091,12 @@ def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_integer_min_inclusive_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7621,11 +8108,12 @@ def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_integer_min_inclusive_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7637,11 +8125,12 @@ def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_integer_min_inclusive_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7653,11 +8142,12 @@ def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_integer_min_inclusive_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7669,11 +8159,12 @@ def test_atomic_negative_integer_min_inclusive_8_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7685,11 +8176,12 @@ def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7701,11 +8193,12 @@ def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7717,11 +8210,12 @@ def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7733,11 +8227,12 @@ def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7749,11 +8244,12 @@ def test_atomic_negative_integer_min_inclusive_7_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7765,11 +8261,12 @@ def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7781,11 +8278,12 @@ def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7797,11 +8295,12 @@ def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7813,11 +8312,12 @@ def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7829,11 +8329,12 @@ def test_atomic_negative_integer_min_inclusive_6_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7845,11 +8346,12 @@ def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7861,11 +8363,12 @@ def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7877,11 +8380,12 @@ def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7893,11 +8397,12 @@ def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -7909,11 +8414,12 @@ def test_atomic_negative_integer_min_inclusive_5_nistxml_sv_ii_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-II-atomic-negativeInteger-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_positive_integer_total_digits_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -7925,11 +8431,12 @@ def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_positive_integer_total_digits_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -7941,11 +8448,12 @@ def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_positive_integer_total_digits_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -7957,11 +8465,12 @@ def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_positive_integer_total_digits_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -7973,11 +8482,12 @@ def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_positive_integer_total_digits_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -7989,11 +8499,12 @@ def test_atomic_non_positive_integer_total_digits_9_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_positive_integer_total_digits_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8005,11 +8516,12 @@ def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_positive_integer_total_digits_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8021,11 +8533,12 @@ def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_positive_integer_total_digits_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8037,11 +8550,12 @@ def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_positive_integer_total_digits_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8053,11 +8567,12 @@ def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_positive_integer_total_digits_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8069,11 +8584,12 @@ def test_atomic_non_positive_integer_total_digits_8_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_positive_integer_total_digits_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8085,11 +8601,12 @@ def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_positive_integer_total_digits_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8101,11 +8618,12 @@ def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_positive_integer_total_digits_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8117,11 +8635,12 @@ def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_positive_integer_total_digits_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8133,11 +8652,12 @@ def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_positive_integer_total_digits_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8149,11 +8669,12 @@ def test_atomic_non_positive_integer_total_digits_7_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_positive_integer_total_digits_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8165,11 +8686,12 @@ def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_positive_integer_total_digits_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8181,11 +8703,12 @@ def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_positive_integer_total_digits_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8197,11 +8720,12 @@ def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_positive_integer_total_digits_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8213,11 +8737,12 @@ def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_positive_integer_total_digits_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8229,11 +8754,12 @@ def test_atomic_non_positive_integer_total_digits_6_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_positive_integer_total_digits_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8245,11 +8771,12 @@ def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_positive_integer_total_digits_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8261,11 +8788,12 @@ def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_positive_integer_total_digits_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8277,11 +8805,12 @@ def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_positive_integer_total_digits_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8293,11 +8822,12 @@ def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_positive_integer_total_digits_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -8309,11 +8839,12 @@ def test_atomic_non_positive_integer_total_digits_5_nistxml_sv_ii_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8325,11 +8856,12 @@ def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8341,11 +8873,12 @@ def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8357,11 +8890,12 @@ def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8373,11 +8907,12 @@ def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8389,11 +8924,12 @@ def test_atomic_non_positive_integer_max_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8405,11 +8941,12 @@ def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8421,11 +8958,12 @@ def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8437,11 +8975,12 @@ def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8453,11 +8992,12 @@ def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8469,11 +9009,12 @@ def test_atomic_non_positive_integer_max_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8485,11 +9026,12 @@ def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8501,11 +9043,12 @@ def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8517,11 +9060,12 @@ def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8533,11 +9077,12 @@ def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8549,11 +9094,12 @@ def test_atomic_non_positive_integer_max_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8565,11 +9111,12 @@ def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8581,11 +9128,12 @@ def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8597,11 +9145,12 @@ def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8613,11 +9162,12 @@ def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8629,11 +9179,12 @@ def test_atomic_non_positive_integer_max_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8645,11 +9196,12 @@ def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8661,11 +9213,12 @@ def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8677,11 +9230,12 @@ def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8693,11 +9247,12 @@ def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_max_inclusive_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -8709,11 +9264,12 @@ def test_atomic_non_positive_integer_max_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_6_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8725,11 +9281,12 @@ def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_6_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8741,11 +9298,12 @@ def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_6_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8757,11 +9315,12 @@ def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_6_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8773,11 +9332,12 @@ def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_6_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8789,11 +9349,12 @@ def test_atomic_non_positive_integer_min_inclusive_9_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8805,11 +9366,12 @@ def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8821,11 +9383,12 @@ def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8837,11 +9400,12 @@ def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8853,11 +9417,12 @@ def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8869,11 +9434,12 @@ def test_atomic_non_positive_integer_min_inclusive_8_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8885,11 +9451,12 @@ def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8901,11 +9468,12 @@ def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8917,11 +9485,12 @@ def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8933,11 +9502,12 @@ def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8949,11 +9519,12 @@ def test_atomic_non_positive_integer_min_inclusive_7_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8965,11 +9536,12 @@ def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8981,11 +9553,12 @@ def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -8997,11 +9570,12 @@ def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9013,11 +9587,12 @@ def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9029,11 +9604,12 @@ def test_atomic_non_positive_integer_min_inclusive_6_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9045,11 +9621,12 @@ def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9061,11 +9638,12 @@ def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9077,11 +9655,12 @@ def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9093,11 +9672,12 @@ def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_positive_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -9109,11 +9689,12 @@ def test_atomic_non_positive_integer_min_inclusive_5_nistxml_sv_ii_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-atomic-nonPositiveInteger-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -9124,11 +9705,12 @@ def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -9139,11 +9721,12 @@ def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -9154,11 +9737,12 @@ def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -9169,11 +9753,12 @@ def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -9184,11 +9769,12 @@ def test_atomic_integer_total_digits_9_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 10.
@@ -9199,11 +9785,12 @@ def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 10.
@@ -9214,11 +9801,12 @@ def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 10.
@@ -9229,11 +9817,12 @@ def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 10.
@@ -9244,11 +9833,12 @@ def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 10.
@@ -9259,11 +9849,12 @@ def test_atomic_integer_total_digits_8_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 7.
@@ -9274,11 +9865,12 @@ def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 7.
@@ -9289,11 +9881,12 @@ def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 7.
@@ -9304,11 +9897,12 @@ def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 7.
@@ -9319,11 +9913,12 @@ def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 7.
@@ -9334,11 +9929,12 @@ def test_atomic_integer_total_digits_7_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 4.
@@ -9349,11 +9945,12 @@ def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 4.
@@ -9364,11 +9961,12 @@ def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 4.
@@ -9379,11 +9977,12 @@ def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 4.
@@ -9394,11 +9993,12 @@ def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 4.
@@ -9409,11 +10009,12 @@ def test_atomic_integer_total_digits_6_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -9424,11 +10025,12 @@ def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -9439,11 +10041,12 @@ def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -9454,11 +10057,12 @@ def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -9469,11 +10073,12 @@ def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -9484,11 +10089,12 @@ def test_atomic_integer_total_digits_5_nistxml_sv_ii_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9500,11 +10106,12 @@ def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9516,11 +10123,12 @@ def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9532,11 +10140,12 @@ def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9548,11 +10157,12 @@ def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9564,11 +10174,12 @@ def test_atomic_integer_max_inclusive_9_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9580,11 +10191,12 @@ def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9596,11 +10208,12 @@ def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9612,11 +10225,12 @@ def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9628,11 +10242,12 @@ def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9644,11 +10259,12 @@ def test_atomic_integer_max_inclusive_8_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9660,11 +10276,12 @@ def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9676,11 +10293,12 @@ def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9692,11 +10310,12 @@ def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9708,11 +10327,12 @@ def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9724,11 +10344,12 @@ def test_atomic_integer_max_inclusive_7_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9740,11 +10361,12 @@ def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9756,11 +10378,12 @@ def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9772,11 +10395,12 @@ def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9788,11 +10412,12 @@ def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9804,11 +10429,12 @@ def test_atomic_integer_max_inclusive_6_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9820,11 +10446,12 @@ def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusive_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9836,11 +10463,12 @@ def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusive_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9852,11 +10480,12 @@ def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusive_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9868,11 +10497,12 @@ def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusive_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -9884,11 +10514,12 @@ def test_atomic_integer_max_inclusive_5_nistxml_sv_ii_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusive_6_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9900,11 +10531,12 @@ def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusive_6_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9916,11 +10548,12 @@ def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusive_6_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9932,11 +10565,12 @@ def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusive_6_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9948,11 +10582,12 @@ def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusive_6_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9964,11 +10599,12 @@ def test_atomic_integer_min_inclusive_9_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9980,11 +10616,12 @@ def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusive_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -9996,11 +10633,12 @@ def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusive_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10012,11 +10650,12 @@ def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusive_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10028,11 +10667,12 @@ def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusive_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10044,11 +10684,12 @@ def test_atomic_integer_min_inclusive_8_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10060,11 +10701,12 @@ def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10076,11 +10718,12 @@ def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10092,11 +10735,12 @@ def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10108,11 +10752,12 @@ def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10124,11 +10769,12 @@ def test_atomic_integer_min_inclusive_7_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10140,11 +10786,12 @@ def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10156,11 +10803,12 @@ def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10172,11 +10820,12 @@ def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10188,11 +10837,12 @@ def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10204,11 +10854,12 @@ def test_atomic_integer_min_inclusive_6_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10220,11 +10871,12 @@ def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10236,11 +10888,12 @@ def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10252,11 +10905,12 @@ def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10268,11 +10922,12 @@ def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -10284,11 +10939,12 @@ def test_atomic_integer_min_inclusive_5_nistxml_sv_ii_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-II-atomic-integer-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -10299,11 +10955,12 @@ def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -10314,11 +10971,12 @@ def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -10329,11 +10987,12 @@ def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -10344,11 +11003,12 @@ def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -10359,11 +11019,12 @@ def test_atomic_decimal_total_digits_9_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 10.
@@ -10374,11 +11035,12 @@ def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 10.
@@ -10389,11 +11051,12 @@ def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 10.
@@ -10404,11 +11067,12 @@ def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 10.
@@ -10419,11 +11083,12 @@ def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 10.
@@ -10434,11 +11099,12 @@ def test_atomic_decimal_total_digits_8_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 7.
@@ -10449,11 +11115,12 @@ def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 7.
@@ -10464,11 +11131,12 @@ def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 7.
@@ -10479,11 +11147,12 @@ def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 7.
@@ -10494,11 +11163,12 @@ def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 7.
@@ -10509,11 +11179,12 @@ def test_atomic_decimal_total_digits_7_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 4.
@@ -10524,11 +11195,12 @@ def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 4.
@@ -10539,11 +11211,12 @@ def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 4.
@@ -10554,11 +11227,12 @@ def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 4.
@@ -10569,11 +11243,12 @@ def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 4.
@@ -10584,11 +11259,12 @@ def test_atomic_decimal_total_digits_6_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -10599,11 +11275,12 @@ def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -10614,11 +11291,12 @@ def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -10629,11 +11307,12 @@ def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -10644,11 +11323,12 @@ def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -10659,11 +11339,12 @@ def test_atomic_decimal_total_digits_5_nistxml_sv_ii_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-totalDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_digits_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10675,11 +11356,12 @@ def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_digits_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10691,11 +11373,12 @@ def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_digits_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10707,11 +11390,12 @@ def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_digits_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10723,11 +11407,12 @@ def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_digits_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10739,11 +11424,12 @@ def test_atomic_decimal_fraction_digits_9_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_digits_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10755,11 +11441,12 @@ def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_digits_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10771,11 +11458,12 @@ def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_digits_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10787,11 +11475,12 @@ def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_digits_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10803,11 +11492,12 @@ def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_digits_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10819,11 +11509,12 @@ def test_atomic_decimal_fraction_digits_8_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_digits_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10835,11 +11526,12 @@ def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_digits_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10851,11 +11543,12 @@ def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_digits_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10867,11 +11560,12 @@ def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_digits_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10883,11 +11577,12 @@ def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_digits_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10899,11 +11594,12 @@ def test_atomic_decimal_fraction_digits_7_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_digits_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10915,11 +11611,12 @@ def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_digits_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10931,11 +11628,12 @@ def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_digits_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10947,11 +11645,12 @@ def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_digits_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10963,11 +11662,12 @@ def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_digits_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10979,11 +11679,12 @@ def test_atomic_decimal_fraction_digits_6_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_digits_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -10995,11 +11696,12 @@ def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_digits_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -11011,11 +11713,12 @@ def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_digits_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -11027,11 +11730,12 @@ def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_digits_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -11043,11 +11747,12 @@ def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_digits_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -11059,11 +11764,12 @@ def test_atomic_decimal_fraction_digits_5_nistxml_sv_ii_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-fractionDigits-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11075,11 +11781,12 @@ def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusive_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11091,11 +11798,12 @@ def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusive_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11107,11 +11815,12 @@ def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusive_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11123,11 +11832,12 @@ def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusive_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11139,11 +11849,12 @@ def test_atomic_decimal_max_inclusive_9_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11155,11 +11866,12 @@ def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11171,11 +11883,12 @@ def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11187,11 +11900,12 @@ def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11203,11 +11917,12 @@ def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11219,11 +11934,12 @@ def test_atomic_decimal_max_inclusive_8_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11235,11 +11951,12 @@ def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11251,11 +11968,12 @@ def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11267,11 +11985,12 @@ def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11283,11 +12002,12 @@ def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11299,11 +12019,12 @@ def test_atomic_decimal_max_inclusive_7_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11315,11 +12036,12 @@ def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11331,11 +12053,12 @@ def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11347,11 +12070,12 @@ def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11363,11 +12087,12 @@ def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11379,11 +12104,12 @@ def test_atomic_decimal_max_inclusive_6_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11395,11 +12121,12 @@ def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusive_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11411,11 +12138,12 @@ def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusive_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11427,11 +12155,12 @@ def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusive_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11443,11 +12172,12 @@ def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusive_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -11459,11 +12189,12 @@ def test_atomic_decimal_max_inclusive_5_nistxml_sv_ii_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-maxInclusive-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusive_6_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11475,11 +12206,12 @@ def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-6-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusive_6_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11491,11 +12223,12 @@ def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-6-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusive_6_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11507,11 +12240,12 @@ def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-6-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusive_6_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11523,11 +12257,12 @@ def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-6-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusive_6_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11539,11 +12274,12 @@ def test_atomic_decimal_min_inclusive_9_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-6-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive6",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11555,11 +12291,12 @@ def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusive_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11571,11 +12308,12 @@ def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusive_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11587,11 +12325,12 @@ def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusive_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11603,11 +12342,12 @@ def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusive_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11619,11 +12359,12 @@ def test_atomic_decimal_min_inclusive_8_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11635,11 +12376,12 @@ def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11651,11 +12393,12 @@ def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11667,11 +12410,12 @@ def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11683,11 +12427,12 @@ def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11699,11 +12444,12 @@ def test_atomic_decimal_min_inclusive_7_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11715,11 +12461,12 @@ def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11731,11 +12478,12 @@ def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11747,11 +12495,12 @@ def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11763,11 +12512,12 @@ def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11779,11 +12529,12 @@ def test_atomic_decimal_min_inclusive_6_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11795,11 +12546,12 @@ def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11811,11 +12563,12 @@ def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11827,11 +12580,12 @@ def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11843,11 +12597,12 @@ def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -11859,11 +12614,12 @@ def test_atomic_decimal_min_inclusive_5_nistxml_sv_ii_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-II-atomic-decimal-minInclusive-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11874,11 +12630,12 @@ def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11889,11 +12646,12 @@ def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11904,11 +12662,12 @@ def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11919,11 +12678,12 @@ def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11934,11 +12694,12 @@ def test_atomic_float_enumeration_9_nistxml_sv_ii_atomic_float_enumeration_5_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11949,11 +12710,12 @@ def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11964,11 +12726,12 @@ def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11979,11 +12742,12 @@ def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11994,11 +12758,12 @@ def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12009,11 +12774,12 @@ def test_atomic_float_enumeration_8_nistxml_sv_ii_atomic_float_enumeration_4_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12024,11 +12790,12 @@ def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12039,11 +12806,12 @@ def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12054,11 +12822,12 @@ def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12069,11 +12838,12 @@ def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12084,11 +12854,12 @@ def test_atomic_float_enumeration_7_nistxml_sv_ii_atomic_float_enumeration_3_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12099,11 +12870,12 @@ def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12114,11 +12886,12 @@ def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12129,11 +12902,12 @@ def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12144,11 +12918,12 @@ def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12159,11 +12934,12 @@ def test_atomic_float_enumeration_6_nistxml_sv_ii_atomic_float_enumeration_2_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12174,11 +12950,12 @@ def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12189,11 +12966,12 @@ def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12204,11 +12982,12 @@ def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12219,11 +12998,12 @@ def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -12234,11 +13014,12 @@ def test_atomic_float_enumeration_5_nistxml_sv_ii_atomic_float_enumeration_1_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12250,11 +13031,12 @@ def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12266,11 +13048,12 @@ def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12282,11 +13065,12 @@ def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12298,11 +13082,12 @@ def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12314,11 +13099,12 @@ def test_atomic_float_pattern_9_nistxml_sv_ii_atomic_float_pattern_5_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12330,11 +13116,12 @@ def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12346,11 +13133,12 @@ def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12362,11 +13150,12 @@ def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12378,11 +13167,12 @@ def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12394,11 +13184,12 @@ def test_atomic_float_pattern_8_nistxml_sv_ii_atomic_float_pattern_4_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12410,11 +13201,12 @@ def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12426,11 +13218,12 @@ def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12442,11 +13235,12 @@ def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12458,11 +13252,12 @@ def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12474,11 +13269,12 @@ def test_atomic_float_pattern_7_nistxml_sv_ii_atomic_float_pattern_3_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12490,11 +13286,12 @@ def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12506,11 +13303,12 @@ def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12522,11 +13320,12 @@ def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12538,11 +13337,12 @@ def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12554,11 +13354,12 @@ def test_atomic_float_pattern_6_nistxml_sv_ii_atomic_float_pattern_2_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12570,11 +13371,12 @@ def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12586,11 +13388,12 @@ def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12602,11 +13405,12 @@ def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12618,11 +13422,12 @@ def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12634,11 +13439,12 @@ def test_atomic_float_pattern_5_nistxml_sv_ii_atomic_float_pattern_1_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-II-atomic-float-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12649,11 +13455,12 @@ def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12664,11 +13471,12 @@ def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12679,11 +13487,12 @@ def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12694,11 +13503,12 @@ def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12709,11 +13519,12 @@ def test_atomic_double_enumeration_9_nistxml_sv_ii_atomic_double_enumeration_5_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12724,11 +13535,12 @@ def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12739,11 +13551,12 @@ def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12754,11 +13567,12 @@ def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12769,11 +13583,12 @@ def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12784,11 +13599,12 @@ def test_atomic_double_enumeration_8_nistxml_sv_ii_atomic_double_enumeration_4_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12799,11 +13615,12 @@ def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12814,11 +13631,12 @@ def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12829,11 +13647,12 @@ def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12844,11 +13663,12 @@ def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12859,11 +13679,12 @@ def test_atomic_double_enumeration_7_nistxml_sv_ii_atomic_double_enumeration_3_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12874,11 +13695,12 @@ def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12889,11 +13711,12 @@ def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12904,11 +13727,12 @@ def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12919,11 +13743,12 @@ def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12934,11 +13759,12 @@ def test_atomic_double_enumeration_6_nistxml_sv_ii_atomic_double_enumeration_2_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12949,11 +13775,12 @@ def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12964,11 +13791,12 @@ def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12979,11 +13807,12 @@ def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12994,11 +13823,12 @@ def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -13009,11 +13839,12 @@ def test_atomic_double_enumeration_5_nistxml_sv_ii_atomic_double_enumeration_1_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13025,11 +13856,12 @@ def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13041,11 +13873,12 @@ def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13057,11 +13890,12 @@ def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13073,11 +13907,12 @@ def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13089,11 +13924,12 @@ def test_atomic_double_pattern_9_nistxml_sv_ii_atomic_double_pattern_5_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13105,11 +13941,12 @@ def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13121,11 +13958,12 @@ def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13137,11 +13975,12 @@ def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13153,11 +13992,12 @@ def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13169,11 +14009,12 @@ def test_atomic_double_pattern_8_nistxml_sv_ii_atomic_double_pattern_4_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13185,11 +14026,12 @@ def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13201,11 +14043,12 @@ def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13217,11 +14060,12 @@ def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13233,11 +14077,12 @@ def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13249,11 +14094,12 @@ def test_atomic_double_pattern_7_nistxml_sv_ii_atomic_double_pattern_3_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13265,11 +14111,12 @@ def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13281,11 +14128,12 @@ def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13297,11 +14145,12 @@ def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13313,11 +14162,12 @@ def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13329,11 +14179,12 @@ def test_atomic_double_pattern_6_nistxml_sv_ii_atomic_double_pattern_2_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13345,11 +14196,12 @@ def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13361,11 +14213,12 @@ def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13377,11 +14230,12 @@ def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13393,11 +14247,12 @@ def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13409,11 +14264,12 @@ def test_atomic_double_pattern_5_nistxml_sv_ii_atomic_double_pattern_1_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-II-atomic-double-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_space_1_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet whiteSpace with value
@@ -13425,11 +14281,12 @@ def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_spa
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_space_1_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet whiteSpace with value
@@ -13441,11 +14298,12 @@ def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_spa
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_space_1_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet whiteSpace with value
@@ -13457,11 +14315,12 @@ def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_spa
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_space_1_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet whiteSpace with value
@@ -13473,11 +14332,12 @@ def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_spa
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_space_1_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet whiteSpace with value
@@ -13489,11 +14349,12 @@ def test_atomic_hex_binary_white_space_nistxml_sv_iv_atomic_hex_binary_white_spa
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumeration_5_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13504,11 +14365,12 @@ def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumeration_5_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13519,11 +14381,12 @@ def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumeration_5_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13534,11 +14397,12 @@ def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumeration_5_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13549,11 +14413,12 @@ def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumeration_5_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13564,11 +14429,12 @@ def test_atomic_hex_binary_enumeration_4_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumeration_4_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13579,11 +14445,12 @@ def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumeration_4_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13594,11 +14461,12 @@ def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumeration_4_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13609,11 +14477,12 @@ def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumeration_4_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13624,11 +14493,12 @@ def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumeration_4_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13639,11 +14509,12 @@ def test_atomic_hex_binary_enumeration_3_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumeration_3_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13654,11 +14525,12 @@ def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumeration_3_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13669,11 +14541,12 @@ def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumeration_3_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13684,11 +14557,12 @@ def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumeration_3_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13699,11 +14573,12 @@ def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumeration_3_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13714,11 +14589,12 @@ def test_atomic_hex_binary_enumeration_2_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumeration_2_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13729,11 +14605,12 @@ def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumeration_2_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13744,11 +14621,12 @@ def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumeration_2_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13759,11 +14637,12 @@ def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumeration_2_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13774,11 +14653,12 @@ def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumeration_2_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13789,11 +14669,12 @@ def test_atomic_hex_binary_enumeration_1_nistxml_sv_iv_atomic_hex_binary_enumera
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumeration_1_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13804,11 +14685,12 @@ def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumerati
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumeration_1_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13819,11 +14701,12 @@ def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumerati
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumeration_1_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13834,11 +14717,12 @@ def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumerati
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumeration_1_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13849,11 +14733,12 @@ def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumerati
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumeration_1_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet enumeration.
@@ -13864,11 +14749,12 @@ def test_atomic_hex_binary_enumeration_nistxml_sv_iv_atomic_hex_binary_enumerati
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13880,11 +14766,12 @@ def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_1
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13896,11 +14783,12 @@ def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_2
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13912,11 +14800,12 @@ def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_3
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13928,11 +14817,12 @@ def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_4
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13944,11 +14834,12 @@ def test_atomic_hex_binary_pattern_4_nistxml_sv_iv_atomic_hex_binary_pattern_5_5
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13960,11 +14851,12 @@ def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_1
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13976,11 +14868,12 @@ def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_2
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -13992,11 +14885,12 @@ def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_3
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14008,11 +14902,12 @@ def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_4
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14024,11 +14919,12 @@ def test_atomic_hex_binary_pattern_3_nistxml_sv_iv_atomic_hex_binary_pattern_4_5
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14040,11 +14936,12 @@ def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_1
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14056,11 +14953,12 @@ def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_2
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14072,11 +14970,12 @@ def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_3
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14088,11 +14987,12 @@ def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_4
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14104,11 +15004,12 @@ def test_atomic_hex_binary_pattern_2_nistxml_sv_iv_atomic_hex_binary_pattern_3_5
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14120,11 +15021,12 @@ def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_1
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14136,11 +15038,12 @@ def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_2
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14152,11 +15055,12 @@ def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_3
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14168,11 +15072,12 @@ def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_4
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14184,11 +15089,12 @@ def test_atomic_hex_binary_pattern_1_nistxml_sv_iv_atomic_hex_binary_pattern_2_5
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14200,11 +15106,12 @@ def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_1(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14216,11 +15123,12 @@ def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_2(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14232,11 +15140,12 @@ def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_3(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14248,11 +15157,12 @@ def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_4(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet pattern with value
@@ -14264,11 +15174,12 @@ def test_atomic_hex_binary_pattern_nistxml_sv_iv_atomic_hex_binary_pattern_1_5(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 74.
@@ -14279,11 +15190,12 @@ def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_1(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 74.
@@ -14294,11 +15206,12 @@ def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_2(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 74.
@@ -14309,11 +15222,12 @@ def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_3(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 74.
@@ -14324,11 +15238,12 @@ def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_4(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 74.
@@ -14339,11 +15254,12 @@ def test_atomic_hex_binary_length_4_nistxml_sv_iv_atomic_hex_binary_length_5_5(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 68.
@@ -14354,11 +15270,12 @@ def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_1(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 68.
@@ -14369,11 +15286,12 @@ def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_2(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 68.
@@ -14384,11 +15302,12 @@ def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_3(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 68.
@@ -14399,11 +15318,12 @@ def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_4(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 68.
@@ -14414,11 +15334,12 @@ def test_atomic_hex_binary_length_3_nistxml_sv_iv_atomic_hex_binary_length_4_5(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 41.
@@ -14429,11 +15350,12 @@ def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_1(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 41.
@@ -14444,11 +15366,12 @@ def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_2(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 41.
@@ -14459,11 +15382,12 @@ def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_3(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 41.
@@ -14474,11 +15398,12 @@ def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_4(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 41.
@@ -14489,11 +15414,12 @@ def test_atomic_hex_binary_length_2_nistxml_sv_iv_atomic_hex_binary_length_3_5(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 16.
@@ -14504,11 +15430,12 @@ def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_1(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 16.
@@ -14519,11 +15446,12 @@ def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_2(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 16.
@@ -14534,11 +15462,12 @@ def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_3(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 16.
@@ -14549,11 +15478,12 @@ def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_4(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 16.
@@ -14564,11 +15494,12 @@ def test_atomic_hex_binary_length_1_nistxml_sv_iv_atomic_hex_binary_length_2_5(s
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 1.
@@ -14579,11 +15510,12 @@ def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_1(sav
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 1.
@@ -14594,11 +15526,12 @@ def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_2(sav
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 1.
@@ -14609,11 +15542,12 @@ def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_3(sav
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 1.
@@ -14624,11 +15558,12 @@ def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_4(sav
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet length with value 1.
@@ -14639,11 +15574,12 @@ def test_atomic_hex_binary_length_nistxml_sv_iv_atomic_hex_binary_length_1_5(sav
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_length_5_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 74.
@@ -14654,11 +15590,12 @@ def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_length_5_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 74.
@@ -14669,11 +15606,12 @@ def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_length_5_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 74.
@@ -14684,11 +15622,12 @@ def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_length_5_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 74.
@@ -14699,11 +15638,12 @@ def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_length_5_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 74.
@@ -14714,11 +15654,12 @@ def test_atomic_hex_binary_min_length_4_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_length_4_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 48.
@@ -14729,11 +15670,12 @@ def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_length_4_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 48.
@@ -14744,11 +15686,12 @@ def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_length_4_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 48.
@@ -14759,11 +15702,12 @@ def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_length_4_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 48.
@@ -14774,11 +15718,12 @@ def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_length_4_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 48.
@@ -14789,11 +15734,12 @@ def test_atomic_hex_binary_min_length_3_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_length_3_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 2.
@@ -14804,11 +15750,12 @@ def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_length_3_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 2.
@@ -14819,11 +15766,12 @@ def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_length_3_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 2.
@@ -14834,11 +15782,12 @@ def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_length_3_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 2.
@@ -14849,11 +15798,12 @@ def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_length_3_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 2.
@@ -14864,11 +15814,12 @@ def test_atomic_hex_binary_min_length_2_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_length_2_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 28.
@@ -14879,11 +15830,12 @@ def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_length_2_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 28.
@@ -14894,11 +15846,12 @@ def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_length_2_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 28.
@@ -14909,11 +15862,12 @@ def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_length_2_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 28.
@@ -14924,11 +15878,12 @@ def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_length_2_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 28.
@@ -14939,11 +15894,12 @@ def test_atomic_hex_binary_min_length_1_nistxml_sv_iv_atomic_hex_binary_min_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length_1_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 1.
@@ -14954,11 +15910,12 @@ def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length_1_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 1.
@@ -14969,11 +15926,12 @@ def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length_1_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 1.
@@ -14984,11 +15942,12 @@ def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length_1_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 1.
@@ -14999,11 +15958,12 @@ def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length_1_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet minLength with value 1.
@@ -15014,11 +15974,12 @@ def test_atomic_hex_binary_min_length_nistxml_sv_iv_atomic_hex_binary_min_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_length_5_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 74.
@@ -15029,11 +15990,12 @@ def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_length_5_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 74.
@@ -15044,11 +16006,12 @@ def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_length_5_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 74.
@@ -15059,11 +16022,12 @@ def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_length_5_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 74.
@@ -15074,11 +16038,12 @@ def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_length_5_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 74.
@@ -15089,11 +16054,12 @@ def test_atomic_hex_binary_max_length_4_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_length_4_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 6.
@@ -15104,11 +16070,12 @@ def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_length_4_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 6.
@@ -15119,11 +16086,12 @@ def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_length_4_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 6.
@@ -15134,11 +16102,12 @@ def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_length_4_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 6.
@@ -15149,11 +16118,12 @@ def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_length_4_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 6.
@@ -15164,11 +16134,12 @@ def test_atomic_hex_binary_max_length_3_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_length_3_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 7.
@@ -15179,11 +16150,12 @@ def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_length_3_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 7.
@@ -15194,11 +16166,12 @@ def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_length_3_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 7.
@@ -15209,11 +16182,12 @@ def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_length_3_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 7.
@@ -15224,11 +16198,12 @@ def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_length_3_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 7.
@@ -15239,11 +16214,12 @@ def test_atomic_hex_binary_max_length_2_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_length_2_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 29.
@@ -15254,11 +16230,12 @@ def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_length_2_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 29.
@@ -15269,11 +16246,12 @@ def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_length_2_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 29.
@@ -15284,11 +16262,12 @@ def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_length_2_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 29.
@@ -15299,11 +16278,12 @@ def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_length_2_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 29.
@@ -15314,11 +16294,12 @@ def test_atomic_hex_binary_max_length_1_nistxml_sv_iv_atomic_hex_binary_max_leng
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length_1_1(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 1.
@@ -15329,11 +16310,12 @@ def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length_1_2(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 1.
@@ -15344,11 +16326,12 @@ def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length_1_3(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 1.
@@ -15359,11 +16342,12 @@ def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length_1_4(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 1.
@@ -15374,11 +16358,12 @@ def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length_1_5(save_xml):
     """
     Type atomic/hexBinary is restricted by facet maxLength with value 1.
@@ -15389,11 +16374,12 @@ def test_atomic_hex_binary_max_length_nistxml_sv_iv_atomic_hex_binary_max_length
         instance="nistData/atomic/hexBinary/Schema+Instance/NISTXML-SV-IV-atomic-hexBinary-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_white_space_1_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet whiteSpace with value
@@ -15405,11 +16391,12 @@ def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_whi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_white_space_1_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet whiteSpace with value
@@ -15421,11 +16408,12 @@ def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_whi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_white_space_1_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet whiteSpace with value
@@ -15437,11 +16425,12 @@ def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_whi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_white_space_1_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet whiteSpace with value
@@ -15453,11 +16442,12 @@ def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_whi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_white_space_1_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet whiteSpace with value
@@ -15469,11 +16459,12 @@ def test_atomic_base64_binary_white_space_nistxml_sv_iv_atomic_base64_binary_whi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_enumeration_5_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15484,11 +16475,12 @@ def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_enumeration_5_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15499,11 +16491,12 @@ def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_enumeration_5_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15514,11 +16507,12 @@ def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_enumeration_5_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15529,11 +16523,12 @@ def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_enumeration_5_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15544,11 +16539,12 @@ def test_atomic_base64_binary_enumeration_4_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_enumeration_4_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15559,11 +16555,12 @@ def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_enumeration_4_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15574,11 +16571,12 @@ def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_enumeration_4_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15589,11 +16587,12 @@ def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_enumeration_4_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15604,11 +16603,12 @@ def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_enumeration_4_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15619,11 +16619,12 @@ def test_atomic_base64_binary_enumeration_3_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_enumeration_3_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15634,11 +16635,12 @@ def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_enumeration_3_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -15649,6 +16651,6 @@ def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_15000.py
+++ b/tests/test_nist_meta_15000.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_enumeration_3_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -13,11 +14,12 @@ def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_enumeration_3_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -28,11 +30,12 @@ def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_enumeration_3_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -43,11 +46,12 @@ def test_atomic_base64_binary_enumeration_2_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_enumeration_2_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -58,11 +62,12 @@ def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_enumeration_2_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -73,11 +78,12 @@ def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_enumeration_2_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -88,11 +94,12 @@ def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_enumeration_2_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -103,11 +110,12 @@ def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_enumeration_2_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -118,11 +126,12 @@ def test_atomic_base64_binary_enumeration_1_nistxml_sv_iv_atomic_base64_binary_e
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enumeration_1_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -133,11 +142,12 @@ def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enu
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enumeration_1_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -148,11 +158,12 @@ def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enu
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enumeration_1_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -163,11 +174,12 @@ def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enu
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enumeration_1_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -178,11 +190,12 @@ def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enu
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enumeration_1_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet enumeration.
@@ -193,11 +206,12 @@ def test_atomic_base64_binary_enumeration_nistxml_sv_iv_atomic_base64_binary_enu
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_pattern_5_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -209,11 +223,12 @@ def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_pattern_5_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -225,11 +240,12 @@ def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_pattern_5_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -241,11 +257,12 @@ def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_pattern_5_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -257,11 +274,12 @@ def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_pattern_5_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -273,11 +291,12 @@ def test_atomic_base64_binary_pattern_4_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_pattern_4_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -289,11 +308,12 @@ def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_pattern_4_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -305,11 +325,12 @@ def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_pattern_4_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -321,11 +342,12 @@ def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_pattern_4_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -337,11 +359,12 @@ def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_pattern_4_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -353,11 +376,12 @@ def test_atomic_base64_binary_pattern_3_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_pattern_3_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -369,11 +393,12 @@ def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_pattern_3_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -385,11 +410,12 @@ def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_pattern_3_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -401,11 +427,12 @@ def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_pattern_3_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -417,11 +444,12 @@ def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_pattern_3_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -433,11 +461,12 @@ def test_atomic_base64_binary_pattern_2_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_pattern_2_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -449,11 +478,12 @@ def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_pattern_2_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -465,11 +495,12 @@ def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_pattern_2_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -481,11 +512,12 @@ def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_pattern_2_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -497,11 +529,12 @@ def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_pattern_2_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -513,11 +546,12 @@ def test_atomic_base64_binary_pattern_1_nistxml_sv_iv_atomic_base64_binary_patte
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern_1_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -529,11 +563,12 @@ def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern_1_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -545,11 +580,12 @@ def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern_1_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -561,11 +597,12 @@ def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern_1_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -577,11 +614,12 @@ def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern_1_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet pattern with value
@@ -593,11 +631,12 @@ def test_atomic_base64_binary_pattern_nistxml_sv_iv_atomic_base64_binary_pattern
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length_5_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 74.
@@ -608,11 +647,12 @@ def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length_5_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 74.
@@ -623,11 +663,12 @@ def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length_5_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 74.
@@ -638,11 +679,12 @@ def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length_5_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 74.
@@ -653,11 +695,12 @@ def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length_5_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 74.
@@ -668,11 +711,12 @@ def test_atomic_base64_binary_length_4_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length_4_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 47.
@@ -683,11 +727,12 @@ def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length_4_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 47.
@@ -698,11 +743,12 @@ def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length_4_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 47.
@@ -713,11 +759,12 @@ def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length_4_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 47.
@@ -728,11 +775,12 @@ def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length_4_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 47.
@@ -743,11 +791,12 @@ def test_atomic_base64_binary_length_3_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length_3_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 31.
@@ -758,11 +807,12 @@ def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length_3_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 31.
@@ -773,11 +823,12 @@ def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length_3_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 31.
@@ -788,11 +839,12 @@ def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length_3_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 31.
@@ -803,11 +855,12 @@ def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length_3_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 31.
@@ -818,11 +871,12 @@ def test_atomic_base64_binary_length_2_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length_2_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -833,11 +887,12 @@ def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length_2_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -848,11 +903,12 @@ def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length_2_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -863,11 +919,12 @@ def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length_2_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -878,11 +935,12 @@ def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length_2_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -893,11 +951,12 @@ def test_atomic_base64_binary_length_1_nistxml_sv_iv_atomic_base64_binary_length
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -908,11 +967,12 @@ def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -923,11 +983,12 @@ def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -938,11 +999,12 @@ def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -953,11 +1015,12 @@ def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet length with value 1.
@@ -968,11 +1031,12 @@ def test_atomic_base64_binary_length_nistxml_sv_iv_atomic_base64_binary_length_1
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_min_length_5_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -984,11 +1048,12 @@ def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_min_length_5_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1000,11 +1065,12 @@ def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_min_length_5_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1016,11 +1082,12 @@ def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_min_length_5_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1032,11 +1099,12 @@ def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_min_length_5_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1048,11 +1116,12 @@ def test_atomic_base64_binary_min_length_4_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_min_length_4_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1064,11 +1133,12 @@ def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_min_length_4_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1080,11 +1150,12 @@ def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_min_length_4_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1096,11 +1167,12 @@ def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_min_length_4_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1112,11 +1184,12 @@ def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_min_length_4_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1128,11 +1201,12 @@ def test_atomic_base64_binary_min_length_3_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_min_length_3_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1144,11 +1218,12 @@ def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_min_length_3_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1160,11 +1235,12 @@ def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_min_length_3_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1176,11 +1252,12 @@ def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_min_length_3_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1192,11 +1269,12 @@ def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_min_length_3_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1208,11 +1286,12 @@ def test_atomic_base64_binary_min_length_2_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_min_length_2_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1224,11 +1303,12 @@ def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_min_length_2_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1240,11 +1320,12 @@ def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_min_length_2_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1256,11 +1337,12 @@ def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_min_length_2_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1272,11 +1354,12 @@ def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_min_length_2_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1288,11 +1371,12 @@ def test_atomic_base64_binary_min_length_1_nistxml_sv_iv_atomic_base64_binary_mi
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_length_1_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1304,11 +1388,12 @@ def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_length_1_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1320,11 +1405,12 @@ def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_length_1_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1336,11 +1422,12 @@ def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_length_1_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1352,11 +1439,12 @@ def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_length_1_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet minLength with value
@@ -1368,11 +1456,12 @@ def test_atomic_base64_binary_min_length_nistxml_sv_iv_atomic_base64_binary_min_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_max_length_5_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1384,11 +1473,12 @@ def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_max_length_5_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1400,11 +1490,12 @@ def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_max_length_5_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1416,11 +1507,12 @@ def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_max_length_5_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1432,11 +1524,12 @@ def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_max_length_5_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1448,11 +1541,12 @@ def test_atomic_base64_binary_max_length_4_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_max_length_4_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1464,11 +1558,12 @@ def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_max_length_4_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1480,11 +1575,12 @@ def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_max_length_4_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1496,11 +1592,12 @@ def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_max_length_4_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1512,11 +1609,12 @@ def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_max_length_4_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1528,11 +1626,12 @@ def test_atomic_base64_binary_max_length_3_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_max_length_3_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1544,11 +1643,12 @@ def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_max_length_3_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1560,11 +1660,12 @@ def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_max_length_3_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1576,11 +1677,12 @@ def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_max_length_3_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1592,11 +1694,12 @@ def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_max_length_3_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1608,11 +1711,12 @@ def test_atomic_base64_binary_max_length_2_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_max_length_2_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1624,11 +1728,12 @@ def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_max_length_2_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1640,11 +1745,12 @@ def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_max_length_2_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1656,11 +1762,12 @@ def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_max_length_2_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1672,11 +1779,12 @@ def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_max_length_2_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1688,11 +1796,12 @@ def test_atomic_base64_binary_max_length_1_nistxml_sv_iv_atomic_base64_binary_ma
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_length_1_1(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1704,11 +1813,12 @@ def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_length_1_2(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1720,11 +1830,12 @@ def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_length_1_3(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1736,11 +1847,12 @@ def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_length_1_4(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1752,11 +1864,12 @@ def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_length_1_5(save_xml):
     """
     Type atomic/base64Binary is restricted by facet maxLength with value
@@ -1768,11 +1881,12 @@ def test_atomic_base64_binary_max_length_nistxml_sv_iv_atomic_base64_binary_max_
         instance="nistData/atomic/base64Binary/Schema+Instance/NISTXML-SV-IV-atomic-base64Binary-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5_1(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1784,11 +1898,12 @@ def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5_2(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1800,11 +1915,12 @@ def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5_3(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1816,11 +1932,12 @@ def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5_4(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1832,11 +1949,12 @@ def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5_5(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1848,11 +1966,12 @@ def test_atomic_boolean_white_space_4_nistxml_sv_iv_atomic_boolean_white_space_5
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4_1(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1864,11 +1983,12 @@ def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4_2(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1880,11 +2000,12 @@ def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4_3(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1896,11 +2017,12 @@ def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4_4(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1912,11 +2034,12 @@ def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4_5(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1928,11 +2051,12 @@ def test_atomic_boolean_white_space_3_nistxml_sv_iv_atomic_boolean_white_space_4
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3_1(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1944,11 +2068,12 @@ def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3_2(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1960,11 +2085,12 @@ def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3_3(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1976,11 +2102,12 @@ def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3_4(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -1992,11 +2119,12 @@ def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3_5(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2008,11 +2136,12 @@ def test_atomic_boolean_white_space_2_nistxml_sv_iv_atomic_boolean_white_space_3
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2_1(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2024,11 +2153,12 @@ def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2_2(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2040,11 +2170,12 @@ def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2_3(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2056,11 +2187,12 @@ def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2_4(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2072,11 +2204,12 @@ def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2_5(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2088,11 +2221,12 @@ def test_atomic_boolean_white_space_1_nistxml_sv_iv_atomic_boolean_white_space_2
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_1(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2104,11 +2238,12 @@ def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_1
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_2(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2120,11 +2255,12 @@ def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_2
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_3(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2136,11 +2272,12 @@ def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_3
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_4(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2152,11 +2289,12 @@ def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_4
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_5(save_xml):
     """
     Type atomic/boolean is restricted by facet whiteSpace with value
@@ -2168,11 +2306,12 @@ def test_atomic_boolean_white_space_nistxml_sv_iv_atomic_boolean_white_space_1_5
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_1(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2183,11 +2322,12 @@ def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_1(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_2(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2198,11 +2338,12 @@ def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_2(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_3(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2213,11 +2354,12 @@ def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_3(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_4(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2228,11 +2370,12 @@ def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_4(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_5(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2243,11 +2386,12 @@ def test_atomic_boolean_pattern_4_nistxml_sv_iv_atomic_boolean_pattern_5_5(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_1(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2258,11 +2402,12 @@ def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_1(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_2(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2273,11 +2418,12 @@ def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_2(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_3(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2288,11 +2434,12 @@ def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_3(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_4(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2303,11 +2450,12 @@ def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_4(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_5(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2318,11 +2466,12 @@ def test_atomic_boolean_pattern_3_nistxml_sv_iv_atomic_boolean_pattern_4_5(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_1(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2333,11 +2482,12 @@ def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_1(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_2(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2348,11 +2498,12 @@ def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_2(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_3(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2363,11 +2514,12 @@ def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_3(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_4(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2378,11 +2530,12 @@ def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_4(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_5(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2393,11 +2546,12 @@ def test_atomic_boolean_pattern_2_nistxml_sv_iv_atomic_boolean_pattern_3_5(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_1(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2408,11 +2562,12 @@ def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_1(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_2(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2423,11 +2578,12 @@ def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_2(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_3(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2438,11 +2594,12 @@ def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_3(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_4(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2453,11 +2610,12 @@ def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_4(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_5(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value false.
@@ -2468,11 +2626,12 @@ def test_atomic_boolean_pattern_1_nistxml_sv_iv_atomic_boolean_pattern_2_5(save_
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_1(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2483,11 +2642,12 @@ def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_1(save_xm
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_2(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2498,11 +2658,12 @@ def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_2(save_xm
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_3(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2513,11 +2674,12 @@ def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_3(save_xm
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_4(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2528,11 +2690,12 @@ def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_4(save_xm
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_5(save_xml):
     """
     Type atomic/boolean is restricted by facet pattern with value [1]{1}.
@@ -2543,11 +2706,12 @@ def test_atomic_boolean_pattern_nistxml_sv_iv_atomic_boolean_pattern_1_5(save_xm
         instance="nistData/atomic/boolean/Schema+Instance/NISTXML-SV-IV-atomic-boolean-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_1(save_xml):
     """
     Type atomic/QName is restricted by facet whiteSpace with value
@@ -2559,11 +2723,12 @@ def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_2(save_xml):
     """
     Type atomic/QName is restricted by facet whiteSpace with value
@@ -2575,11 +2740,12 @@ def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_3(save_xml):
     """
     Type atomic/QName is restricted by facet whiteSpace with value
@@ -2591,11 +2757,12 @@ def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_4(save_xml):
     """
     Type atomic/QName is restricted by facet whiteSpace with value
@@ -2607,11 +2774,12 @@ def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_5(save_xml):
     """
     Type atomic/QName is restricted by facet whiteSpace with value
@@ -2623,11 +2791,12 @@ def test_atomic_qname_white_space_nistxml_sv_iv_atomic_qname_white_space_1_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_1(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2638,11 +2807,12 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_1(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_2(save_xml):
     """
@@ -2654,11 +2824,12 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_2(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_3(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2669,11 +2840,12 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_3(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_4(save_xml):
     """
@@ -2685,11 +2857,12 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_4(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_5(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2700,11 +2873,12 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_5(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_1(save_xml):
     """
@@ -2716,11 +2890,12 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_1(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_2(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2731,11 +2906,12 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_2(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_3(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2746,11 +2922,12 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_3(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_4(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2761,11 +2938,12 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_4(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_5(save_xml):
     """
@@ -2777,11 +2955,12 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_5(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_1(save_xml):
     """
@@ -2793,11 +2972,12 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_1(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_2(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2808,11 +2988,12 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_2(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_3(save_xml):
     """
@@ -2824,11 +3005,12 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_3(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_4(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2839,11 +3021,12 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_4(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_5(save_xml):
     """
@@ -2855,11 +3038,12 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_5(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_1(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2870,11 +3054,12 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_1(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_2(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2885,11 +3070,12 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_2(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_3(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2900,11 +3086,12 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_3(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_4(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2915,11 +3102,12 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_4(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_5(save_xml):
     """
@@ -2931,11 +3119,12 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_5(s
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_1(save_xml):
     """
@@ -2947,11 +3136,12 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_2(save_xml):
     """
@@ -2963,11 +3153,12 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_3(save_xml):
     """
@@ -2979,11 +3170,12 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_4(save_xml):
     """
@@ -2995,11 +3187,12 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_5(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -3010,11 +3203,12 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_1(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3026,11 +3220,12 @@ def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_1(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_2(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3042,11 +3237,12 @@ def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_2(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_3(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3058,11 +3254,12 @@ def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_3(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_4(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3074,11 +3271,12 @@ def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_4(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_5(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3090,11 +3288,12 @@ def test_atomic_qname_pattern_4_nistxml_sv_iv_atomic_qname_pattern_5_5(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_1(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3106,11 +3305,12 @@ def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_1(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_2(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3122,11 +3322,12 @@ def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_2(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_3(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3138,11 +3339,12 @@ def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_3(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_4(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3154,11 +3356,12 @@ def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_4(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_5(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3170,11 +3373,12 @@ def test_atomic_qname_pattern_3_nistxml_sv_iv_atomic_qname_pattern_4_5(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_1(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3186,11 +3390,12 @@ def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_1(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_2(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3202,11 +3407,12 @@ def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_2(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_3(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3218,11 +3424,12 @@ def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_3(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_4(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3234,11 +3441,12 @@ def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_4(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_5(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3250,11 +3458,12 @@ def test_atomic_qname_pattern_2_nistxml_sv_iv_atomic_qname_pattern_3_5(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_1(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3266,11 +3475,12 @@ def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_1(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_2(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3282,11 +3492,12 @@ def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_2(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_3(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3298,11 +3509,12 @@ def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_3(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_4(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3314,11 +3526,12 @@ def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_4(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_5(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3330,11 +3543,12 @@ def test_atomic_qname_pattern_1_nistxml_sv_iv_atomic_qname_pattern_2_5(save_xml)
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_1(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3346,11 +3560,12 @@ def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_1(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_2(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3362,11 +3577,12 @@ def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_2(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_3(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3378,11 +3594,12 @@ def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_3(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_4(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3394,11 +3611,12 @@ def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_4(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_5(save_xml):
     r"""
     Type atomic/QName is restricted by facet pattern with value
@@ -3410,11 +3628,12 @@ def test_atomic_qname_pattern_nistxml_sv_iv_atomic_qname_pattern_1_5(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_1(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 64. The
@@ -3427,11 +3646,12 @@ def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_1(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_2(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 64. The
@@ -3444,11 +3664,12 @@ def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_2(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_3(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 64. The
@@ -3461,11 +3682,12 @@ def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_3(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_4(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 64. The
@@ -3478,11 +3700,12 @@ def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_4(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_5(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 64. The
@@ -3495,11 +3718,12 @@ def test_atomic_qname_length_4_nistxml_sv_iv_atomic_qname_length_5_5(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_1(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 34. The
@@ -3512,11 +3736,12 @@ def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_1(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_2(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 34. The
@@ -3529,11 +3754,12 @@ def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_2(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_3(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 34. The
@@ -3546,11 +3772,12 @@ def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_3(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_4(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 34. The
@@ -3563,11 +3790,12 @@ def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_4(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_5(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 34. The
@@ -3580,11 +3808,12 @@ def test_atomic_qname_length_3_nistxml_sv_iv_atomic_qname_length_4_5(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_1(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 33. The
@@ -3597,11 +3826,12 @@ def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_1(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_2(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 33. The
@@ -3614,11 +3844,12 @@ def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_2(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_3(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 33. The
@@ -3631,11 +3862,12 @@ def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_3(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_4(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 33. The
@@ -3648,11 +3880,12 @@ def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_4(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_5(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 33. The
@@ -3665,11 +3898,12 @@ def test_atomic_qname_length_2_nistxml_sv_iv_atomic_qname_length_3_5(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_1(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 7. The
@@ -3682,11 +3916,12 @@ def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_1(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_2(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 7. The
@@ -3699,11 +3934,12 @@ def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_2(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_3(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 7. The
@@ -3716,11 +3952,12 @@ def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_3(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_4(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 7. The
@@ -3733,11 +3970,12 @@ def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_4(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_5(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 7. The
@@ -3750,11 +3988,12 @@ def test_atomic_qname_length_1_nistxml_sv_iv_atomic_qname_length_2_5(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_1(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 1. The
@@ -3767,11 +4006,12 @@ def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_1(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_2(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 1. The
@@ -3784,11 +4024,12 @@ def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_2(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_3(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 1. The
@@ -3801,11 +4042,12 @@ def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_3(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_4(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 1. The
@@ -3818,11 +4060,12 @@ def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_4(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_5(save_xml):
     """
     Type atomic/QName is restricted by facet length with value 1. The
@@ -3835,11 +4078,12 @@ def test_atomic_qname_length_nistxml_sv_iv_atomic_qname_length_1_5(save_xml):
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_1(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 64. The
@@ -3852,11 +4096,12 @@ def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_2(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 64. The
@@ -3869,11 +4114,12 @@ def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_3(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 64. The
@@ -3886,11 +4132,12 @@ def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_4(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 64. The
@@ -3903,11 +4150,12 @@ def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_5(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 64. The
@@ -3920,11 +4168,12 @@ def test_atomic_qname_min_length_4_nistxml_sv_iv_atomic_qname_min_length_5_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_1(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 18. The
@@ -3937,11 +4186,12 @@ def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_2(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 18. The
@@ -3954,11 +4204,12 @@ def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_3(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 18. The
@@ -3971,11 +4222,12 @@ def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_4(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 18. The
@@ -3988,11 +4240,12 @@ def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_5(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 18. The
@@ -4005,11 +4258,12 @@ def test_atomic_qname_min_length_3_nistxml_sv_iv_atomic_qname_min_length_4_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_1(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 50. The
@@ -4022,11 +4276,12 @@ def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_2(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 50. The
@@ -4039,11 +4294,12 @@ def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_3(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 50. The
@@ -4056,11 +4312,12 @@ def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_4(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 50. The
@@ -4073,11 +4330,12 @@ def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_5(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 50. The
@@ -4090,11 +4348,12 @@ def test_atomic_qname_min_length_2_nistxml_sv_iv_atomic_qname_min_length_3_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_1(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 8. The
@@ -4107,11 +4366,12 @@ def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_2(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 8. The
@@ -4124,11 +4384,12 @@ def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_3(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 8. The
@@ -4141,11 +4402,12 @@ def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_4(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 8. The
@@ -4158,11 +4420,12 @@ def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_5(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 8. The
@@ -4175,11 +4438,12 @@ def test_atomic_qname_min_length_1_nistxml_sv_iv_atomic_qname_min_length_2_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_1(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 1. The
@@ -4192,11 +4456,12 @@ def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_1(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_2(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 1. The
@@ -4209,11 +4474,12 @@ def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_2(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_3(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 1. The
@@ -4226,11 +4492,12 @@ def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_3(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_4(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 1. The
@@ -4243,11 +4510,12 @@ def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_4(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_5(save_xml):
     """
     Type atomic/QName is restricted by facet minLength with value 1. The
@@ -4260,11 +4528,12 @@ def test_atomic_qname_min_length_nistxml_sv_iv_atomic_qname_min_length_1_5(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_1(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 64. The
@@ -4277,11 +4546,12 @@ def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_2(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 64. The
@@ -4294,11 +4564,12 @@ def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_3(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 64. The
@@ -4311,11 +4582,12 @@ def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_4(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 64. The
@@ -4328,11 +4600,12 @@ def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_5(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 64. The
@@ -4345,11 +4618,12 @@ def test_atomic_qname_max_length_4_nistxml_sv_iv_atomic_qname_max_length_5_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_1(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 61. The
@@ -4362,11 +4636,12 @@ def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_2(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 61. The
@@ -4379,11 +4654,12 @@ def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_3(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 61. The
@@ -4396,11 +4672,12 @@ def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_4(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 61. The
@@ -4413,11 +4690,12 @@ def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_5(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 61. The
@@ -4430,11 +4708,12 @@ def test_atomic_qname_max_length_3_nistxml_sv_iv_atomic_qname_max_length_4_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_1(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 57. The
@@ -4447,11 +4726,12 @@ def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_2(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 57. The
@@ -4464,11 +4744,12 @@ def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_3(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 57. The
@@ -4481,11 +4762,12 @@ def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_4(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 57. The
@@ -4498,11 +4780,12 @@ def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_5(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 57. The
@@ -4515,11 +4798,12 @@ def test_atomic_qname_max_length_2_nistxml_sv_iv_atomic_qname_max_length_3_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_1(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 4. The
@@ -4532,11 +4816,12 @@ def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_1(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_2(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 4. The
@@ -4549,11 +4834,12 @@ def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_2(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_3(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 4. The
@@ -4566,11 +4852,12 @@ def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_3(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_4(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 4. The
@@ -4583,11 +4870,12 @@ def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_4(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_5(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 4. The
@@ -4600,11 +4888,12 @@ def test_atomic_qname_max_length_1_nistxml_sv_iv_atomic_qname_max_length_2_5(sav
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_1(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 1. The
@@ -4617,11 +4906,12 @@ def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_1(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_2(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 1. The
@@ -4634,11 +4924,12 @@ def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_2(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_3(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 1. The
@@ -4651,11 +4942,12 @@ def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_3(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_4(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 1. The
@@ -4668,11 +4960,12 @@ def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_4(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_5(save_xml):
     """
     Type atomic/QName is restricted by facet maxLength with value 1. The
@@ -4685,11 +4978,12 @@ def test_atomic_qname_max_length_nistxml_sv_iv_atomic_qname_max_length_1_5(save_
         instance="nistData/atomic/QName/Schema+Instance/NISTXML-SV-IV-atomic-QName-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet whiteSpace with value
@@ -4701,11 +4995,12 @@ def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet whiteSpace with value
@@ -4717,11 +5012,12 @@ def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet whiteSpace with value
@@ -4733,11 +5029,12 @@ def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet whiteSpace with value
@@ -4749,11 +5046,12 @@ def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet whiteSpace with value
@@ -4765,11 +5063,12 @@ def test_atomic_any_uri_white_space_nistxml_sv_iv_atomic_any_uri_white_space_1_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4780,11 +5079,12 @@ def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4795,11 +5095,12 @@ def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4810,11 +5111,12 @@ def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4825,11 +5127,12 @@ def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4840,11 +5143,12 @@ def test_atomic_any_uri_enumeration_4_nistxml_sv_iv_atomic_any_uri_enumeration_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4855,11 +5159,12 @@ def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4870,11 +5175,12 @@ def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4885,11 +5191,12 @@ def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4900,11 +5207,12 @@ def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4915,11 +5223,12 @@ def test_atomic_any_uri_enumeration_3_nistxml_sv_iv_atomic_any_uri_enumeration_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4930,11 +5239,12 @@ def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4945,11 +5255,12 @@ def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4960,11 +5271,12 @@ def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4975,11 +5287,12 @@ def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -4990,11 +5303,12 @@ def test_atomic_any_uri_enumeration_2_nistxml_sv_iv_atomic_any_uri_enumeration_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5005,11 +5319,12 @@ def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5020,11 +5335,12 @@ def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5035,11 +5351,12 @@ def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5050,11 +5367,12 @@ def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5065,11 +5383,12 @@ def test_atomic_any_uri_enumeration_1_nistxml_sv_iv_atomic_any_uri_enumeration_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5080,11 +5399,12 @@ def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5095,11 +5415,12 @@ def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5110,11 +5431,12 @@ def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5125,11 +5447,12 @@ def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet enumeration.
@@ -5140,11 +5463,12 @@ def test_atomic_any_uri_enumeration_nistxml_sv_iv_atomic_any_uri_enumeration_1_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5156,11 +5480,12 @@ def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5172,11 +5497,12 @@ def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5188,11 +5514,12 @@ def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5204,11 +5531,12 @@ def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5220,11 +5548,12 @@ def test_atomic_any_uri_pattern_4_nistxml_sv_iv_atomic_any_uri_pattern_5_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5236,11 +5565,12 @@ def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5252,11 +5582,12 @@ def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5268,11 +5599,12 @@ def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5284,11 +5616,12 @@ def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5300,11 +5633,12 @@ def test_atomic_any_uri_pattern_3_nistxml_sv_iv_atomic_any_uri_pattern_4_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5316,11 +5650,12 @@ def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5332,11 +5667,12 @@ def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5348,11 +5684,12 @@ def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5364,11 +5701,12 @@ def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5380,11 +5718,12 @@ def test_atomic_any_uri_pattern_2_nistxml_sv_iv_atomic_any_uri_pattern_3_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5396,11 +5735,12 @@ def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_1(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5412,11 +5752,12 @@ def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_2(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5428,11 +5769,12 @@ def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_3(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5444,11 +5786,12 @@ def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_4(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5460,11 +5803,12 @@ def test_atomic_any_uri_pattern_1_nistxml_sv_iv_atomic_any_uri_pattern_2_5(save_
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_1(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5476,11 +5820,12 @@ def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_2(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5492,11 +5837,12 @@ def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_3(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5508,11 +5854,12 @@ def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_4(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5524,11 +5871,12 @@ def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_5(save_xml):
     r"""
     Type atomic/anyURI is restricted by facet pattern with value
@@ -5540,11 +5888,12 @@ def test_atomic_any_uri_pattern_nistxml_sv_iv_atomic_any_uri_pattern_1_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -5555,11 +5904,12 @@ def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -5570,11 +5920,12 @@ def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -5585,11 +5936,12 @@ def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -5600,11 +5952,12 @@ def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 63.
@@ -5615,11 +5968,12 @@ def test_atomic_any_uri_length_4_nistxml_sv_iv_atomic_any_uri_length_5_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 12.
@@ -5630,11 +5984,12 @@ def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 12.
@@ -5645,11 +6000,12 @@ def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 12.
@@ -5660,11 +6016,12 @@ def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 12.
@@ -5675,11 +6032,12 @@ def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 12.
@@ -5690,11 +6048,12 @@ def test_atomic_any_uri_length_3_nistxml_sv_iv_atomic_any_uri_length_4_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 34.
@@ -5705,11 +6064,12 @@ def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 34.
@@ -5720,11 +6080,12 @@ def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 34.
@@ -5735,11 +6096,12 @@ def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 34.
@@ -5750,11 +6112,12 @@ def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 34.
@@ -5765,11 +6128,12 @@ def test_atomic_any_uri_length_2_nistxml_sv_iv_atomic_any_uri_length_3_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5780,11 +6144,12 @@ def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_1(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5795,11 +6160,12 @@ def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_2(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5810,11 +6176,12 @@ def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_3(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5825,11 +6192,12 @@ def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_4(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5840,11 +6208,12 @@ def test_atomic_any_uri_length_1_nistxml_sv_iv_atomic_any_uri_length_2_5(save_xm
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5855,11 +6224,12 @@ def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_1(save_xml)
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5870,11 +6240,12 @@ def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_2(save_xml)
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5885,11 +6256,12 @@ def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_3(save_xml)
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5900,11 +6272,12 @@ def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_4(save_xml)
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet length with value 11.
@@ -5915,11 +6288,12 @@ def test_atomic_any_uri_length_nistxml_sv_iv_atomic_any_uri_length_1_5(save_xml)
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -5930,11 +6304,12 @@ def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -5945,11 +6320,12 @@ def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -5960,11 +6336,12 @@ def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -5975,11 +6352,12 @@ def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 63.
@@ -5990,11 +6368,12 @@ def test_atomic_any_uri_min_length_4_nistxml_sv_iv_atomic_any_uri_min_length_5_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 50.
@@ -6005,11 +6384,12 @@ def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 50.
@@ -6020,11 +6400,12 @@ def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 50.
@@ -6035,11 +6416,12 @@ def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 50.
@@ -6050,11 +6432,12 @@ def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 50.
@@ -6065,11 +6448,12 @@ def test_atomic_any_uri_min_length_3_nistxml_sv_iv_atomic_any_uri_min_length_4_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 36.
@@ -6080,11 +6464,12 @@ def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 36.
@@ -6095,11 +6480,12 @@ def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 36.
@@ -6110,11 +6496,12 @@ def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 36.
@@ -6125,11 +6512,12 @@ def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 36.
@@ -6140,11 +6528,12 @@ def test_atomic_any_uri_min_length_2_nistxml_sv_iv_atomic_any_uri_min_length_3_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 41.
@@ -6155,11 +6544,12 @@ def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 41.
@@ -6170,11 +6560,12 @@ def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 41.
@@ -6185,11 +6576,12 @@ def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 41.
@@ -6200,11 +6592,12 @@ def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 41.
@@ -6215,11 +6608,12 @@ def test_atomic_any_uri_min_length_1_nistxml_sv_iv_atomic_any_uri_min_length_2_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 11.
@@ -6230,11 +6624,12 @@ def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_1(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 11.
@@ -6245,11 +6640,12 @@ def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_2(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 11.
@@ -6260,11 +6656,12 @@ def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_3(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 11.
@@ -6275,11 +6672,12 @@ def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_4(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet minLength with value 11.
@@ -6290,11 +6688,12 @@ def test_atomic_any_uri_min_length_nistxml_sv_iv_atomic_any_uri_min_length_1_5(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 63.
@@ -6305,11 +6704,12 @@ def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 63.
@@ -6320,11 +6720,12 @@ def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 63.
@@ -6335,11 +6736,12 @@ def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 63.
@@ -6350,11 +6752,12 @@ def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 63.
@@ -6365,11 +6768,12 @@ def test_atomic_any_uri_max_length_4_nistxml_sv_iv_atomic_any_uri_max_length_5_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 31.
@@ -6380,11 +6784,12 @@ def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 31.
@@ -6395,11 +6800,12 @@ def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 31.
@@ -6410,11 +6816,12 @@ def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 31.
@@ -6425,11 +6832,12 @@ def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 31.
@@ -6440,11 +6848,12 @@ def test_atomic_any_uri_max_length_3_nistxml_sv_iv_atomic_any_uri_max_length_4_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 26.
@@ -6455,11 +6864,12 @@ def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 26.
@@ -6470,11 +6880,12 @@ def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 26.
@@ -6485,11 +6896,12 @@ def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 26.
@@ -6500,11 +6912,12 @@ def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 26.
@@ -6515,11 +6928,12 @@ def test_atomic_any_uri_max_length_2_nistxml_sv_iv_atomic_any_uri_max_length_3_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 40.
@@ -6530,11 +6944,12 @@ def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_1
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 40.
@@ -6545,11 +6960,12 @@ def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_2
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 40.
@@ -6560,11 +6976,12 @@ def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_3
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 40.
@@ -6575,11 +6992,12 @@ def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_4
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 40.
@@ -6590,11 +7008,12 @@ def test_atomic_any_uri_max_length_1_nistxml_sv_iv_atomic_any_uri_max_length_2_5
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_1(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -6605,11 +7024,12 @@ def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_1(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_2(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -6620,11 +7040,12 @@ def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_2(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_3(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -6635,11 +7056,12 @@ def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_3(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_4(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -6650,11 +7072,12 @@ def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_4(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_5(save_xml):
     """
     Type atomic/anyURI is restricted by facet maxLength with value 11.
@@ -6665,11 +7088,12 @@ def test_atomic_any_uri_max_length_nistxml_sv_iv_atomic_any_uri_max_length_1_5(s
         instance="nistData/atomic/anyURI/Schema+Instance/NISTXML-SV-IV-atomic-anyURI-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1_1(save_xml):
     """
     Type atomic/language is restricted by facet whiteSpace with value
@@ -6681,11 +7105,12 @@ def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1_2(save_xml):
     """
     Type atomic/language is restricted by facet whiteSpace with value
@@ -6697,11 +7122,12 @@ def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1_3(save_xml):
     """
     Type atomic/language is restricted by facet whiteSpace with value
@@ -6713,11 +7139,12 @@ def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1_4(save_xml):
     """
     Type atomic/language is restricted by facet whiteSpace with value
@@ -6729,11 +7156,12 @@ def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1_5(save_xml):
     """
     Type atomic/language is restricted by facet whiteSpace with value
@@ -6745,11 +7173,12 @@ def test_atomic_language_white_space_nistxml_sv_iv_atomic_language_white_space_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration_5_1(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6760,11 +7189,12 @@ def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration_5_2(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6775,11 +7205,12 @@ def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration_5_3(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6790,11 +7221,12 @@ def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration_5_4(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6805,11 +7237,12 @@ def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration_5_5(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6820,11 +7253,12 @@ def test_atomic_language_enumeration_4_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration_4_1(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6835,11 +7269,12 @@ def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration_4_2(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6850,11 +7285,12 @@ def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration_4_3(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6865,11 +7301,12 @@ def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration_4_4(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6880,11 +7317,12 @@ def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration_4_5(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6895,11 +7333,12 @@ def test_atomic_language_enumeration_3_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration_3_1(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6910,11 +7349,12 @@ def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration_3_2(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6925,11 +7365,12 @@ def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration_3_3(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6940,11 +7381,12 @@ def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration_3_4(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6955,11 +7397,12 @@ def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration_3_5(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6970,11 +7413,12 @@ def test_atomic_language_enumeration_2_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration_2_1(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -6985,11 +7429,12 @@ def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration_2_2(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7000,11 +7445,12 @@ def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration_2_3(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7015,11 +7461,12 @@ def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration_2_4(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7030,11 +7477,12 @@ def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration_2_5(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7045,11 +7493,12 @@ def test_atomic_language_enumeration_1_nistxml_sv_iv_atomic_language_enumeration
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1_1(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7060,11 +7509,12 @@ def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1_2(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7075,11 +7525,12 @@ def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1_3(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7090,11 +7541,12 @@ def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1_4(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7105,11 +7557,12 @@ def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1_5(save_xml):
     """
     Type atomic/language is restricted by facet enumeration.
@@ -7120,11 +7573,12 @@ def test_atomic_language_enumeration_nistxml_sv_iv_atomic_language_enumeration_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_1(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7136,11 +7590,12 @@ def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_1(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_2(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7152,11 +7607,12 @@ def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_2(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_3(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7168,11 +7624,12 @@ def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_3(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_4(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7184,11 +7641,12 @@ def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_4(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_5(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7200,11 +7658,12 @@ def test_atomic_language_pattern_4_nistxml_sv_iv_atomic_language_pattern_5_5(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_1(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7216,11 +7675,12 @@ def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_1(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_2(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7232,11 +7692,12 @@ def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_2(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_3(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7248,11 +7709,12 @@ def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_3(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_4(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7264,11 +7726,12 @@ def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_4(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_5(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7280,11 +7743,12 @@ def test_atomic_language_pattern_3_nistxml_sv_iv_atomic_language_pattern_4_5(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_1(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7296,11 +7760,12 @@ def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_1(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_2(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7312,11 +7777,12 @@ def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_2(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_3(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7328,11 +7794,12 @@ def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_3(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_4(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7344,11 +7811,12 @@ def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_4(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_5(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7360,11 +7828,12 @@ def test_atomic_language_pattern_2_nistxml_sv_iv_atomic_language_pattern_3_5(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_1(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7376,11 +7845,12 @@ def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_1(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_2(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7392,11 +7862,12 @@ def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_2(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_3(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7408,11 +7879,12 @@ def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_3(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_4(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7424,11 +7896,12 @@ def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_4(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_5(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7440,11 +7913,12 @@ def test_atomic_language_pattern_1_nistxml_sv_iv_atomic_language_pattern_2_5(sav
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_1(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7456,11 +7930,12 @@ def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_2(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7472,11 +7947,12 @@ def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_3(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7488,11 +7964,12 @@ def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_4(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7504,11 +7981,12 @@ def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_5(save_xml):
     """
     Type atomic/language is restricted by facet pattern with value
@@ -7520,11 +7998,12 @@ def test_atomic_language_pattern_nistxml_sv_iv_atomic_language_pattern_1_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7535,11 +8014,12 @@ def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7550,11 +8030,12 @@ def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7565,11 +8046,12 @@ def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7580,11 +8062,12 @@ def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 11.
@@ -7595,11 +8078,12 @@ def test_atomic_language_length_4_nistxml_sv_iv_atomic_language_length_5_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7610,11 +8094,12 @@ def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7625,11 +8110,12 @@ def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7640,11 +8126,12 @@ def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7655,11 +8142,12 @@ def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 5.
@@ -7670,11 +8158,12 @@ def test_atomic_language_length_3_nistxml_sv_iv_atomic_language_length_4_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 10.
@@ -7685,11 +8174,12 @@ def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 10.
@@ -7700,11 +8190,12 @@ def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 10.
@@ -7715,11 +8206,12 @@ def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 10.
@@ -7730,11 +8222,12 @@ def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 10.
@@ -7745,11 +8238,12 @@ def test_atomic_language_length_2_nistxml_sv_iv_atomic_language_length_3_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7760,11 +8254,12 @@ def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_1(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7775,11 +8270,12 @@ def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_2(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7790,11 +8286,12 @@ def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_3(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7805,11 +8302,12 @@ def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_4(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 7.
@@ -7820,11 +8318,12 @@ def test_atomic_language_length_1_nistxml_sv_iv_atomic_language_length_2_5(save_
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_1(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -7835,11 +8334,12 @@ def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_1(save_xm
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_2(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -7850,11 +8350,12 @@ def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_2(save_xm
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_3(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -7865,11 +8366,12 @@ def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_3(save_xm
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_4(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -7880,11 +8382,12 @@ def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_4(save_xm
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_5(save_xml):
     """
     Type atomic/language is restricted by facet length with value 2.
@@ -7895,11 +8398,12 @@ def test_atomic_language_length_nistxml_sv_iv_atomic_language_length_1_5(save_xm
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -7910,11 +8414,12 @@ def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -7925,11 +8430,12 @@ def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -7940,11 +8446,12 @@ def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -7955,11 +8462,12 @@ def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 11.
@@ -7970,11 +8478,12 @@ def test_atomic_language_min_length_4_nistxml_sv_iv_atomic_language_min_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 4.
@@ -7985,11 +8494,12 @@ def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 4.
@@ -8000,11 +8510,12 @@ def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 4.
@@ -8015,11 +8526,12 @@ def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 4.
@@ -8030,11 +8542,12 @@ def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 4.
@@ -8045,11 +8558,12 @@ def test_atomic_language_min_length_3_nistxml_sv_iv_atomic_language_min_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8060,11 +8574,12 @@ def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8075,11 +8590,12 @@ def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8090,11 +8606,12 @@ def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8105,11 +8622,12 @@ def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 9.
@@ -8120,11 +8638,12 @@ def test_atomic_language_min_length_2_nistxml_sv_iv_atomic_language_min_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 5.
@@ -8135,11 +8654,12 @@ def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 5.
@@ -8150,11 +8670,12 @@ def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 5.
@@ -8165,11 +8686,12 @@ def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 5.
@@ -8180,11 +8702,12 @@ def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 5.
@@ -8195,11 +8718,12 @@ def test_atomic_language_min_length_1_nistxml_sv_iv_atomic_language_min_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_1(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 2.
@@ -8210,11 +8734,12 @@ def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_2(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 2.
@@ -8225,11 +8750,12 @@ def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_3(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 2.
@@ -8240,11 +8766,12 @@ def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_4(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 2.
@@ -8255,11 +8782,12 @@ def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_5(save_xml):
     """
     Type atomic/language is restricted by facet minLength with value 2.
@@ -8270,11 +8798,12 @@ def test_atomic_language_min_length_nistxml_sv_iv_atomic_language_min_length_1_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 11.
@@ -8285,11 +8814,12 @@ def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 11.
@@ -8300,11 +8830,12 @@ def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 11.
@@ -8315,11 +8846,12 @@ def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 11.
@@ -8330,11 +8862,12 @@ def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 11.
@@ -8345,11 +8878,12 @@ def test_atomic_language_max_length_4_nistxml_sv_iv_atomic_language_max_length_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8360,11 +8894,12 @@ def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8375,11 +8910,12 @@ def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8390,11 +8926,12 @@ def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8405,11 +8942,12 @@ def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 9.
@@ -8420,11 +8958,12 @@ def test_atomic_language_max_length_3_nistxml_sv_iv_atomic_language_max_length_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8435,11 +8974,12 @@ def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8450,11 +8990,12 @@ def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8465,11 +9006,12 @@ def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8480,11 +9022,12 @@ def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8495,11 +9038,12 @@ def test_atomic_language_max_length_2_nistxml_sv_iv_atomic_language_max_length_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8510,11 +9054,12 @@ def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8525,11 +9070,12 @@ def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8540,11 +9086,12 @@ def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8555,11 +9102,12 @@ def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8570,11 +9118,12 @@ def test_atomic_language_max_length_1_nistxml_sv_iv_atomic_language_max_length_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_1(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8585,11 +9134,12 @@ def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_1
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_2(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8600,11 +9150,12 @@ def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_2
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_3(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8615,11 +9166,12 @@ def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_3
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_4(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8630,11 +9182,12 @@ def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_4
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_5(save_xml):
     """
     Type atomic/language is restricted by facet maxLength with value 2.
@@ -8645,11 +9198,12 @@ def test_atomic_language_max_length_nistxml_sv_iv_atomic_language_max_length_1_5
         instance="nistData/atomic/language/Schema+Instance/NISTXML-SV-IV-atomic-language-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet whiteSpace with value collapse.
@@ -8660,11 +9214,12 @@ def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet whiteSpace with value collapse.
@@ -8675,11 +9230,12 @@ def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet whiteSpace with value collapse.
@@ -8690,11 +9246,12 @@ def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet whiteSpace with value collapse.
@@ -8705,11 +9262,12 @@ def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet whiteSpace with value collapse.
@@ -8720,11 +9278,12 @@ def test_atomic_id_white_space_nistxml_sv_iv_atomic_id_white_space_1_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8735,11 +9294,12 @@ def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_1(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8750,11 +9310,12 @@ def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_2(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8765,11 +9326,12 @@ def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_3(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8780,11 +9342,12 @@ def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_4(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8795,11 +9358,12 @@ def test_atomic_id_enumeration_4_nistxml_sv_iv_atomic_id_enumeration_5_5(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8810,11 +9374,12 @@ def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_1(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8825,11 +9390,12 @@ def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_2(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8840,11 +9406,12 @@ def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_3(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8855,11 +9422,12 @@ def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_4(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8870,11 +9438,12 @@ def test_atomic_id_enumeration_3_nistxml_sv_iv_atomic_id_enumeration_4_5(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8885,11 +9454,12 @@ def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_1(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8900,11 +9470,12 @@ def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_2(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8915,11 +9486,12 @@ def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_3(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8930,11 +9502,12 @@ def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_4(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8945,11 +9518,12 @@ def test_atomic_id_enumeration_2_nistxml_sv_iv_atomic_id_enumeration_3_5(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8960,11 +9534,12 @@ def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_1(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8975,11 +9550,12 @@ def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_2(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -8990,11 +9566,12 @@ def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_3(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9005,11 +9582,12 @@ def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_4(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9020,11 +9598,12 @@ def test_atomic_id_enumeration_1_nistxml_sv_iv_atomic_id_enumeration_2_5(save_xm
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9035,11 +9614,12 @@ def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9050,11 +9630,12 @@ def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9065,11 +9646,12 @@ def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9080,11 +9662,12 @@ def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet enumeration.
@@ -9095,11 +9678,12 @@ def test_atomic_id_enumeration_nistxml_sv_iv_atomic_id_enumeration_1_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_1(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9111,11 +9695,12 @@ def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_2(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9127,11 +9712,12 @@ def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_3(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9143,11 +9729,12 @@ def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_4(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9159,11 +9746,12 @@ def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_5(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9175,11 +9763,12 @@ def test_atomic_id_pattern_4_nistxml_sv_iv_atomic_id_pattern_5_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_1(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9191,11 +9780,12 @@ def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_2(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9207,11 +9797,12 @@ def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_3(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9223,11 +9814,12 @@ def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_4(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9239,11 +9831,12 @@ def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_5(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9255,11 +9848,12 @@ def test_atomic_id_pattern_3_nistxml_sv_iv_atomic_id_pattern_4_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_1(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9271,11 +9865,12 @@ def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_2(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9287,11 +9882,12 @@ def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_3(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9303,11 +9899,12 @@ def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_4(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9319,11 +9916,12 @@ def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_5(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9335,11 +9933,12 @@ def test_atomic_id_pattern_2_nistxml_sv_iv_atomic_id_pattern_3_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_1(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9351,11 +9950,12 @@ def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_2(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9367,11 +9967,12 @@ def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_3(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9383,11 +9984,12 @@ def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_4(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9399,11 +10001,12 @@ def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_5(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9415,11 +10018,12 @@ def test_atomic_id_pattern_1_nistxml_sv_iv_atomic_id_pattern_2_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_1(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9431,11 +10035,12 @@ def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_2(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9447,11 +10052,12 @@ def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_3(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9463,11 +10069,12 @@ def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_4(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9479,11 +10086,12 @@ def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_5(save_xml):
     r"""
     Type atomic/ID is restricted by facet pattern with value
@@ -9495,11 +10103,12 @@ def test_atomic_id_pattern_nistxml_sv_iv_atomic_id_pattern_1_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9510,11 +10119,12 @@ def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9525,11 +10135,12 @@ def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9540,11 +10151,12 @@ def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9555,11 +10167,12 @@ def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 64.
@@ -9570,11 +10183,12 @@ def test_atomic_id_length_4_nistxml_sv_iv_atomic_id_length_5_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 8.
@@ -9585,11 +10199,12 @@ def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 8.
@@ -9600,11 +10215,12 @@ def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 8.
@@ -9615,11 +10231,12 @@ def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 8.
@@ -9630,11 +10247,12 @@ def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 8.
@@ -9645,11 +10263,12 @@ def test_atomic_id_length_3_nistxml_sv_iv_atomic_id_length_4_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 24.
@@ -9660,11 +10279,12 @@ def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 24.
@@ -9675,11 +10295,12 @@ def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 24.
@@ -9690,11 +10311,12 @@ def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 24.
@@ -9705,11 +10327,12 @@ def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 24.
@@ -9720,11 +10343,12 @@ def test_atomic_id_length_2_nistxml_sv_iv_atomic_id_length_3_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 57.
@@ -9735,11 +10359,12 @@ def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 57.
@@ -9750,11 +10375,12 @@ def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 57.
@@ -9765,11 +10391,12 @@ def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 57.
@@ -9780,11 +10407,12 @@ def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 57.
@@ -9795,11 +10423,12 @@ def test_atomic_id_length_1_nistxml_sv_iv_atomic_id_length_2_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -9810,11 +10439,12 @@ def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -9825,11 +10455,12 @@ def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -9840,11 +10471,12 @@ def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -9855,11 +10487,12 @@ def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet length with value 1.
@@ -9870,11 +10503,12 @@ def test_atomic_id_length_nistxml_sv_iv_atomic_id_length_1_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-length-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -9885,11 +10519,12 @@ def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -9900,11 +10535,12 @@ def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -9915,11 +10551,12 @@ def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -9930,11 +10567,12 @@ def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 64.
@@ -9945,11 +10583,12 @@ def test_atomic_id_min_length_4_nistxml_sv_iv_atomic_id_min_length_5_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 6.
@@ -9960,11 +10599,12 @@ def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 6.
@@ -9975,11 +10615,12 @@ def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 6.
@@ -9990,11 +10631,12 @@ def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 6.
@@ -10005,11 +10647,12 @@ def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 6.
@@ -10020,11 +10663,12 @@ def test_atomic_id_min_length_3_nistxml_sv_iv_atomic_id_min_length_4_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 58.
@@ -10035,11 +10679,12 @@ def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 58.
@@ -10050,11 +10695,12 @@ def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 58.
@@ -10065,11 +10711,12 @@ def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 58.
@@ -10080,11 +10727,12 @@ def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 58.
@@ -10095,11 +10743,12 @@ def test_atomic_id_min_length_2_nistxml_sv_iv_atomic_id_min_length_3_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 45.
@@ -10110,11 +10759,12 @@ def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 45.
@@ -10125,11 +10775,12 @@ def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 45.
@@ -10140,11 +10791,12 @@ def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 45.
@@ -10155,11 +10807,12 @@ def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 45.
@@ -10170,11 +10823,12 @@ def test_atomic_id_min_length_1_nistxml_sv_iv_atomic_id_min_length_2_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 1.
@@ -10185,11 +10839,12 @@ def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 1.
@@ -10200,11 +10855,12 @@ def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 1.
@@ -10215,11 +10871,12 @@ def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 1.
@@ -10230,11 +10887,12 @@ def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet minLength with value 1.
@@ -10245,11 +10903,12 @@ def test_atomic_id_min_length_nistxml_sv_iv_atomic_id_min_length_1_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10260,11 +10919,12 @@ def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10275,11 +10935,12 @@ def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10290,11 +10951,12 @@ def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10305,11 +10967,12 @@ def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 64.
@@ -10320,11 +10983,12 @@ def test_atomic_id_max_length_4_nistxml_sv_iv_atomic_id_max_length_5_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 22.
@@ -10335,11 +10999,12 @@ def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 22.
@@ -10350,11 +11015,12 @@ def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 22.
@@ -10365,11 +11031,12 @@ def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 22.
@@ -10380,11 +11047,12 @@ def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 22.
@@ -10395,11 +11063,12 @@ def test_atomic_id_max_length_3_nistxml_sv_iv_atomic_id_max_length_4_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 58.
@@ -10410,11 +11079,12 @@ def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 58.
@@ -10425,11 +11095,12 @@ def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 58.
@@ -10440,11 +11111,12 @@ def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 58.
@@ -10455,11 +11127,12 @@ def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 58.
@@ -10470,11 +11143,12 @@ def test_atomic_id_max_length_2_nistxml_sv_iv_atomic_id_max_length_3_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10485,11 +11159,12 @@ def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_1(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10500,11 +11175,12 @@ def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_2(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10515,11 +11191,12 @@ def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_3(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10530,11 +11207,12 @@ def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_4(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 62.
@@ -10545,11 +11223,12 @@ def test_atomic_id_max_length_1_nistxml_sv_iv_atomic_id_max_length_2_5(save_xml)
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_1(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10560,11 +11239,12 @@ def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_1(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_2(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10575,11 +11255,12 @@ def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_2(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_3(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10590,11 +11271,12 @@ def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_3(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_4(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10605,11 +11287,12 @@ def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_4(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_5(save_xml):
     """
     Type atomic/ID is restricted by facet maxLength with value 1.
@@ -10620,11 +11303,12 @@ def test_atomic_id_max_length_nistxml_sv_iv_atomic_id_max_length_1_5(save_xml):
         instance="nistData/atomic/ID/Schema+Instance/NISTXML-SV-IV-atomic-ID-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet whiteSpace with value
@@ -10636,11 +11320,12 @@ def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet whiteSpace with value
@@ -10652,11 +11337,12 @@ def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet whiteSpace with value
@@ -10668,11 +11354,12 @@ def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet whiteSpace with value
@@ -10684,11 +11371,12 @@ def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet whiteSpace with value
@@ -10700,11 +11388,12 @@ def test_atomic_ncname_white_space_nistxml_sv_iv_atomic_ncname_white_space_1_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10715,11 +11404,12 @@ def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_1
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10730,11 +11420,12 @@ def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_2
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10745,11 +11436,12 @@ def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_3
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10760,11 +11452,12 @@ def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_4
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10775,11 +11468,12 @@ def test_atomic_ncname_enumeration_4_nistxml_sv_iv_atomic_ncname_enumeration_5_5
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10790,11 +11484,12 @@ def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_1
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10805,11 +11500,12 @@ def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_2
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10820,11 +11516,12 @@ def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_3
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10835,11 +11532,12 @@ def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_4
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10850,11 +11548,12 @@ def test_atomic_ncname_enumeration_3_nistxml_sv_iv_atomic_ncname_enumeration_4_5
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10865,11 +11564,12 @@ def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_1
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10880,11 +11580,12 @@ def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_2
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10895,11 +11596,12 @@ def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_3
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10910,11 +11612,12 @@ def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_4
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10925,11 +11628,12 @@ def test_atomic_ncname_enumeration_2_nistxml_sv_iv_atomic_ncname_enumeration_3_5
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10940,11 +11644,12 @@ def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_1
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10955,11 +11660,12 @@ def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_2
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10970,11 +11676,12 @@ def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_3
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -10985,11 +11692,12 @@ def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_4
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -11000,11 +11708,12 @@ def test_atomic_ncname_enumeration_1_nistxml_sv_iv_atomic_ncname_enumeration_2_5
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -11015,11 +11724,12 @@ def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -11030,11 +11740,12 @@ def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -11045,11 +11756,12 @@ def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -11060,11 +11772,12 @@ def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet enumeration.
@@ -11075,11 +11788,12 @@ def test_atomic_ncname_enumeration_nistxml_sv_iv_atomic_ncname_enumeration_1_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_1(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11091,11 +11805,12 @@ def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_1(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_2(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11107,11 +11822,12 @@ def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_2(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_3(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11123,11 +11839,12 @@ def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_3(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_4(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11139,11 +11856,12 @@ def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_4(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_5(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11155,11 +11873,12 @@ def test_atomic_ncname_pattern_4_nistxml_sv_iv_atomic_ncname_pattern_5_5(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_1(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11171,11 +11890,12 @@ def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_1(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_2(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11187,11 +11907,12 @@ def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_2(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_3(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11203,11 +11924,12 @@ def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_3(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_4(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11219,11 +11941,12 @@ def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_4(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_5(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11235,11 +11958,12 @@ def test_atomic_ncname_pattern_3_nistxml_sv_iv_atomic_ncname_pattern_4_5(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_1(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11251,11 +11975,12 @@ def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_1(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_2(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11267,11 +11992,12 @@ def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_2(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_3(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11283,11 +12009,12 @@ def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_3(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_4(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11299,11 +12026,12 @@ def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_4(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_5(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11315,11 +12043,12 @@ def test_atomic_ncname_pattern_2_nistxml_sv_iv_atomic_ncname_pattern_3_5(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_1(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11331,11 +12060,12 @@ def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_1(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_2(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11347,11 +12077,12 @@ def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_2(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_3(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11363,11 +12094,12 @@ def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_3(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_4(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11379,11 +12111,12 @@ def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_4(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_5(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11395,11 +12128,12 @@ def test_atomic_ncname_pattern_1_nistxml_sv_iv_atomic_ncname_pattern_2_5(save_xm
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_1(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11411,11 +12145,12 @@ def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_2(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11427,11 +12162,12 @@ def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_3(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11443,11 +12179,12 @@ def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_4(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11459,11 +12196,12 @@ def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_5(save_xml):
     r"""
     Type atomic/NCName is restricted by facet pattern with value
@@ -11475,11 +12213,12 @@ def test_atomic_ncname_pattern_nistxml_sv_iv_atomic_ncname_pattern_1_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -11490,11 +12229,12 @@ def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -11505,11 +12245,12 @@ def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -11520,11 +12261,12 @@ def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -11535,11 +12277,12 @@ def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 64.
@@ -11550,11 +12293,12 @@ def test_atomic_ncname_length_4_nistxml_sv_iv_atomic_ncname_length_5_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11565,11 +12309,12 @@ def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11580,11 +12325,12 @@ def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11595,11 +12341,12 @@ def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11610,11 +12357,12 @@ def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11625,11 +12373,12 @@ def test_atomic_ncname_length_3_nistxml_sv_iv_atomic_ncname_length_4_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 53.
@@ -11640,11 +12389,12 @@ def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 53.
@@ -11655,11 +12405,12 @@ def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 53.
@@ -11670,11 +12421,12 @@ def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 53.
@@ -11685,11 +12437,12 @@ def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 53.
@@ -11700,11 +12453,12 @@ def test_atomic_ncname_length_2_nistxml_sv_iv_atomic_ncname_length_3_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11715,11 +12469,12 @@ def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_1(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11730,11 +12485,12 @@ def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_2(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11745,11 +12501,12 @@ def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_3(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11760,11 +12517,12 @@ def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_4(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 61.
@@ -11775,11 +12533,12 @@ def test_atomic_ncname_length_1_nistxml_sv_iv_atomic_ncname_length_2_5(save_xml)
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -11790,11 +12549,12 @@ def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_1(save_xml):
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -11805,11 +12565,12 @@ def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_2(save_xml):
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -11820,11 +12581,12 @@ def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_3(save_xml):
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -11835,11 +12597,12 @@ def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_4(save_xml):
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet length with value 1.
@@ -11850,11 +12613,12 @@ def test_atomic_ncname_length_nistxml_sv_iv_atomic_ncname_length_1_5(save_xml):
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -11865,11 +12629,12 @@ def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -11880,11 +12645,12 @@ def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -11895,11 +12661,12 @@ def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -11910,11 +12677,12 @@ def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 64.
@@ -11925,11 +12693,12 @@ def test_atomic_ncname_min_length_4_nistxml_sv_iv_atomic_ncname_min_length_5_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 60.
@@ -11940,11 +12709,12 @@ def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 60.
@@ -11955,11 +12725,12 @@ def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 60.
@@ -11970,11 +12741,12 @@ def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 60.
@@ -11985,11 +12757,12 @@ def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 60.
@@ -12000,11 +12773,12 @@ def test_atomic_ncname_min_length_3_nistxml_sv_iv_atomic_ncname_min_length_4_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 32.
@@ -12015,11 +12789,12 @@ def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 32.
@@ -12030,11 +12805,12 @@ def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 32.
@@ -12045,11 +12821,12 @@ def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 32.
@@ -12060,11 +12837,12 @@ def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 32.
@@ -12075,11 +12853,12 @@ def test_atomic_ncname_min_length_2_nistxml_sv_iv_atomic_ncname_min_length_3_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 47.
@@ -12090,11 +12869,12 @@ def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 47.
@@ -12105,11 +12885,12 @@ def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 47.
@@ -12120,11 +12901,12 @@ def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 47.
@@ -12135,11 +12917,12 @@ def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 47.
@@ -12150,11 +12933,12 @@ def test_atomic_ncname_min_length_1_nistxml_sv_iv_atomic_ncname_min_length_2_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 1.
@@ -12165,11 +12949,12 @@ def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_1(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 1.
@@ -12180,11 +12965,12 @@ def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_2(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 1.
@@ -12195,11 +12981,12 @@ def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_3(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 1.
@@ -12210,11 +12997,12 @@ def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_4(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet minLength with value 1.
@@ -12225,11 +13013,12 @@ def test_atomic_ncname_min_length_nistxml_sv_iv_atomic_ncname_min_length_1_5(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -12240,11 +13029,12 @@ def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -12255,11 +13045,12 @@ def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -12270,11 +13061,12 @@ def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -12285,11 +13077,12 @@ def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 64.
@@ -12300,11 +13093,12 @@ def test_atomic_ncname_max_length_4_nistxml_sv_iv_atomic_ncname_max_length_5_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 37.
@@ -12315,11 +13109,12 @@ def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 37.
@@ -12330,11 +13125,12 @@ def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 37.
@@ -12345,11 +13141,12 @@ def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 37.
@@ -12360,11 +13157,12 @@ def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 37.
@@ -12375,11 +13173,12 @@ def test_atomic_ncname_max_length_3_nistxml_sv_iv_atomic_ncname_max_length_4_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 12.
@@ -12390,11 +13189,12 @@ def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 12.
@@ -12405,11 +13205,12 @@ def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 12.
@@ -12420,11 +13221,12 @@ def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 12.
@@ -12435,11 +13237,12 @@ def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 12.
@@ -12450,11 +13253,12 @@ def test_atomic_ncname_max_length_2_nistxml_sv_iv_atomic_ncname_max_length_3_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 48.
@@ -12465,11 +13269,12 @@ def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_1(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 48.
@@ -12480,11 +13285,12 @@ def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_2(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 48.
@@ -12495,11 +13301,12 @@ def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_3(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 48.
@@ -12510,11 +13317,12 @@ def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_4(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 48.
@@ -12525,11 +13333,12 @@ def test_atomic_ncname_max_length_1_nistxml_sv_iv_atomic_ncname_max_length_2_5(s
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_1(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -12540,11 +13349,12 @@ def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_1(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_2(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -12555,11 +13365,12 @@ def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_2(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_3(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -12570,11 +13381,12 @@ def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_3(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_4(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -12585,11 +13397,12 @@ def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_4(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_5(save_xml):
     """
     Type atomic/NCName is restricted by facet maxLength with value 1.
@@ -12600,11 +13413,12 @@ def test_atomic_ncname_max_length_nistxml_sv_iv_atomic_ncname_max_length_1_5(sav
         instance="nistData/atomic/NCName/Schema+Instance/NISTXML-SV-IV-atomic-NCName-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet whiteSpace with value
@@ -12616,11 +13430,12 @@ def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet whiteSpace with value
@@ -12632,11 +13447,12 @@ def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet whiteSpace with value
@@ -12648,11 +13464,12 @@ def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet whiteSpace with value
@@ -12664,11 +13481,12 @@ def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet whiteSpace with value
@@ -12680,11 +13498,12 @@ def test_atomic_nmtoken_white_space_nistxml_sv_iv_atomic_nmtoken_white_space_1_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12695,11 +13514,12 @@ def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12710,11 +13530,12 @@ def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12725,11 +13546,12 @@ def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12740,11 +13562,12 @@ def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12755,11 +13578,12 @@ def test_atomic_nmtoken_enumeration_4_nistxml_sv_iv_atomic_nmtoken_enumeration_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12770,11 +13594,12 @@ def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12785,11 +13610,12 @@ def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12800,11 +13626,12 @@ def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12815,11 +13642,12 @@ def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12830,11 +13658,12 @@ def test_atomic_nmtoken_enumeration_3_nistxml_sv_iv_atomic_nmtoken_enumeration_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12845,11 +13674,12 @@ def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12860,11 +13690,12 @@ def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12875,11 +13706,12 @@ def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12890,11 +13722,12 @@ def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12905,11 +13738,12 @@ def test_atomic_nmtoken_enumeration_2_nistxml_sv_iv_atomic_nmtoken_enumeration_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12920,11 +13754,12 @@ def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12935,11 +13770,12 @@ def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12950,11 +13786,12 @@ def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12965,11 +13802,12 @@ def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12980,11 +13818,12 @@ def test_atomic_nmtoken_enumeration_1_nistxml_sv_iv_atomic_nmtoken_enumeration_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -12995,11 +13834,12 @@ def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -13010,11 +13850,12 @@ def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -13025,11 +13866,12 @@ def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -13040,11 +13882,12 @@ def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet enumeration.
@@ -13055,11 +13898,12 @@ def test_atomic_nmtoken_enumeration_nistxml_sv_iv_atomic_nmtoken_enumeration_1_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_1(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13070,11 +13914,12 @@ def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_1(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_2(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13085,11 +13930,12 @@ def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_2(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_3(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13100,11 +13946,12 @@ def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_3(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_4(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13115,11 +13962,12 @@ def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_4(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_5(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13130,11 +13978,12 @@ def test_atomic_nmtoken_pattern_4_nistxml_sv_iv_atomic_nmtoken_pattern_5_5(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_1(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{33}.
@@ -13145,11 +13994,12 @@ def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_1(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_2(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{33}.
@@ -13160,11 +14010,12 @@ def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_2(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_3(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{33}.
@@ -13175,11 +14026,12 @@ def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_3(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_4(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{33}.
@@ -13190,11 +14042,12 @@ def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_4(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_5(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{33}.
@@ -13205,11 +14058,12 @@ def test_atomic_nmtoken_pattern_3_nistxml_sv_iv_atomic_nmtoken_pattern_4_5(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_1(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{6}.
@@ -13220,11 +14074,12 @@ def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_1(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_2(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{6}.
@@ -13235,11 +14090,12 @@ def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_2(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_3(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{6}.
@@ -13250,11 +14106,12 @@ def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_3(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_4(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{6}.
@@ -13265,11 +14122,12 @@ def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_4(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_5(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{6}.
@@ -13280,11 +14138,12 @@ def test_atomic_nmtoken_pattern_2_nistxml_sv_iv_atomic_nmtoken_pattern_3_5(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_1(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13295,11 +14154,12 @@ def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_1(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_2(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13310,11 +14170,12 @@ def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_2(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_3(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13325,11 +14186,12 @@ def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_3(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_4(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13340,11 +14202,12 @@ def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_4(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_5(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{18}.
@@ -13355,11 +14218,12 @@ def test_atomic_nmtoken_pattern_1_nistxml_sv_iv_atomic_nmtoken_pattern_2_5(save_
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_1(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{40}.
@@ -13370,11 +14234,12 @@ def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_2(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{40}.
@@ -13385,11 +14250,12 @@ def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_3(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{40}.
@@ -13400,11 +14266,12 @@ def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_4(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{40}.
@@ -13415,11 +14282,12 @@ def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_5(save_xml):
     r"""
     Type atomic/NMTOKEN is restricted by facet pattern with value \c{40}.
@@ -13430,11 +14298,12 @@ def test_atomic_nmtoken_pattern_nistxml_sv_iv_atomic_nmtoken_pattern_1_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -13445,11 +14314,12 @@ def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -13460,11 +14330,12 @@ def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -13475,11 +14346,12 @@ def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -13490,11 +14362,12 @@ def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 64.
@@ -13505,11 +14378,12 @@ def test_atomic_nmtoken_length_4_nistxml_sv_iv_atomic_nmtoken_length_5_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 60.
@@ -13520,11 +14394,12 @@ def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 60.
@@ -13535,11 +14410,12 @@ def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 60.
@@ -13550,11 +14426,12 @@ def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 60.
@@ -13565,11 +14442,12 @@ def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 60.
@@ -13580,11 +14458,12 @@ def test_atomic_nmtoken_length_3_nistxml_sv_iv_atomic_nmtoken_length_4_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 57.
@@ -13595,11 +14474,12 @@ def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 57.
@@ -13610,11 +14490,12 @@ def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 57.
@@ -13625,11 +14506,12 @@ def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 57.
@@ -13640,11 +14522,12 @@ def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 57.
@@ -13655,11 +14538,12 @@ def test_atomic_nmtoken_length_2_nistxml_sv_iv_atomic_nmtoken_length_3_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 38.
@@ -13670,11 +14554,12 @@ def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_1(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 38.
@@ -13685,11 +14570,12 @@ def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_2(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 38.
@@ -13700,11 +14586,12 @@ def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_3(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 38.
@@ -13715,11 +14602,12 @@ def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_4(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 38.
@@ -13730,11 +14618,12 @@ def test_atomic_nmtoken_length_1_nistxml_sv_iv_atomic_nmtoken_length_2_5(save_xm
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -13745,11 +14634,12 @@ def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_1(save_xml)
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -13760,11 +14650,12 @@ def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_2(save_xml)
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -13775,11 +14666,12 @@ def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_3(save_xml)
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -13790,11 +14682,12 @@ def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_4(save_xml)
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet length with value 1.
@@ -13805,11 +14698,12 @@ def test_atomic_nmtoken_length_nistxml_sv_iv_atomic_nmtoken_length_1_5(save_xml)
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -13820,11 +14714,12 @@ def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -13835,11 +14730,12 @@ def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -13850,11 +14746,12 @@ def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -13865,11 +14762,12 @@ def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 64.
@@ -13880,11 +14778,12 @@ def test_atomic_nmtoken_min_length_4_nistxml_sv_iv_atomic_nmtoken_min_length_5_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 33.
@@ -13895,11 +14794,12 @@ def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 33.
@@ -13910,11 +14810,12 @@ def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 33.
@@ -13925,11 +14826,12 @@ def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 33.
@@ -13940,11 +14842,12 @@ def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 33.
@@ -13955,11 +14858,12 @@ def test_atomic_nmtoken_min_length_3_nistxml_sv_iv_atomic_nmtoken_min_length_4_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 35.
@@ -13970,11 +14874,12 @@ def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 35.
@@ -13985,11 +14890,12 @@ def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 35.
@@ -14000,11 +14906,12 @@ def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 35.
@@ -14015,11 +14922,12 @@ def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 35.
@@ -14030,11 +14938,12 @@ def test_atomic_nmtoken_min_length_2_nistxml_sv_iv_atomic_nmtoken_min_length_3_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 45.
@@ -14045,11 +14954,12 @@ def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 45.
@@ -14060,11 +14970,12 @@ def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 45.
@@ -14075,11 +14986,12 @@ def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 45.
@@ -14090,11 +15002,12 @@ def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 45.
@@ -14105,11 +15018,12 @@ def test_atomic_nmtoken_min_length_1_nistxml_sv_iv_atomic_nmtoken_min_length_2_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 1.
@@ -14120,11 +15034,12 @@ def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_1(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 1.
@@ -14135,11 +15050,12 @@ def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_2(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 1.
@@ -14150,11 +15066,12 @@ def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_3(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 1.
@@ -14165,11 +15082,12 @@ def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_4(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet minLength with value 1.
@@ -14180,11 +15098,12 @@ def test_atomic_nmtoken_min_length_nistxml_sv_iv_atomic_nmtoken_min_length_1_5(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -14195,11 +15114,12 @@ def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -14210,11 +15130,12 @@ def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -14225,11 +15146,12 @@ def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -14240,11 +15162,12 @@ def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 64.
@@ -14255,11 +15178,12 @@ def test_atomic_nmtoken_max_length_4_nistxml_sv_iv_atomic_nmtoken_max_length_5_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 54.
@@ -14270,11 +15194,12 @@ def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 54.
@@ -14285,11 +15210,12 @@ def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 54.
@@ -14300,11 +15226,12 @@ def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 54.
@@ -14315,11 +15242,12 @@ def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 54.
@@ -14330,11 +15258,12 @@ def test_atomic_nmtoken_max_length_3_nistxml_sv_iv_atomic_nmtoken_max_length_4_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 42.
@@ -14345,11 +15274,12 @@ def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 42.
@@ -14360,11 +15290,12 @@ def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 42.
@@ -14375,11 +15306,12 @@ def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 42.
@@ -14390,11 +15322,12 @@ def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 42.
@@ -14405,11 +15338,12 @@ def test_atomic_nmtoken_max_length_2_nistxml_sv_iv_atomic_nmtoken_max_length_3_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 41.
@@ -14420,11 +15354,12 @@ def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_1
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 41.
@@ -14435,11 +15370,12 @@ def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_2
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 41.
@@ -14450,11 +15386,12 @@ def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_3
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 41.
@@ -14465,11 +15402,12 @@ def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_4
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 41.
@@ -14480,11 +15418,12 @@ def test_atomic_nmtoken_max_length_1_nistxml_sv_iv_atomic_nmtoken_max_length_2_5
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_1(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -14495,11 +15434,12 @@ def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_1(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_2(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -14510,11 +15450,12 @@ def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_2(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_3(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -14525,11 +15466,12 @@ def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_3(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_4(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -14540,11 +15482,12 @@ def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_4(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_5(save_xml):
     """
     Type atomic/NMTOKEN is restricted by facet maxLength with value 1.
@@ -14555,11 +15498,12 @@ def test_atomic_nmtoken_max_length_nistxml_sv_iv_atomic_nmtoken_max_length_1_5(s
         instance="nistData/atomic/NMTOKEN/Schema+Instance/NISTXML-SV-IV-atomic-NMTOKEN-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet whiteSpace with value
@@ -14571,11 +15515,12 @@ def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet whiteSpace with value
@@ -14587,11 +15532,12 @@ def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet whiteSpace with value
@@ -14603,11 +15549,12 @@ def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet whiteSpace with value
@@ -14619,11 +15566,12 @@ def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet whiteSpace with value
@@ -14635,11 +15583,12 @@ def test_atomic_name_white_space_nistxml_sv_iv_atomic_name_white_space_1_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14650,11 +15599,12 @@ def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_1(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14665,11 +15615,12 @@ def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_2(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14680,11 +15631,12 @@ def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_3(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14695,11 +15647,12 @@ def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_4(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14710,11 +15663,12 @@ def test_atomic_name_enumeration_4_nistxml_sv_iv_atomic_name_enumeration_5_5(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14725,11 +15679,12 @@ def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_1(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14740,11 +15695,12 @@ def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_2(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14755,11 +15711,12 @@ def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_3(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14770,11 +15727,12 @@ def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_4(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14785,11 +15743,12 @@ def test_atomic_name_enumeration_3_nistxml_sv_iv_atomic_name_enumeration_4_5(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14800,11 +15759,12 @@ def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_1(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14815,11 +15775,12 @@ def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_2(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14830,11 +15791,12 @@ def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_3(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14845,11 +15807,12 @@ def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_4(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14860,11 +15823,12 @@ def test_atomic_name_enumeration_2_nistxml_sv_iv_atomic_name_enumeration_3_5(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14875,11 +15839,12 @@ def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_1(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14890,11 +15855,12 @@ def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_2(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14905,11 +15871,12 @@ def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_3(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14920,11 +15887,12 @@ def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_4(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14935,11 +15903,12 @@ def test_atomic_name_enumeration_1_nistxml_sv_iv_atomic_name_enumeration_2_5(sav
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14950,11 +15919,12 @@ def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14965,11 +15935,12 @@ def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14980,11 +15951,12 @@ def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -14995,11 +15967,12 @@ def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet enumeration.
@@ -15010,11 +15983,12 @@ def test_atomic_name_enumeration_nistxml_sv_iv_atomic_name_enumeration_1_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_1(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{31}.
@@ -15025,11 +15999,12 @@ def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_2(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{31}.
@@ -15040,11 +16015,12 @@ def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_3(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{31}.
@@ -15055,11 +16031,12 @@ def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_4(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{31}.
@@ -15070,11 +16047,12 @@ def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_5(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{31}.
@@ -15085,11 +16063,12 @@ def test_atomic_name_pattern_4_nistxml_sv_iv_atomic_name_pattern_5_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_1(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{14}.
@@ -15100,11 +16079,12 @@ def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_2(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{14}.
@@ -15115,11 +16095,12 @@ def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_3(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{14}.
@@ -15130,11 +16111,12 @@ def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_4(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{14}.
@@ -15145,11 +16127,12 @@ def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_5(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{14}.
@@ -15160,11 +16143,12 @@ def test_atomic_name_pattern_3_nistxml_sv_iv_atomic_name_pattern_4_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_1(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{32}.
@@ -15175,11 +16159,12 @@ def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_2(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{32}.
@@ -15190,11 +16175,12 @@ def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_3(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{32}.
@@ -15205,11 +16191,12 @@ def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_4(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{32}.
@@ -15220,11 +16207,12 @@ def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_5(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{32}.
@@ -15235,11 +16223,12 @@ def test_atomic_name_pattern_2_nistxml_sv_iv_atomic_name_pattern_3_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_1(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{52}.
@@ -15250,11 +16239,12 @@ def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_2(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{52}.
@@ -15265,11 +16255,12 @@ def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_3(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{52}.
@@ -15280,11 +16271,12 @@ def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_4(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{52}.
@@ -15295,11 +16287,12 @@ def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_5(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{52}.
@@ -15310,11 +16303,12 @@ def test_atomic_name_pattern_1_nistxml_sv_iv_atomic_name_pattern_2_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_1(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{45}.
@@ -15325,11 +16319,12 @@ def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_2(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{45}.
@@ -15340,11 +16335,12 @@ def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_3(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{45}.
@@ -15355,11 +16351,12 @@ def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_4(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{45}.
@@ -15370,11 +16367,12 @@ def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_5(save_xml):
     r"""
     Type atomic/Name is restricted by facet pattern with value \i\c{45}.
@@ -15385,11 +16383,12 @@ def test_atomic_name_pattern_nistxml_sv_iv_atomic_name_pattern_1_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -15400,11 +16399,12 @@ def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -15415,6 +16415,6 @@ def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_15000.py
+++ b/tests/test_nist_meta_15000.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
@@ -2641,6 +2643,7 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_1(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_2(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2671,6 +2674,7 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_3(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_4(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2701,6 +2705,7 @@ def test_atomic_qname_enumeration_4_nistxml_sv_iv_atomic_qname_enumeration_5_5(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_1(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2761,6 +2766,7 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_4(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_5(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2776,6 +2782,7 @@ def test_atomic_qname_enumeration_3_nistxml_sv_iv_atomic_qname_enumeration_4_5(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_1(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2806,6 +2813,7 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_2(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_3(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2836,6 +2844,7 @@ def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_4(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_2_nistxml_sv_iv_atomic_qname_enumeration_3_5(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2911,6 +2920,7 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_4(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_5(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2926,6 +2936,7 @@ def test_atomic_qname_enumeration_1_nistxml_sv_iv_atomic_qname_enumeration_2_5(s
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_1(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2941,6 +2952,7 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_1(sav
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_2(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2956,6 +2968,7 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_2(sav
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_3(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.
@@ -2971,6 +2984,7 @@ def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_3(sav
     )
 
 
+@pytest.mark.xfail
 def test_atomic_qname_enumeration_nistxml_sv_iv_atomic_qname_enumeration_1_4(save_xml):
     """
     Type atomic/QName is restricted by facet enumeration.

--- a/tests/test_nist_meta_16000.py
+++ b/tests/test_nist_meta_16000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -11,11 +14,12 @@ def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -26,11 +30,12 @@ def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 64.
@@ -41,11 +46,12 @@ def test_atomic_name_length_4_nistxml_sv_iv_atomic_name_length_5_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 6.
@@ -56,11 +62,12 @@ def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 6.
@@ -71,11 +78,12 @@ def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 6.
@@ -86,11 +94,12 @@ def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 6.
@@ -101,11 +110,12 @@ def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 6.
@@ -116,11 +126,12 @@ def test_atomic_name_length_3_nistxml_sv_iv_atomic_name_length_4_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 60.
@@ -131,11 +142,12 @@ def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 60.
@@ -146,11 +158,12 @@ def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 60.
@@ -161,11 +174,12 @@ def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 60.
@@ -176,11 +190,12 @@ def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 60.
@@ -191,11 +206,12 @@ def test_atomic_name_length_2_nistxml_sv_iv_atomic_name_length_3_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 8.
@@ -206,11 +222,12 @@ def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 8.
@@ -221,11 +238,12 @@ def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 8.
@@ -236,11 +254,12 @@ def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 8.
@@ -251,11 +270,12 @@ def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 8.
@@ -266,11 +286,12 @@ def test_atomic_name_length_1_nistxml_sv_iv_atomic_name_length_2_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -281,11 +302,12 @@ def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_1(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -296,11 +318,12 @@ def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_2(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -311,11 +334,12 @@ def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_3(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -326,11 +350,12 @@ def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_4(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet length with value 1.
@@ -341,11 +366,12 @@ def test_atomic_name_length_nistxml_sv_iv_atomic_name_length_1_5(save_xml):
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -356,11 +382,12 @@ def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -371,11 +398,12 @@ def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -386,11 +414,12 @@ def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -401,11 +430,12 @@ def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 64.
@@ -416,11 +446,12 @@ def test_atomic_name_min_length_4_nistxml_sv_iv_atomic_name_min_length_5_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 54.
@@ -431,11 +462,12 @@ def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 54.
@@ -446,11 +478,12 @@ def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 54.
@@ -461,11 +494,12 @@ def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 54.
@@ -476,11 +510,12 @@ def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 54.
@@ -491,11 +526,12 @@ def test_atomic_name_min_length_3_nistxml_sv_iv_atomic_name_min_length_4_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 28.
@@ -506,11 +542,12 @@ def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 28.
@@ -521,11 +558,12 @@ def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 28.
@@ -536,11 +574,12 @@ def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 28.
@@ -551,11 +590,12 @@ def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 28.
@@ -566,11 +606,12 @@ def test_atomic_name_min_length_2_nistxml_sv_iv_atomic_name_min_length_3_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 63.
@@ -581,11 +622,12 @@ def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 63.
@@ -596,11 +638,12 @@ def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 63.
@@ -611,11 +654,12 @@ def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 63.
@@ -626,11 +670,12 @@ def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 63.
@@ -641,11 +686,12 @@ def test_atomic_name_min_length_1_nistxml_sv_iv_atomic_name_min_length_2_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 1.
@@ -656,11 +702,12 @@ def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_1(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 1.
@@ -671,11 +718,12 @@ def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_2(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 1.
@@ -686,11 +734,12 @@ def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_3(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 1.
@@ -701,11 +750,12 @@ def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_4(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet minLength with value 1.
@@ -716,11 +766,12 @@ def test_atomic_name_min_length_nistxml_sv_iv_atomic_name_min_length_1_5(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -731,11 +782,12 @@ def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -746,11 +798,12 @@ def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -761,11 +814,12 @@ def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -776,11 +830,12 @@ def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 64.
@@ -791,11 +846,12 @@ def test_atomic_name_max_length_4_nistxml_sv_iv_atomic_name_max_length_5_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 24.
@@ -806,11 +862,12 @@ def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 24.
@@ -821,11 +878,12 @@ def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 24.
@@ -836,11 +894,12 @@ def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 24.
@@ -851,11 +910,12 @@ def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 24.
@@ -866,11 +926,12 @@ def test_atomic_name_max_length_3_nistxml_sv_iv_atomic_name_max_length_4_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 11.
@@ -881,11 +942,12 @@ def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 11.
@@ -896,11 +958,12 @@ def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 11.
@@ -911,11 +974,12 @@ def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 11.
@@ -926,11 +990,12 @@ def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 11.
@@ -941,11 +1006,12 @@ def test_atomic_name_max_length_2_nistxml_sv_iv_atomic_name_max_length_3_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 2.
@@ -956,11 +1022,12 @@ def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_1(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 2.
@@ -971,11 +1038,12 @@ def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_2(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 2.
@@ -986,11 +1054,12 @@ def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_3(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 2.
@@ -1001,11 +1070,12 @@ def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_4(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 2.
@@ -1016,11 +1086,12 @@ def test_atomic_name_max_length_1_nistxml_sv_iv_atomic_name_max_length_2_5(save_
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_1(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -1031,11 +1102,12 @@ def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_1(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_2(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -1046,11 +1118,12 @@ def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_2(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_3(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -1061,11 +1134,12 @@ def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_3(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_4(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -1076,11 +1150,12 @@ def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_4(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_5(save_xml):
     """
     Type atomic/Name is restricted by facet maxLength with value 1.
@@ -1091,11 +1166,12 @@ def test_atomic_name_max_length_nistxml_sv_iv_atomic_name_max_length_1_5(save_xm
         instance="nistData/atomic/Name/Schema+Instance/NISTXML-SV-IV-atomic-Name-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_1(save_xml):
     """
     Type atomic/token is restricted by facet whiteSpace with value
@@ -1107,11 +1183,12 @@ def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_2(save_xml):
     """
     Type atomic/token is restricted by facet whiteSpace with value
@@ -1123,11 +1200,12 @@ def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_3(save_xml):
     """
     Type atomic/token is restricted by facet whiteSpace with value
@@ -1139,11 +1217,12 @@ def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_4(save_xml):
     """
     Type atomic/token is restricted by facet whiteSpace with value
@@ -1155,11 +1234,12 @@ def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_5(save_xml):
     """
     Type atomic/token is restricted by facet whiteSpace with value
@@ -1171,11 +1251,12 @@ def test_atomic_token_white_space_nistxml_sv_iv_atomic_token_white_space_1_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_1(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1186,11 +1267,12 @@ def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_1(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_2(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1201,11 +1283,12 @@ def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_2(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_3(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1216,11 +1299,12 @@ def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_3(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_4(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1231,11 +1315,12 @@ def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_4(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_5(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1246,11 +1331,12 @@ def test_atomic_token_enumeration_4_nistxml_sv_iv_atomic_token_enumeration_5_5(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_1(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1261,11 +1347,12 @@ def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_1(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_2(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1276,11 +1363,12 @@ def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_2(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_3(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1291,11 +1379,12 @@ def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_3(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_4(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1306,11 +1395,12 @@ def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_4(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_5(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1321,11 +1411,12 @@ def test_atomic_token_enumeration_3_nistxml_sv_iv_atomic_token_enumeration_4_5(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_1(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1336,11 +1427,12 @@ def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_1(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_2(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1351,11 +1443,12 @@ def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_2(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_3(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1366,11 +1459,12 @@ def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_3(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_4(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1381,11 +1475,12 @@ def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_4(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_5(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1396,11 +1491,12 @@ def test_atomic_token_enumeration_2_nistxml_sv_iv_atomic_token_enumeration_3_5(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_1(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1411,11 +1507,12 @@ def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_1(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_2(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1426,11 +1523,12 @@ def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_2(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_3(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1441,11 +1539,12 @@ def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_3(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_4(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1456,11 +1555,12 @@ def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_4(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_5(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1471,11 +1571,12 @@ def test_atomic_token_enumeration_1_nistxml_sv_iv_atomic_token_enumeration_2_5(s
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_1(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1486,11 +1587,12 @@ def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_2(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1501,11 +1603,12 @@ def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_3(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1516,11 +1619,12 @@ def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_4(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1531,11 +1635,12 @@ def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_5(save_xml):
     """
     Type atomic/token is restricted by facet enumeration.
@@ -1546,11 +1651,12 @@ def test_atomic_token_enumeration_nistxml_sv_iv_atomic_token_enumeration_1_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_1(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1563,11 +1669,12 @@ def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_1(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_2(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1580,11 +1687,12 @@ def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_2(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_3(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1597,11 +1705,12 @@ def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_3(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_4(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1614,11 +1723,12 @@ def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_4(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_5(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1631,11 +1741,12 @@ def test_atomic_token_pattern_4_nistxml_sv_iv_atomic_token_pattern_5_5(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_1(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1648,11 +1759,12 @@ def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_1(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_2(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1665,11 +1777,12 @@ def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_2(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_3(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1682,11 +1795,12 @@ def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_3(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_4(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1699,11 +1813,12 @@ def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_4(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_5(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1716,11 +1831,12 @@ def test_atomic_token_pattern_3_nistxml_sv_iv_atomic_token_pattern_4_5(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_1(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1733,11 +1849,12 @@ def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_1(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_2(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1750,11 +1867,12 @@ def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_2(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_3(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1767,11 +1885,12 @@ def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_3(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_4(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1784,11 +1903,12 @@ def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_4(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_5(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1801,11 +1921,12 @@ def test_atomic_token_pattern_2_nistxml_sv_iv_atomic_token_pattern_3_5(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_1(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1818,11 +1939,12 @@ def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_1(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_2(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1835,11 +1957,12 @@ def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_2(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_3(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1852,11 +1975,12 @@ def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_3(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_4(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1869,11 +1993,12 @@ def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_4(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_5(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1886,11 +2011,12 @@ def test_atomic_token_pattern_1_nistxml_sv_iv_atomic_token_pattern_2_5(save_xml)
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_1(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1903,11 +2029,12 @@ def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_2(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1920,11 +2047,12 @@ def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_3(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1937,11 +2065,12 @@ def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_4(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1954,11 +2083,12 @@ def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_5(save_xml):
     r"""
     Type atomic/token is restricted by facet pattern with value \d{1,5}\s(
@@ -1971,11 +2101,12 @@ def test_atomic_token_pattern_nistxml_sv_iv_atomic_token_pattern_1_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -1986,11 +2117,12 @@ def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -2001,11 +2133,12 @@ def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -2016,11 +2149,12 @@ def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -2031,11 +2165,12 @@ def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 1000.
@@ -2046,11 +2181,12 @@ def test_atomic_token_length_4_nistxml_sv_iv_atomic_token_length_5_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 979.
@@ -2061,11 +2197,12 @@ def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 979.
@@ -2076,11 +2213,12 @@ def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 979.
@@ -2091,11 +2229,12 @@ def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 979.
@@ -2106,11 +2245,12 @@ def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 979.
@@ -2121,11 +2261,12 @@ def test_atomic_token_length_3_nistxml_sv_iv_atomic_token_length_4_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 662.
@@ -2136,11 +2277,12 @@ def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 662.
@@ -2151,11 +2293,12 @@ def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 662.
@@ -2166,11 +2309,12 @@ def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 662.
@@ -2181,11 +2325,12 @@ def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 662.
@@ -2196,11 +2341,12 @@ def test_atomic_token_length_2_nistxml_sv_iv_atomic_token_length_3_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 295.
@@ -2211,11 +2357,12 @@ def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 295.
@@ -2226,11 +2373,12 @@ def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 295.
@@ -2241,11 +2389,12 @@ def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 295.
@@ -2256,11 +2405,12 @@ def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 295.
@@ -2271,11 +2421,12 @@ def test_atomic_token_length_1_nistxml_sv_iv_atomic_token_length_2_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_1(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -2286,11 +2437,12 @@ def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_1(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_2(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -2301,11 +2453,12 @@ def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_2(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_3(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -2316,11 +2469,12 @@ def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_3(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_4(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -2331,11 +2485,12 @@ def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_4(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_5(save_xml):
     """
     Type atomic/token is restricted by facet length with value 0.
@@ -2346,11 +2501,12 @@ def test_atomic_token_length_nistxml_sv_iv_atomic_token_length_1_5(save_xml):
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -2361,11 +2517,12 @@ def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -2376,11 +2533,12 @@ def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -2391,11 +2549,12 @@ def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -2406,11 +2565,12 @@ def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 1000.
@@ -2421,11 +2581,12 @@ def test_atomic_token_min_length_4_nistxml_sv_iv_atomic_token_min_length_5_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 202.
@@ -2436,11 +2597,12 @@ def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 202.
@@ -2451,11 +2613,12 @@ def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 202.
@@ -2466,11 +2629,12 @@ def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 202.
@@ -2481,11 +2645,12 @@ def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 202.
@@ -2496,11 +2661,12 @@ def test_atomic_token_min_length_3_nistxml_sv_iv_atomic_token_min_length_4_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 39.
@@ -2511,11 +2677,12 @@ def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 39.
@@ -2526,11 +2693,12 @@ def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 39.
@@ -2541,11 +2709,12 @@ def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 39.
@@ -2556,11 +2725,12 @@ def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 39.
@@ -2571,11 +2741,12 @@ def test_atomic_token_min_length_2_nistxml_sv_iv_atomic_token_min_length_3_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 305.
@@ -2586,11 +2757,12 @@ def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 305.
@@ -2601,11 +2773,12 @@ def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 305.
@@ -2616,11 +2789,12 @@ def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 305.
@@ -2631,11 +2805,12 @@ def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 305.
@@ -2646,11 +2821,12 @@ def test_atomic_token_min_length_1_nistxml_sv_iv_atomic_token_min_length_2_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_1(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 0.
@@ -2661,11 +2837,12 @@ def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_1(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_2(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 0.
@@ -2676,11 +2853,12 @@ def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_2(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_3(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 0.
@@ -2691,11 +2869,12 @@ def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_3(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_4(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 0.
@@ -2706,11 +2885,12 @@ def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_4(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_5(save_xml):
     """
     Type atomic/token is restricted by facet minLength with value 0.
@@ -2721,11 +2901,12 @@ def test_atomic_token_min_length_nistxml_sv_iv_atomic_token_min_length_1_5(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -2736,11 +2917,12 @@ def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -2751,11 +2933,12 @@ def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -2766,11 +2949,12 @@ def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -2781,11 +2965,12 @@ def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 1000.
@@ -2796,11 +2981,12 @@ def test_atomic_token_max_length_4_nistxml_sv_iv_atomic_token_max_length_5_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 670.
@@ -2811,11 +2997,12 @@ def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 670.
@@ -2826,11 +3013,12 @@ def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 670.
@@ -2841,11 +3029,12 @@ def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 670.
@@ -2856,11 +3045,12 @@ def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 670.
@@ -2871,11 +3061,12 @@ def test_atomic_token_max_length_3_nistxml_sv_iv_atomic_token_max_length_4_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 834.
@@ -2886,11 +3077,12 @@ def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 834.
@@ -2901,11 +3093,12 @@ def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 834.
@@ -2916,11 +3109,12 @@ def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 834.
@@ -2931,11 +3125,12 @@ def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 834.
@@ -2946,11 +3141,12 @@ def test_atomic_token_max_length_2_nistxml_sv_iv_atomic_token_max_length_3_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 919.
@@ -2961,11 +3157,12 @@ def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_1(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 919.
@@ -2976,11 +3173,12 @@ def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_2(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 919.
@@ -2991,11 +3189,12 @@ def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_3(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 919.
@@ -3006,11 +3205,12 @@ def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_4(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 919.
@@ -3021,11 +3221,12 @@ def test_atomic_token_max_length_1_nistxml_sv_iv_atomic_token_max_length_2_5(sav
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_1(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -3036,11 +3237,12 @@ def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_1(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_2(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -3051,11 +3253,12 @@ def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_2(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_3(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -3066,11 +3269,12 @@ def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_3(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_4(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -3081,11 +3285,12 @@ def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_4(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_5(save_xml):
     """
     Type atomic/token is restricted by facet maxLength with value 0.
@@ -3096,11 +3301,12 @@ def test_atomic_token_max_length_nistxml_sv_iv_atomic_token_max_length_1_5(save_
         instance="nistData/atomic/token/Schema+Instance/NISTXML-SV-IV-atomic-token-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_string_white_space_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3112,11 +3318,12 @@ def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_string_white_space_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3128,11 +3335,12 @@ def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_string_white_space_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3144,11 +3352,12 @@ def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_string_white_space_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3160,11 +3369,12 @@ def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_string_white_space_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3176,11 +3386,12 @@ def test_atomic_normalized_string_white_space_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_string_white_space_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3192,11 +3403,12 @@ def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_string_white_space_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3208,11 +3420,12 @@ def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_string_white_space_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3224,11 +3437,12 @@ def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_string_white_space_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3240,11 +3454,12 @@ def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_string_white_space_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet whiteSpace with
@@ -3256,11 +3471,12 @@ def test_atomic_normalized_string_white_space_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_string_enumeration_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3271,11 +3487,12 @@ def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_string_enumeration_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3286,11 +3503,12 @@ def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_string_enumeration_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3301,11 +3519,12 @@ def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_string_enumeration_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3316,11 +3535,12 @@ def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_string_enumeration_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3331,11 +3551,12 @@ def test_atomic_normalized_string_enumeration_4_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_string_enumeration_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3346,11 +3567,12 @@ def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_string_enumeration_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3361,11 +3583,12 @@ def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_string_enumeration_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3376,11 +3599,12 @@ def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_string_enumeration_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3391,11 +3615,12 @@ def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_string_enumeration_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3406,11 +3631,12 @@ def test_atomic_normalized_string_enumeration_3_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_string_enumeration_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3421,11 +3647,12 @@ def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_string_enumeration_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3436,11 +3663,12 @@ def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_string_enumeration_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3451,11 +3679,12 @@ def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_string_enumeration_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3466,11 +3695,12 @@ def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_string_enumeration_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3481,11 +3711,12 @@ def test_atomic_normalized_string_enumeration_2_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_string_enumeration_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3496,11 +3727,12 @@ def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_string_enumeration_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3511,11 +3743,12 @@ def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_string_enumeration_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3526,11 +3759,12 @@ def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_string_enumeration_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3541,11 +3775,12 @@ def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_string_enumeration_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3556,11 +3791,12 @@ def test_atomic_normalized_string_enumeration_1_nistxml_sv_iv_atomic_normalized_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_string_enumeration_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3571,11 +3807,12 @@ def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_string_enumeration_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3586,11 +3823,12 @@ def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_string_enumeration_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3601,11 +3839,12 @@ def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_string_enumeration_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3616,11 +3855,12 @@ def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_string_enumeration_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet enumeration.
@@ -3631,11 +3871,12 @@ def test_atomic_normalized_string_enumeration_nistxml_sv_iv_atomic_normalized_st
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_string_pattern_5_1(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3648,11 +3889,12 @@ def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_string_pattern_5_2(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3665,11 +3907,12 @@ def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_string_pattern_5_3(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3682,11 +3925,12 @@ def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_string_pattern_5_4(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3699,11 +3943,12 @@ def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_string_pattern_5_5(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3716,11 +3961,12 @@ def test_atomic_normalized_string_pattern_4_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_string_pattern_4_1(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3733,11 +3979,12 @@ def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_string_pattern_4_2(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3750,11 +3997,12 @@ def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_string_pattern_4_3(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3767,11 +4015,12 @@ def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_string_pattern_4_4(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3784,11 +4033,12 @@ def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_string_pattern_4_5(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3801,11 +4051,12 @@ def test_atomic_normalized_string_pattern_3_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_string_pattern_3_1(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3818,11 +4069,12 @@ def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_string_pattern_3_2(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3835,11 +4087,12 @@ def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_string_pattern_3_3(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3852,11 +4105,12 @@ def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_string_pattern_3_4(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3869,11 +4123,12 @@ def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_string_pattern_3_5(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3886,11 +4141,12 @@ def test_atomic_normalized_string_pattern_2_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_string_pattern_2_1(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3903,11 +4159,12 @@ def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_string_pattern_2_2(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3920,11 +4177,12 @@ def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_string_pattern_2_3(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3937,11 +4195,12 @@ def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_string_pattern_2_4(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3954,11 +4213,12 @@ def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_string_pattern_2_5(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3971,11 +4231,12 @@ def test_atomic_normalized_string_pattern_1_nistxml_sv_iv_atomic_normalized_stri
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string_pattern_1_1(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -3988,11 +4249,12 @@ def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string_pattern_1_2(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -4005,11 +4267,12 @@ def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string_pattern_1_3(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -4022,11 +4285,12 @@ def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string_pattern_1_4(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -4039,11 +4303,12 @@ def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string_pattern_1_5(save_xml):
     r"""
     Type atomic/normalizedString is restricted by facet pattern with value
@@ -4056,11 +4321,12 @@ def test_atomic_normalized_string_pattern_nistxml_sv_iv_atomic_normalized_string
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_string_length_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4072,11 +4338,12 @@ def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_string_length_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4088,11 +4355,12 @@ def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_string_length_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4104,11 +4372,12 @@ def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_string_length_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4120,11 +4389,12 @@ def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_string_length_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4136,11 +4406,12 @@ def test_atomic_normalized_string_length_4_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_string_length_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4152,11 +4423,12 @@ def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_string_length_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4168,11 +4440,12 @@ def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_string_length_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4184,11 +4457,12 @@ def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_string_length_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4200,11 +4474,12 @@ def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_string_length_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4216,11 +4491,12 @@ def test_atomic_normalized_string_length_3_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_string_length_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4232,11 +4508,12 @@ def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_string_length_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4248,11 +4525,12 @@ def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_string_length_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4264,11 +4542,12 @@ def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_string_length_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4280,11 +4559,12 @@ def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_string_length_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4296,11 +4576,12 @@ def test_atomic_normalized_string_length_2_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_string_length_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4312,11 +4593,12 @@ def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_string_length_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4328,11 +4610,12 @@ def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_string_length_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4344,11 +4627,12 @@ def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_string_length_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4360,11 +4644,12 @@ def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_string_length_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4376,11 +4661,12 @@ def test_atomic_normalized_string_length_1_nistxml_sv_iv_atomic_normalized_strin
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_length_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4392,11 +4678,12 @@ def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_length_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4408,11 +4695,12 @@ def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_length_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4424,11 +4712,12 @@ def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_length_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4440,11 +4729,12 @@ def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_length_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet length with value
@@ -4456,11 +4746,12 @@ def test_atomic_normalized_string_length_nistxml_sv_iv_atomic_normalized_string_
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_string_min_length_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4472,11 +4763,12 @@ def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_string_min_length_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4488,11 +4780,12 @@ def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_string_min_length_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4504,11 +4797,12 @@ def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_string_min_length_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4520,11 +4814,12 @@ def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_string_min_length_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4536,11 +4831,12 @@ def test_atomic_normalized_string_min_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_string_min_length_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4552,11 +4848,12 @@ def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_string_min_length_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4568,11 +4865,12 @@ def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_string_min_length_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4584,11 +4882,12 @@ def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_string_min_length_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4600,11 +4899,12 @@ def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_string_min_length_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4616,11 +4916,12 @@ def test_atomic_normalized_string_min_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_string_min_length_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4632,11 +4933,12 @@ def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_string_min_length_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4648,11 +4950,12 @@ def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_string_min_length_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4664,11 +4967,12 @@ def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_string_min_length_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4680,11 +4984,12 @@ def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_string_min_length_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4696,11 +5001,12 @@ def test_atomic_normalized_string_min_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_string_min_length_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4712,11 +5018,12 @@ def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_string_min_length_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4728,11 +5035,12 @@ def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_string_min_length_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4744,11 +5052,12 @@ def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_string_min_length_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4760,11 +5069,12 @@ def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_string_min_length_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4776,11 +5086,12 @@ def test_atomic_normalized_string_min_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_string_min_length_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4792,11 +5103,12 @@ def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_string_min_length_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4808,11 +5120,12 @@ def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_string_min_length_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4824,11 +5137,12 @@ def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_string_min_length_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4840,11 +5154,12 @@ def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_string_min_length_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet minLength with
@@ -4856,11 +5171,12 @@ def test_atomic_normalized_string_min_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_string_max_length_5_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4872,11 +5188,12 @@ def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_string_max_length_5_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4888,11 +5205,12 @@ def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_string_max_length_5_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4904,11 +5222,12 @@ def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_string_max_length_5_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4920,11 +5239,12 @@ def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_string_max_length_5_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4936,11 +5256,12 @@ def test_atomic_normalized_string_max_length_4_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_string_max_length_4_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4952,11 +5273,12 @@ def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_string_max_length_4_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4968,11 +5290,12 @@ def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_string_max_length_4_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -4984,11 +5307,12 @@ def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_string_max_length_4_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5000,11 +5324,12 @@ def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_string_max_length_4_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5016,11 +5341,12 @@ def test_atomic_normalized_string_max_length_3_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_string_max_length_3_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5032,11 +5358,12 @@ def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_string_max_length_3_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5048,11 +5375,12 @@ def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_string_max_length_3_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5064,11 +5392,12 @@ def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_string_max_length_3_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5080,11 +5409,12 @@ def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_string_max_length_3_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5096,11 +5426,12 @@ def test_atomic_normalized_string_max_length_2_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_string_max_length_2_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5112,11 +5443,12 @@ def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_string_max_length_2_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5128,11 +5460,12 @@ def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_string_max_length_2_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5144,11 +5477,12 @@ def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_string_max_length_2_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5160,11 +5494,12 @@ def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_string_max_length_2_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5176,11 +5511,12 @@ def test_atomic_normalized_string_max_length_1_nistxml_sv_iv_atomic_normalized_s
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_string_max_length_1_1(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5192,11 +5528,12 @@ def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_string_max_length_1_2(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5208,11 +5545,12 @@ def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_string_max_length_1_3(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5224,11 +5562,12 @@ def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_string_max_length_1_4(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5240,11 +5579,12 @@ def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_string_max_length_1_5(save_xml):
     """
     Type atomic/normalizedString is restricted by facet maxLength with
@@ -5256,11 +5596,12 @@ def test_atomic_normalized_string_max_length_nistxml_sv_iv_atomic_normalized_str
         instance="nistData/atomic/normalizedString/Schema+Instance/NISTXML-SV-IV-atomic-normalizedString-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_1(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5272,11 +5613,12 @@ def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_1
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_2(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5288,11 +5630,12 @@ def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_2
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_3(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5304,11 +5647,12 @@ def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_3
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_4(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5320,11 +5664,12 @@ def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_4
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_5(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5336,11 +5681,12 @@ def test_atomic_string_white_space_2_nistxml_sv_iv_atomic_string_white_space_3_5
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_1(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5352,11 +5698,12 @@ def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_1
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_2(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5368,11 +5715,12 @@ def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_2
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_3(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5384,11 +5732,12 @@ def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_3
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_4(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5400,11 +5749,12 @@ def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_4
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_5(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5416,11 +5766,12 @@ def test_atomic_string_white_space_1_nistxml_sv_iv_atomic_string_white_space_2_5
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_1(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5432,11 +5783,12 @@ def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_2(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5448,11 +5800,12 @@ def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_3(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5464,11 +5817,12 @@ def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_4(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5480,11 +5834,12 @@ def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_5(save_xml):
     """
     Type atomic/string is restricted by facet whiteSpace with value
@@ -5496,11 +5851,12 @@ def test_atomic_string_white_space_nistxml_sv_iv_atomic_string_white_space_1_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_1(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5511,11 +5867,12 @@ def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_1
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_2(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5526,11 +5883,12 @@ def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_2
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_3(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5541,11 +5899,12 @@ def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_3
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_4(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5556,11 +5915,12 @@ def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_4
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_5(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5571,11 +5931,12 @@ def test_atomic_string_enumeration_4_nistxml_sv_iv_atomic_string_enumeration_5_5
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_1(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5586,11 +5947,12 @@ def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_1
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_2(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5601,11 +5963,12 @@ def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_2
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_3(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5616,11 +5979,12 @@ def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_3
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_4(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5631,11 +5995,12 @@ def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_4
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_5(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5646,11 +6011,12 @@ def test_atomic_string_enumeration_3_nistxml_sv_iv_atomic_string_enumeration_4_5
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_1(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5661,11 +6027,12 @@ def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_1
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_2(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5676,11 +6043,12 @@ def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_2
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_3(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5691,11 +6059,12 @@ def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_3
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_4(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5706,11 +6075,12 @@ def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_4
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_5(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5721,11 +6091,12 @@ def test_atomic_string_enumeration_2_nistxml_sv_iv_atomic_string_enumeration_3_5
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_1(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5736,11 +6107,12 @@ def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_1
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_2(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5751,11 +6123,12 @@ def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_2
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_3(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5766,11 +6139,12 @@ def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_3
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_4(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5781,11 +6155,12 @@ def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_4
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_5(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5796,11 +6171,12 @@ def test_atomic_string_enumeration_1_nistxml_sv_iv_atomic_string_enumeration_2_5
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_1(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5811,11 +6187,12 @@ def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_2(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5826,11 +6203,12 @@ def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_3(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5841,11 +6219,12 @@ def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_4(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5856,11 +6235,12 @@ def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_5(save_xml):
     """
     Type atomic/string is restricted by facet enumeration.
@@ -5871,11 +6251,12 @@ def test_atomic_string_enumeration_nistxml_sv_iv_atomic_string_enumeration_1_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_1(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5888,11 +6269,12 @@ def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_1(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_2(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5905,11 +6287,12 @@ def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_2(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_3(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5922,11 +6305,12 @@ def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_3(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_4(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5939,11 +6323,12 @@ def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_4(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_5(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5956,11 +6341,12 @@ def test_atomic_string_pattern_4_nistxml_sv_iv_atomic_string_pattern_5_5(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_1(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5973,11 +6359,12 @@ def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_1(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_2(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -5990,11 +6377,12 @@ def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_2(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_3(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6007,11 +6395,12 @@ def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_3(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_4(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6024,11 +6413,12 @@ def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_4(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_5(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6041,11 +6431,12 @@ def test_atomic_string_pattern_3_nistxml_sv_iv_atomic_string_pattern_4_5(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_1(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6058,11 +6449,12 @@ def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_1(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_2(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6075,11 +6467,12 @@ def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_2(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_3(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6092,11 +6485,12 @@ def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_3(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_4(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6109,11 +6503,12 @@ def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_4(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_5(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6126,11 +6521,12 @@ def test_atomic_string_pattern_2_nistxml_sv_iv_atomic_string_pattern_3_5(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_1(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6143,11 +6539,12 @@ def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_1(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_2(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6160,11 +6557,12 @@ def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_2(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_3(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6177,11 +6575,12 @@ def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_3(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_4(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6194,11 +6593,12 @@ def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_4(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_5(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6211,11 +6611,12 @@ def test_atomic_string_pattern_1_nistxml_sv_iv_atomic_string_pattern_2_5(save_xm
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_1(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6228,11 +6629,12 @@ def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_2(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6245,11 +6647,12 @@ def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_3(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6262,11 +6665,12 @@ def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_4(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6279,11 +6683,12 @@ def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_5(save_xml):
     r"""
     Type atomic/string is restricted by facet pattern with value \d{1,5}\s
@@ -6296,11 +6701,12 @@ def test_atomic_string_pattern_nistxml_sv_iv_atomic_string_pattern_1_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -6311,11 +6717,12 @@ def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -6326,11 +6733,12 @@ def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -6341,11 +6749,12 @@ def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -6356,11 +6765,12 @@ def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 1000.
@@ -6371,11 +6781,12 @@ def test_atomic_string_length_4_nistxml_sv_iv_atomic_string_length_5_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 243.
@@ -6386,11 +6797,12 @@ def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 243.
@@ -6401,11 +6813,12 @@ def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 243.
@@ -6416,11 +6829,12 @@ def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 243.
@@ -6431,11 +6845,12 @@ def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 243.
@@ -6446,11 +6861,12 @@ def test_atomic_string_length_3_nistxml_sv_iv_atomic_string_length_4_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 713.
@@ -6461,11 +6877,12 @@ def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 713.
@@ -6476,11 +6893,12 @@ def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 713.
@@ -6491,11 +6909,12 @@ def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 713.
@@ -6506,11 +6925,12 @@ def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 713.
@@ -6521,11 +6941,12 @@ def test_atomic_string_length_2_nistxml_sv_iv_atomic_string_length_3_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 925.
@@ -6536,11 +6957,12 @@ def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_1(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 925.
@@ -6551,11 +6973,12 @@ def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_2(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 925.
@@ -6566,11 +6989,12 @@ def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_3(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 925.
@@ -6581,11 +7005,12 @@ def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_4(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 925.
@@ -6596,11 +7021,12 @@ def test_atomic_string_length_1_nistxml_sv_iv_atomic_string_length_2_5(save_xml)
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_1(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -6611,11 +7037,12 @@ def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_1(save_xml):
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_2(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -6626,11 +7053,12 @@ def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_2(save_xml):
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_3(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -6641,11 +7069,12 @@ def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_3(save_xml):
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_4(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -6656,11 +7085,12 @@ def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_4(save_xml):
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_5(save_xml):
     """
     Type atomic/string is restricted by facet length with value 0.
@@ -6671,11 +7101,12 @@ def test_atomic_string_length_nistxml_sv_iv_atomic_string_length_1_5(save_xml):
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -6686,11 +7117,12 @@ def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -6701,11 +7133,12 @@ def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -6716,11 +7149,12 @@ def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -6731,11 +7165,12 @@ def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 1000.
@@ -6746,11 +7181,12 @@ def test_atomic_string_min_length_4_nistxml_sv_iv_atomic_string_min_length_5_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 946.
@@ -6761,11 +7197,12 @@ def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 946.
@@ -6776,11 +7213,12 @@ def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 946.
@@ -6791,11 +7229,12 @@ def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 946.
@@ -6806,11 +7245,12 @@ def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 946.
@@ -6821,11 +7261,12 @@ def test_atomic_string_min_length_3_nistxml_sv_iv_atomic_string_min_length_4_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 90.
@@ -6836,11 +7277,12 @@ def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 90.
@@ -6851,11 +7293,12 @@ def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 90.
@@ -6866,11 +7309,12 @@ def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 90.
@@ -6881,11 +7325,12 @@ def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 90.
@@ -6896,11 +7341,12 @@ def test_atomic_string_min_length_2_nistxml_sv_iv_atomic_string_min_length_3_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 657.
@@ -6911,11 +7357,12 @@ def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 657.
@@ -6926,11 +7373,12 @@ def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 657.
@@ -6941,11 +7389,12 @@ def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 657.
@@ -6956,11 +7405,12 @@ def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 657.
@@ -6971,11 +7421,12 @@ def test_atomic_string_min_length_1_nistxml_sv_iv_atomic_string_min_length_2_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_1(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 0.
@@ -6986,11 +7437,12 @@ def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_1(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_2(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 0.
@@ -7001,11 +7453,12 @@ def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_2(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_3(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 0.
@@ -7016,11 +7469,12 @@ def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_3(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_4(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 0.
@@ -7031,11 +7485,12 @@ def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_4(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_5(save_xml):
     """
     Type atomic/string is restricted by facet minLength with value 0.
@@ -7046,11 +7501,12 @@ def test_atomic_string_min_length_nistxml_sv_iv_atomic_string_min_length_1_5(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -7061,11 +7517,12 @@ def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -7076,11 +7533,12 @@ def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -7091,11 +7549,12 @@ def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -7106,11 +7565,12 @@ def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 1000.
@@ -7121,11 +7581,12 @@ def test_atomic_string_max_length_4_nistxml_sv_iv_atomic_string_max_length_5_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 205.
@@ -7136,11 +7597,12 @@ def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 205.
@@ -7151,11 +7613,12 @@ def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 205.
@@ -7166,11 +7629,12 @@ def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 205.
@@ -7181,11 +7645,12 @@ def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 205.
@@ -7196,11 +7661,12 @@ def test_atomic_string_max_length_3_nistxml_sv_iv_atomic_string_max_length_4_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 913.
@@ -7211,11 +7677,12 @@ def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 913.
@@ -7226,11 +7693,12 @@ def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 913.
@@ -7241,11 +7709,12 @@ def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 913.
@@ -7256,11 +7725,12 @@ def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 913.
@@ -7271,11 +7741,12 @@ def test_atomic_string_max_length_2_nistxml_sv_iv_atomic_string_max_length_3_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 969.
@@ -7286,11 +7757,12 @@ def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_1(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 969.
@@ -7301,11 +7773,12 @@ def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_2(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 969.
@@ -7316,11 +7789,12 @@ def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_3(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 969.
@@ -7331,11 +7805,12 @@ def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_4(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 969.
@@ -7346,11 +7821,12 @@ def test_atomic_string_max_length_1_nistxml_sv_iv_atomic_string_max_length_2_5(s
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_1(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -7361,11 +7837,12 @@ def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_1(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_2(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -7376,11 +7853,12 @@ def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_2(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_3(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -7391,11 +7869,12 @@ def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_3(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_4(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -7406,11 +7885,12 @@ def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_4(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_5(save_xml):
     """
     Type atomic/string is restricted by facet maxLength with value 0.
@@ -7421,11 +7901,12 @@ def test_atomic_string_max_length_nistxml_sv_iv_atomic_string_max_length_1_5(sav
         instance="nistData/atomic/string/Schema+Instance/NISTXML-SV-IV-atomic-string-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet whiteSpace with value
@@ -7437,11 +7918,12 @@ def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet whiteSpace with value
@@ -7453,11 +7935,12 @@ def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet whiteSpace with value
@@ -7469,11 +7952,12 @@ def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet whiteSpace with value
@@ -7485,11 +7969,12 @@ def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet whiteSpace with value
@@ -7501,11 +7986,12 @@ def test_atomic_g_month_white_space_nistxml_sv_iv_atomic_g_month_white_space_1_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7516,11 +8002,12 @@ def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7531,11 +8018,12 @@ def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7546,11 +8034,12 @@ def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7561,11 +8050,12 @@ def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7576,11 +8066,12 @@ def test_atomic_g_month_enumeration_4_nistxml_sv_iv_atomic_g_month_enumeration_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7591,11 +8082,12 @@ def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7606,11 +8098,12 @@ def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7621,11 +8114,12 @@ def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7636,11 +8130,12 @@ def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7651,11 +8146,12 @@ def test_atomic_g_month_enumeration_3_nistxml_sv_iv_atomic_g_month_enumeration_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7666,11 +8162,12 @@ def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7681,11 +8178,12 @@ def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7696,11 +8194,12 @@ def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7711,11 +8210,12 @@ def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7726,11 +8226,12 @@ def test_atomic_g_month_enumeration_2_nistxml_sv_iv_atomic_g_month_enumeration_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7741,11 +8242,12 @@ def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7756,11 +8258,12 @@ def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7771,11 +8274,12 @@ def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7786,11 +8290,12 @@ def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7801,11 +8306,12 @@ def test_atomic_g_month_enumeration_1_nistxml_sv_iv_atomic_g_month_enumeration_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7816,11 +8322,12 @@ def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_1
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7831,11 +8338,12 @@ def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_2
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7846,11 +8354,12 @@ def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_3
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7861,11 +8370,12 @@ def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_4
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet enumeration.
@@ -7876,11 +8386,12 @@ def test_atomic_g_month_enumeration_nistxml_sv_iv_atomic_g_month_enumeration_1_5
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -7891,11 +8402,12 @@ def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -7906,11 +8418,12 @@ def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -7921,11 +8434,12 @@ def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -7936,11 +8450,12 @@ def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --0\d.
@@ -7951,11 +8466,12 @@ def test_atomic_g_month_pattern_4_nistxml_sv_iv_atomic_g_month_pattern_5_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d6.
@@ -7966,11 +8482,12 @@ def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d6.
@@ -7981,11 +8498,12 @@ def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d6.
@@ -7996,11 +8514,12 @@ def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d6.
@@ -8011,11 +8530,12 @@ def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d6.
@@ -8026,11 +8546,12 @@ def test_atomic_g_month_pattern_3_nistxml_sv_iv_atomic_g_month_pattern_4_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d9.
@@ -8041,11 +8562,12 @@ def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d9.
@@ -8056,11 +8578,12 @@ def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d9.
@@ -8071,11 +8594,12 @@ def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d9.
@@ -8086,11 +8610,12 @@ def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d9.
@@ -8101,11 +8626,12 @@ def test_atomic_g_month_pattern_2_nistxml_sv_iv_atomic_g_month_pattern_3_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d2.
@@ -8116,11 +8642,12 @@ def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_1(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d2.
@@ -8131,11 +8658,12 @@ def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_2(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d2.
@@ -8146,11 +8674,12 @@ def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_3(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d2.
@@ -8161,11 +8690,12 @@ def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_4(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --\d2.
@@ -8176,11 +8706,12 @@ def test_atomic_g_month_pattern_1_nistxml_sv_iv_atomic_g_month_pattern_2_5(save_
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_1(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -8191,11 +8722,12 @@ def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_1(save_xm
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_2(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -8206,11 +8738,12 @@ def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_2(save_xm
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_3(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -8221,11 +8754,12 @@ def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_3(save_xm
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_4(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -8236,11 +8770,12 @@ def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_4(save_xm
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_5(save_xml):
     r"""
     Type atomic/gMonth is restricted by facet pattern with value --1\d.
@@ -8251,11 +8786,12 @@ def test_atomic_g_month_pattern_nistxml_sv_iv_atomic_g_month_pattern_1_5(save_xm
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8267,11 +8803,12 @@ def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusive_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8283,11 +8820,12 @@ def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusive_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8299,11 +8837,12 @@ def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusive_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8315,11 +8854,12 @@ def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusive_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8331,11 +8871,12 @@ def test_atomic_g_month_max_inclusive_4_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8347,11 +8888,12 @@ def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8363,11 +8905,12 @@ def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8379,11 +8922,12 @@ def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8395,11 +8939,12 @@ def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8411,11 +8956,12 @@ def test_atomic_g_month_max_inclusive_3_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8427,11 +8973,12 @@ def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8443,11 +8990,12 @@ def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8459,11 +9007,12 @@ def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8475,11 +9024,12 @@ def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8491,11 +9041,12 @@ def test_atomic_g_month_max_inclusive_2_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8507,11 +9058,12 @@ def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8523,11 +9075,12 @@ def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8539,11 +9092,12 @@ def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8555,11 +9109,12 @@ def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8571,11 +9126,12 @@ def test_atomic_g_month_max_inclusive_1_nistxml_sv_iv_atomic_g_month_max_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_inclusive_nistxml_sv_iv_atomic_g_month_max_inclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxInclusive with value
@@ -8587,11 +9143,12 @@ def test_atomic_g_month_max_inclusive_nistxml_sv_iv_atomic_g_month_max_inclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8603,11 +9160,12 @@ def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusive_5_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8619,11 +9177,12 @@ def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusive_5_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8635,11 +9194,12 @@ def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusive_5_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8651,11 +9211,12 @@ def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusive_5_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8667,11 +9228,12 @@ def test_atomic_g_month_max_exclusive_4_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8683,11 +9245,12 @@ def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8699,11 +9262,12 @@ def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8715,11 +9279,12 @@ def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8731,11 +9296,12 @@ def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8747,11 +9313,12 @@ def test_atomic_g_month_max_exclusive_3_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8763,11 +9330,12 @@ def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8779,11 +9347,12 @@ def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8795,11 +9364,12 @@ def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8811,11 +9381,12 @@ def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8827,11 +9398,12 @@ def test_atomic_g_month_max_exclusive_2_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_1_nistxml_sv_iv_atomic_g_month_max_exclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8843,11 +9415,12 @@ def test_atomic_g_month_max_exclusive_1_nistxml_sv_iv_atomic_g_month_max_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_max_exclusive_nistxml_sv_iv_atomic_g_month_max_exclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet maxExclusive with value
@@ -8859,11 +9432,12 @@ def test_atomic_g_month_max_exclusive_nistxml_sv_iv_atomic_g_month_max_exclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_4_nistxml_sv_iv_atomic_g_month_min_inclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8875,11 +9449,12 @@ def test_atomic_g_month_min_inclusive_4_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8891,11 +9466,12 @@ def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8907,11 +9483,12 @@ def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8923,11 +9500,12 @@ def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8939,11 +9517,12 @@ def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8955,11 +9534,12 @@ def test_atomic_g_month_min_inclusive_3_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8971,11 +9551,12 @@ def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -8987,11 +9568,12 @@ def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9003,11 +9585,12 @@ def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9019,11 +9602,12 @@ def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9035,11 +9619,12 @@ def test_atomic_g_month_min_inclusive_2_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9051,11 +9636,12 @@ def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9067,11 +9653,12 @@ def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9083,11 +9670,12 @@ def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9099,11 +9687,12 @@ def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9115,11 +9704,12 @@ def test_atomic_g_month_min_inclusive_1_nistxml_sv_iv_atomic_g_month_min_inclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9131,11 +9721,12 @@ def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9147,11 +9738,12 @@ def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9163,11 +9755,12 @@ def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9179,11 +9772,12 @@ def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minInclusive with value
@@ -9195,11 +9789,12 @@ def test_atomic_g_month_min_inclusive_nistxml_sv_iv_atomic_g_month_min_inclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_4_nistxml_sv_iv_atomic_g_month_min_exclusive_5_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9211,11 +9806,12 @@ def test_atomic_g_month_min_exclusive_4_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusive_4_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9227,11 +9823,12 @@ def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusive_4_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9243,11 +9840,12 @@ def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusive_4_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9259,11 +9857,12 @@ def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusive_4_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9275,11 +9874,12 @@ def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusive_4_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9291,11 +9891,12 @@ def test_atomic_g_month_min_exclusive_3_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusive_3_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9307,11 +9908,12 @@ def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusive_3_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9323,11 +9925,12 @@ def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusive_3_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9339,11 +9942,12 @@ def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusive_3_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9355,11 +9959,12 @@ def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusive_3_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9371,11 +9976,12 @@ def test_atomic_g_month_min_exclusive_2_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusive_2_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9387,11 +9993,12 @@ def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusive_2_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9403,11 +10010,12 @@ def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusive_2_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9419,11 +10027,12 @@ def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusive_2_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9435,11 +10044,12 @@ def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusive_2_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9451,11 +10061,12 @@ def test_atomic_g_month_min_exclusive_1_nistxml_sv_iv_atomic_g_month_min_exclusi
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive_1_1(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9467,11 +10078,12 @@ def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive_1_2(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9483,11 +10095,12 @@ def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive_1_3(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9499,11 +10112,12 @@ def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive_1_4(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9515,11 +10129,12 @@ def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive_1_5(save_xml):
     """
     Type atomic/gMonth is restricted by facet minExclusive with value
@@ -9531,11 +10146,12 @@ def test_atomic_g_month_min_exclusive_nistxml_sv_iv_atomic_g_month_min_exclusive
         instance="nistData/atomic/gMonth/Schema+Instance/NISTXML-SV-IV-atomic-gMonth-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet whiteSpace with value
@@ -9547,11 +10163,12 @@ def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_1(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet whiteSpace with value
@@ -9563,11 +10180,12 @@ def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_2(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet whiteSpace with value
@@ -9579,11 +10197,12 @@ def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_3(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet whiteSpace with value
@@ -9595,11 +10214,12 @@ def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_4(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet whiteSpace with value
@@ -9611,11 +10231,12 @@ def test_atomic_g_day_white_space_nistxml_sv_iv_atomic_g_day_white_space_1_5(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9626,11 +10247,12 @@ def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9641,11 +10263,12 @@ def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9656,11 +10279,12 @@ def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9671,11 +10295,12 @@ def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9686,11 +10311,12 @@ def test_atomic_g_day_enumeration_4_nistxml_sv_iv_atomic_g_day_enumeration_5_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9701,11 +10327,12 @@ def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9716,11 +10343,12 @@ def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9731,11 +10359,12 @@ def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9746,11 +10375,12 @@ def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9761,11 +10391,12 @@ def test_atomic_g_day_enumeration_3_nistxml_sv_iv_atomic_g_day_enumeration_4_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9776,11 +10407,12 @@ def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9791,11 +10423,12 @@ def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9806,11 +10439,12 @@ def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9821,11 +10455,12 @@ def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9836,11 +10471,12 @@ def test_atomic_g_day_enumeration_2_nistxml_sv_iv_atomic_g_day_enumeration_3_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9851,11 +10487,12 @@ def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_1(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9866,11 +10503,12 @@ def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_2(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9881,11 +10519,12 @@ def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_3(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9896,11 +10535,12 @@ def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_4(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9911,11 +10551,12 @@ def test_atomic_g_day_enumeration_1_nistxml_sv_iv_atomic_g_day_enumeration_2_5(s
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9926,11 +10567,12 @@ def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_1(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9941,11 +10583,12 @@ def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_2(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9956,11 +10599,12 @@ def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_3(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9971,11 +10615,12 @@ def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_4(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet enumeration.
@@ -9986,11 +10631,12 @@ def test_atomic_g_day_enumeration_nistxml_sv_iv_atomic_g_day_enumeration_1_5(sav
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -10001,11 +10647,12 @@ def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -10016,11 +10663,12 @@ def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -10031,11 +10679,12 @@ def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -10046,11 +10695,12 @@ def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---1\d.
@@ -10061,11 +10711,12 @@ def test_atomic_g_day_pattern_4_nistxml_sv_iv_atomic_g_day_pattern_5_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d2.
@@ -10076,11 +10727,12 @@ def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d2.
@@ -10091,11 +10743,12 @@ def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d2.
@@ -10106,11 +10759,12 @@ def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d2.
@@ -10121,11 +10775,12 @@ def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d2.
@@ -10136,11 +10791,12 @@ def test_atomic_g_day_pattern_3_nistxml_sv_iv_atomic_g_day_pattern_4_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -10151,11 +10807,12 @@ def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -10166,11 +10823,12 @@ def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -10181,11 +10839,12 @@ def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -10196,11 +10855,12 @@ def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---0\d.
@@ -10211,11 +10871,12 @@ def test_atomic_g_day_pattern_2_nistxml_sv_iv_atomic_g_day_pattern_3_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10226,11 +10887,12 @@ def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_1(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10241,11 +10903,12 @@ def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_2(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10256,11 +10919,12 @@ def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_3(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10271,11 +10935,12 @@ def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_4(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10286,11 +10951,12 @@ def test_atomic_g_day_pattern_1_nistxml_sv_iv_atomic_g_day_pattern_2_5(save_xml)
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_1(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10301,11 +10967,12 @@ def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_1(save_xml):
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_2(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10316,11 +10983,12 @@ def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_2(save_xml):
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_3(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10331,11 +10999,12 @@ def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_3(save_xml):
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_4(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10346,11 +11015,12 @@ def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_4(save_xml):
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_5(save_xml):
     r"""
     Type atomic/gDay is restricted by facet pattern with value ---\d5.
@@ -10361,11 +11031,12 @@ def test_atomic_g_day_pattern_nistxml_sv_iv_atomic_g_day_pattern_1_5(save_xml):
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---31.
@@ -10376,11 +11047,12 @@ def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---31.
@@ -10391,11 +11063,12 @@ def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---31.
@@ -10406,11 +11079,12 @@ def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---31.
@@ -10421,11 +11095,12 @@ def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---31.
@@ -10436,11 +11111,12 @@ def test_atomic_g_day_max_inclusive_4_nistxml_sv_iv_atomic_g_day_max_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---10.
@@ -10451,11 +11127,12 @@ def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---10.
@@ -10466,11 +11143,12 @@ def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---10.
@@ -10481,11 +11159,12 @@ def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---10.
@@ -10496,11 +11175,12 @@ def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---10.
@@ -10511,11 +11191,12 @@ def test_atomic_g_day_max_inclusive_3_nistxml_sv_iv_atomic_g_day_max_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_2_nistxml_sv_iv_atomic_g_day_max_inclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -10526,11 +11207,12 @@ def test_atomic_g_day_max_inclusive_2_nistxml_sv_iv_atomic_g_day_max_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---07.
@@ -10541,11 +11223,12 @@ def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---07.
@@ -10556,11 +11239,12 @@ def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---07.
@@ -10571,11 +11255,12 @@ def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---07.
@@ -10586,11 +11271,12 @@ def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---07.
@@ -10601,11 +11287,12 @@ def test_atomic_g_day_max_inclusive_1_nistxml_sv_iv_atomic_g_day_max_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_inclusive_nistxml_sv_iv_atomic_g_day_max_inclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxInclusive with value ---01.
@@ -10616,11 +11303,12 @@ def test_atomic_g_day_max_inclusive_nistxml_sv_iv_atomic_g_day_max_inclusive_1_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---31.
@@ -10631,11 +11319,12 @@ def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---31.
@@ -10646,11 +11335,12 @@ def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---31.
@@ -10661,11 +11351,12 @@ def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---31.
@@ -10676,11 +11367,12 @@ def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---31.
@@ -10691,11 +11383,12 @@ def test_atomic_g_day_max_exclusive_4_nistxml_sv_iv_atomic_g_day_max_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---15.
@@ -10706,11 +11399,12 @@ def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---15.
@@ -10721,11 +11415,12 @@ def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---15.
@@ -10736,11 +11431,12 @@ def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---15.
@@ -10751,11 +11447,12 @@ def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---15.
@@ -10766,11 +11463,12 @@ def test_atomic_g_day_max_exclusive_3_nistxml_sv_iv_atomic_g_day_max_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---30.
@@ -10781,11 +11479,12 @@ def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---30.
@@ -10796,11 +11495,12 @@ def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---30.
@@ -10811,11 +11511,12 @@ def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---30.
@@ -10826,11 +11527,12 @@ def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---30.
@@ -10841,11 +11543,12 @@ def test_atomic_g_day_max_exclusive_2_nistxml_sv_iv_atomic_g_day_max_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---25.
@@ -10856,11 +11559,12 @@ def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---25.
@@ -10871,11 +11575,12 @@ def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---25.
@@ -10886,11 +11591,12 @@ def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---25.
@@ -10901,11 +11607,12 @@ def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---25.
@@ -10916,11 +11623,12 @@ def test_atomic_g_day_max_exclusive_1_nistxml_sv_iv_atomic_g_day_max_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_max_exclusive_nistxml_sv_iv_atomic_g_day_max_exclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet maxExclusive with value ---02.
@@ -10931,11 +11639,12 @@ def test_atomic_g_day_max_exclusive_nistxml_sv_iv_atomic_g_day_max_exclusive_1_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_4_nistxml_sv_iv_atomic_g_day_min_inclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---31.
@@ -10946,11 +11655,12 @@ def test_atomic_g_day_min_inclusive_4_nistxml_sv_iv_atomic_g_day_min_inclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---08.
@@ -10961,11 +11671,12 @@ def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---08.
@@ -10976,11 +11687,12 @@ def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---08.
@@ -10991,11 +11703,12 @@ def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---08.
@@ -11006,11 +11719,12 @@ def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---08.
@@ -11021,11 +11735,12 @@ def test_atomic_g_day_min_inclusive_3_nistxml_sv_iv_atomic_g_day_min_inclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---24.
@@ -11036,11 +11751,12 @@ def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---24.
@@ -11051,11 +11767,12 @@ def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---24.
@@ -11066,11 +11783,12 @@ def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---24.
@@ -11081,11 +11799,12 @@ def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---24.
@@ -11096,11 +11815,12 @@ def test_atomic_g_day_min_inclusive_2_nistxml_sv_iv_atomic_g_day_min_inclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -11111,11 +11831,12 @@ def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -11126,11 +11847,12 @@ def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -11141,11 +11863,12 @@ def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -11156,11 +11879,12 @@ def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---16.
@@ -11171,11 +11895,12 @@ def test_atomic_g_day_min_inclusive_1_nistxml_sv_iv_atomic_g_day_min_inclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---01.
@@ -11186,11 +11911,12 @@ def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---01.
@@ -11201,11 +11927,12 @@ def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---01.
@@ -11216,11 +11943,12 @@ def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---01.
@@ -11231,11 +11959,12 @@ def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minInclusive with value ---01.
@@ -11246,11 +11975,12 @@ def test_atomic_g_day_min_inclusive_nistxml_sv_iv_atomic_g_day_min_inclusive_1_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_4_nistxml_sv_iv_atomic_g_day_min_exclusive_5_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---30.
@@ -11261,11 +11991,12 @@ def test_atomic_g_day_min_exclusive_4_nistxml_sv_iv_atomic_g_day_min_exclusive_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11276,11 +12007,12 @@ def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11291,11 +12023,12 @@ def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11306,11 +12039,12 @@ def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11321,11 +12055,12 @@ def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11336,11 +12071,12 @@ def test_atomic_g_day_min_exclusive_3_nistxml_sv_iv_atomic_g_day_min_exclusive_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11351,11 +12087,12 @@ def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11366,11 +12103,12 @@ def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11381,11 +12119,12 @@ def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11396,11 +12135,12 @@ def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---04.
@@ -11411,11 +12151,12 @@ def test_atomic_g_day_min_exclusive_2_nistxml_sv_iv_atomic_g_day_min_exclusive_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---20.
@@ -11426,11 +12167,12 @@ def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---20.
@@ -11441,11 +12183,12 @@ def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---20.
@@ -11456,11 +12199,12 @@ def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---20.
@@ -11471,11 +12215,12 @@ def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---20.
@@ -11486,11 +12231,12 @@ def test_atomic_g_day_min_exclusive_1_nistxml_sv_iv_atomic_g_day_min_exclusive_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_1(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---01.
@@ -11501,11 +12247,12 @@ def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_1
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_2(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---01.
@@ -11516,11 +12263,12 @@ def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_2
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_3(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---01.
@@ -11531,11 +12279,12 @@ def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_3
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_4(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---01.
@@ -11546,11 +12295,12 @@ def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_4
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_5(save_xml):
     """
     Type atomic/gDay is restricted by facet minExclusive with value ---01.
@@ -11561,11 +12311,12 @@ def test_atomic_g_day_min_exclusive_nistxml_sv_iv_atomic_g_day_min_exclusive_1_5
         instance="nistData/atomic/gDay/Schema+Instance/NISTXML-SV-IV-atomic-gDay-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_space_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet whiteSpace with value
@@ -11577,11 +12328,12 @@ def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_s
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_space_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet whiteSpace with value
@@ -11593,11 +12345,12 @@ def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_s
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_space_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet whiteSpace with value
@@ -11609,11 +12362,12 @@ def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_s
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_space_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet whiteSpace with value
@@ -11625,11 +12379,12 @@ def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_s
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_space_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet whiteSpace with value
@@ -11641,11 +12396,12 @@ def test_atomic_g_month_day_white_space_nistxml_sv_iv_atomic_g_month_day_white_s
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enumeration_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11656,11 +12412,12 @@ def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enumeration_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11671,11 +12428,12 @@ def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enumeration_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11686,11 +12444,12 @@ def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enumeration_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11701,11 +12460,12 @@ def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enumeration_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11716,11 +12476,12 @@ def test_atomic_g_month_day_enumeration_4_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enumeration_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11731,11 +12492,12 @@ def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enumeration_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11746,11 +12508,12 @@ def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enumeration_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11761,11 +12524,12 @@ def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enumeration_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11776,11 +12540,12 @@ def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enumeration_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11791,11 +12556,12 @@ def test_atomic_g_month_day_enumeration_3_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enumeration_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11806,11 +12572,12 @@ def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enumeration_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11821,11 +12588,12 @@ def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enumeration_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11836,11 +12604,12 @@ def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enumeration_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11851,11 +12620,12 @@ def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enumeration_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11866,11 +12636,12 @@ def test_atomic_g_month_day_enumeration_2_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enumeration_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11881,11 +12652,12 @@ def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enumeration_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11896,11 +12668,12 @@ def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enumeration_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11911,11 +12684,12 @@ def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enumeration_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11926,11 +12700,12 @@ def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enumeration_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11941,11 +12716,12 @@ def test_atomic_g_month_day_enumeration_1_nistxml_sv_iv_atomic_g_month_day_enume
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumeration_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11956,11 +12732,12 @@ def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumera
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumeration_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11971,11 +12748,12 @@ def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumera
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumeration_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -11986,11 +12764,12 @@ def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumera
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumeration_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -12001,11 +12780,12 @@ def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumera
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumeration_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet enumeration.
@@ -12016,11 +12796,12 @@ def test_atomic_g_month_day_enumeration_nistxml_sv_iv_atomic_g_month_day_enumera
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12032,11 +12813,12 @@ def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12048,11 +12830,12 @@ def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12064,11 +12847,12 @@ def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12080,11 +12864,12 @@ def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12096,11 +12881,12 @@ def test_atomic_g_month_day_pattern_4_nistxml_sv_iv_atomic_g_month_day_pattern_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12112,11 +12898,12 @@ def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12128,11 +12915,12 @@ def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12144,11 +12932,12 @@ def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12160,11 +12949,12 @@ def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12176,11 +12966,12 @@ def test_atomic_g_month_day_pattern_3_nistxml_sv_iv_atomic_g_month_day_pattern_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12192,11 +12983,12 @@ def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12208,11 +13000,12 @@ def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12224,11 +13017,12 @@ def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12240,11 +13034,12 @@ def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12256,11 +13051,12 @@ def test_atomic_g_month_day_pattern_2_nistxml_sv_iv_atomic_g_month_day_pattern_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12272,11 +13068,12 @@ def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12288,11 +13085,12 @@ def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12304,11 +13102,12 @@ def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12320,11 +13119,12 @@ def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12336,11 +13136,12 @@ def test_atomic_g_month_day_pattern_1_nistxml_sv_iv_atomic_g_month_day_pattern_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_1(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12352,11 +13153,12 @@ def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_1
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_2(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12368,11 +13170,12 @@ def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_2
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_3(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12384,11 +13187,12 @@ def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_3
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_4(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12400,11 +13204,12 @@ def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_4
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_5(save_xml):
     r"""
     Type atomic/gMonthDay is restricted by facet pattern with value
@@ -12416,11 +13221,12 @@ def test_atomic_g_month_day_pattern_nistxml_sv_iv_atomic_g_month_day_pattern_1_5
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max_inclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12432,11 +13238,12 @@ def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max_inclusive_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12448,11 +13255,12 @@ def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max_inclusive_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12464,11 +13272,12 @@ def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max_inclusive_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12480,11 +13289,12 @@ def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max_inclusive_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12496,11 +13306,12 @@ def test_atomic_g_month_day_max_inclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max_inclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12512,11 +13323,12 @@ def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max_inclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12528,11 +13340,12 @@ def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max_inclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12544,11 +13357,12 @@ def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max_inclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12560,11 +13374,12 @@ def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max_inclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12576,11 +13391,12 @@ def test_atomic_g_month_day_max_inclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max_inclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12592,11 +13408,12 @@ def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max_inclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12608,11 +13425,12 @@ def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max_inclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12624,11 +13442,12 @@ def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max_inclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12640,11 +13459,12 @@ def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max_inclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12656,11 +13476,12 @@ def test_atomic_g_month_day_max_inclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max_inclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12672,11 +13493,12 @@ def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max_inclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12688,11 +13510,12 @@ def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max_inclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12704,11 +13527,12 @@ def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max_inclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12720,11 +13544,12 @@ def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max_inclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12736,11 +13561,12 @@ def test_atomic_g_month_day_max_inclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_inclusive_nistxml_sv_iv_atomic_g_month_day_max_inclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxInclusive with value
@@ -12752,11 +13578,12 @@ def test_atomic_g_month_day_max_inclusive_nistxml_sv_iv_atomic_g_month_day_max_i
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max_exclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12768,11 +13595,12 @@ def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max_exclusive_5_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12784,11 +13612,12 @@ def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max_exclusive_5_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12800,11 +13629,12 @@ def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max_exclusive_5_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12816,11 +13646,12 @@ def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max_exclusive_5_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12832,11 +13663,12 @@ def test_atomic_g_month_day_max_exclusive_4_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max_exclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12848,11 +13680,12 @@ def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max_exclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12864,11 +13697,12 @@ def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max_exclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12880,11 +13714,12 @@ def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max_exclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12896,11 +13731,12 @@ def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max_exclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12912,11 +13748,12 @@ def test_atomic_g_month_day_max_exclusive_3_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max_exclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12928,11 +13765,12 @@ def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max_exclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12944,11 +13782,12 @@ def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max_exclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12960,11 +13799,12 @@ def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max_exclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12976,11 +13816,12 @@ def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max_exclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -12992,11 +13833,12 @@ def test_atomic_g_month_day_max_exclusive_2_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max_exclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -13008,11 +13850,12 @@ def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max_exclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -13024,11 +13867,12 @@ def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max_exclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -13040,11 +13884,12 @@ def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max_exclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -13056,11 +13901,12 @@ def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max_exclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -13072,11 +13918,12 @@ def test_atomic_g_month_day_max_exclusive_1_nistxml_sv_iv_atomic_g_month_day_max
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_max_exclusive_nistxml_sv_iv_atomic_g_month_day_max_exclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet maxExclusive with value
@@ -13088,11 +13935,12 @@ def test_atomic_g_month_day_max_exclusive_nistxml_sv_iv_atomic_g_month_day_max_e
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_4_nistxml_sv_iv_atomic_g_month_day_min_inclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13104,11 +13952,12 @@ def test_atomic_g_month_day_min_inclusive_4_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min_inclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13120,11 +13969,12 @@ def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min_inclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13136,11 +13986,12 @@ def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min_inclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13152,11 +14003,12 @@ def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min_inclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13168,11 +14020,12 @@ def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min_inclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13184,11 +14037,12 @@ def test_atomic_g_month_day_min_inclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min_inclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13200,11 +14054,12 @@ def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min_inclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13216,11 +14071,12 @@ def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min_inclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13232,11 +14088,12 @@ def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min_inclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13248,11 +14105,12 @@ def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min_inclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13264,11 +14122,12 @@ def test_atomic_g_month_day_min_inclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min_inclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13280,11 +14139,12 @@ def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min_inclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13296,11 +14156,12 @@ def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min_inclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13312,11 +14173,12 @@ def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min_inclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13328,11 +14190,12 @@ def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min_inclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13344,11 +14207,12 @@ def test_atomic_g_month_day_min_inclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_inclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13360,11 +14224,12 @@ def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_i
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_inclusive_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13376,11 +14241,12 @@ def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_i
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_inclusive_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13392,11 +14258,12 @@ def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_i
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_inclusive_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13408,11 +14275,12 @@ def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_i
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_inclusive_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minInclusive with value
@@ -13424,11 +14292,12 @@ def test_atomic_g_month_day_min_inclusive_nistxml_sv_iv_atomic_g_month_day_min_i
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_4_nistxml_sv_iv_atomic_g_month_day_min_exclusive_5_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13440,11 +14309,12 @@ def test_atomic_g_month_day_min_exclusive_4_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min_exclusive_4_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13456,11 +14326,12 @@ def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min_exclusive_4_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13472,11 +14343,12 @@ def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min_exclusive_4_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13488,11 +14360,12 @@ def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min_exclusive_4_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13504,11 +14377,12 @@ def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min_exclusive_4_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13520,11 +14394,12 @@ def test_atomic_g_month_day_min_exclusive_3_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min_exclusive_3_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13536,11 +14411,12 @@ def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min_exclusive_3_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13552,11 +14428,12 @@ def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min_exclusive_3_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13568,11 +14445,12 @@ def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min_exclusive_3_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13584,11 +14462,12 @@ def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min_exclusive_3_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13600,11 +14479,12 @@ def test_atomic_g_month_day_min_exclusive_2_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min_exclusive_2_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13616,11 +14496,12 @@ def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min_exclusive_2_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13632,11 +14513,12 @@ def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min_exclusive_2_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13648,11 +14530,12 @@ def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min_exclusive_2_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13664,11 +14547,12 @@ def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min_exclusive_2_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13680,11 +14564,12 @@ def test_atomic_g_month_day_min_exclusive_1_nistxml_sv_iv_atomic_g_month_day_min
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_exclusive_1_1(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13696,11 +14581,12 @@ def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_e
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_exclusive_1_2(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13712,11 +14598,12 @@ def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_e
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_exclusive_1_3(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13728,11 +14615,12 @@ def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_e
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_exclusive_1_4(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13744,11 +14632,12 @@ def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_e
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_exclusive_1_5(save_xml):
     """
     Type atomic/gMonthDay is restricted by facet minExclusive with value
@@ -13760,11 +14649,12 @@ def test_atomic_g_month_day_min_exclusive_nistxml_sv_iv_atomic_g_month_day_min_e
         instance="nistData/atomic/gMonthDay/Schema+Instance/NISTXML-SV-IV-atomic-gMonthDay-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGMonthDayMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet whiteSpace with value
@@ -13776,11 +14666,12 @@ def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_1(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet whiteSpace with value
@@ -13792,11 +14683,12 @@ def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_2(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet whiteSpace with value
@@ -13808,11 +14700,12 @@ def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_3(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet whiteSpace with value
@@ -13824,11 +14717,12 @@ def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_4(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet whiteSpace with value
@@ -13840,11 +14734,12 @@ def test_atomic_g_year_white_space_nistxml_sv_iv_atomic_g_year_white_space_1_5(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13855,11 +14750,12 @@ def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13870,11 +14766,12 @@ def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13885,11 +14782,12 @@ def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13900,11 +14798,12 @@ def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13915,11 +14814,12 @@ def test_atomic_g_year_enumeration_4_nistxml_sv_iv_atomic_g_year_enumeration_5_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13930,11 +14830,12 @@ def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13945,11 +14846,12 @@ def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13960,11 +14862,12 @@ def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13975,11 +14878,12 @@ def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -13990,11 +14894,12 @@ def test_atomic_g_year_enumeration_3_nistxml_sv_iv_atomic_g_year_enumeration_4_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14005,11 +14910,12 @@ def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14020,11 +14926,12 @@ def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14035,11 +14942,12 @@ def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14050,11 +14958,12 @@ def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14065,11 +14974,12 @@ def test_atomic_g_year_enumeration_2_nistxml_sv_iv_atomic_g_year_enumeration_3_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14080,11 +14990,12 @@ def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14095,11 +15006,12 @@ def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_2
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14110,11 +15022,12 @@ def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_3
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14125,11 +15038,12 @@ def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_4
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14140,11 +15054,12 @@ def test_atomic_g_year_enumeration_1_nistxml_sv_iv_atomic_g_year_enumeration_2_5
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14155,11 +15070,12 @@ def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_1(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14170,11 +15086,12 @@ def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_2(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14185,11 +15102,12 @@ def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_3(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14200,11 +15118,12 @@ def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_4(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet enumeration.
@@ -14215,11 +15134,12 @@ def test_atomic_g_year_enumeration_nistxml_sv_iv_atomic_g_year_enumeration_1_5(s
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d21.
@@ -14230,11 +15150,12 @@ def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d21.
@@ -14245,11 +15166,12 @@ def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d21.
@@ -14260,11 +15182,12 @@ def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d21.
@@ -14275,11 +15198,12 @@ def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d21.
@@ -14290,11 +15214,12 @@ def test_atomic_g_year_pattern_4_nistxml_sv_iv_atomic_g_year_pattern_5_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d14.
@@ -14305,11 +15230,12 @@ def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d14.
@@ -14320,11 +15246,12 @@ def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d14.
@@ -14335,11 +15262,12 @@ def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d14.
@@ -14350,11 +15278,12 @@ def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d14.
@@ -14365,11 +15294,12 @@ def test_atomic_g_year_pattern_3_nistxml_sv_iv_atomic_g_year_pattern_4_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d86.
@@ -14380,11 +15310,12 @@ def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d86.
@@ -14395,11 +15326,12 @@ def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d86.
@@ -14410,11 +15342,12 @@ def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d86.
@@ -14425,11 +15358,12 @@ def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d86.
@@ -14440,11 +15374,12 @@ def test_atomic_g_year_pattern_2_nistxml_sv_iv_atomic_g_year_pattern_3_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d61.
@@ -14455,11 +15390,12 @@ def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_1(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d61.
@@ -14470,11 +15406,12 @@ def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_2(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d61.
@@ -14485,11 +15422,12 @@ def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_3(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d61.
@@ -14500,11 +15438,12 @@ def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_4(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d61.
@@ -14515,11 +15454,12 @@ def test_atomic_g_year_pattern_1_nistxml_sv_iv_atomic_g_year_pattern_2_5(save_xm
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_1(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d47.
@@ -14530,11 +15470,12 @@ def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_1(save_xml)
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_2(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d47.
@@ -14545,11 +15486,12 @@ def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_2(save_xml)
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_3(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d47.
@@ -14560,11 +15502,12 @@ def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_3(save_xml)
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_4(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d47.
@@ -14575,11 +15518,12 @@ def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_4(save_xml)
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_5(save_xml):
     r"""
     Type atomic/gYear is restricted by facet pattern with value \d\d47.
@@ -14590,11 +15534,12 @@ def test_atomic_g_year_pattern_nistxml_sv_iv_atomic_g_year_pattern_1_5(save_xml)
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2030.
@@ -14605,11 +15550,12 @@ def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2030.
@@ -14620,11 +15566,12 @@ def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2030.
@@ -14635,11 +15582,12 @@ def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2030.
@@ -14650,11 +15598,12 @@ def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2030.
@@ -14665,11 +15614,12 @@ def test_atomic_g_year_max_inclusive_4_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1998.
@@ -14680,11 +15630,12 @@ def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1998.
@@ -14695,11 +15646,12 @@ def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1998.
@@ -14710,11 +15662,12 @@ def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1998.
@@ -14725,11 +15678,12 @@ def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1998.
@@ -14740,11 +15694,12 @@ def test_atomic_g_year_max_inclusive_3_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2019.
@@ -14755,11 +15710,12 @@ def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2019.
@@ -14770,11 +15726,12 @@ def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2019.
@@ -14785,11 +15742,12 @@ def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2019.
@@ -14800,11 +15758,12 @@ def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 2019.
@@ -14815,11 +15774,12 @@ def test_atomic_g_year_max_inclusive_2_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1975.
@@ -14830,11 +15790,12 @@ def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1975.
@@ -14845,11 +15806,12 @@ def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1975.
@@ -14860,11 +15822,12 @@ def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1975.
@@ -14875,11 +15838,12 @@ def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1975.
@@ -14890,11 +15854,12 @@ def test_atomic_g_year_max_inclusive_1_nistxml_sv_iv_atomic_g_year_max_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_inclusive_nistxml_sv_iv_atomic_g_year_max_inclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxInclusive with value 1970.
@@ -14905,11 +15870,12 @@ def test_atomic_g_year_max_inclusive_nistxml_sv_iv_atomic_g_year_max_inclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2030.
@@ -14920,11 +15886,12 @@ def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive_5_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2030.
@@ -14935,11 +15902,12 @@ def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive_5_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2030.
@@ -14950,11 +15918,12 @@ def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive_5_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2030.
@@ -14965,11 +15934,12 @@ def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive_5_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2030.
@@ -14980,11 +15950,12 @@ def test_atomic_g_year_max_exclusive_4_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2005.
@@ -14995,11 +15966,12 @@ def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2005.
@@ -15010,11 +15982,12 @@ def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2005.
@@ -15025,11 +15998,12 @@ def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2005.
@@ -15040,11 +16014,12 @@ def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2005.
@@ -15055,11 +16030,12 @@ def test_atomic_g_year_max_exclusive_3_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2003.
@@ -15070,11 +16046,12 @@ def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2003.
@@ -15085,11 +16062,12 @@ def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2003.
@@ -15100,11 +16078,12 @@ def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2003.
@@ -15115,11 +16094,12 @@ def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2003.
@@ -15130,11 +16110,12 @@ def test_atomic_g_year_max_exclusive_2_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2022.
@@ -15145,11 +16126,12 @@ def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2022.
@@ -15160,11 +16142,12 @@ def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2022.
@@ -15175,11 +16158,12 @@ def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2022.
@@ -15190,11 +16174,12 @@ def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 2022.
@@ -15205,11 +16190,12 @@ def test_atomic_g_year_max_exclusive_1_nistxml_sv_iv_atomic_g_year_max_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_max_exclusive_nistxml_sv_iv_atomic_g_year_max_exclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet maxExclusive with value 1971.
@@ -15220,11 +16206,12 @@ def test_atomic_g_year_max_exclusive_nistxml_sv_iv_atomic_g_year_max_exclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_4_nistxml_sv_iv_atomic_g_year_min_inclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2030.
@@ -15235,11 +16222,12 @@ def test_atomic_g_year_min_inclusive_4_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1997.
@@ -15250,11 +16238,12 @@ def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1997.
@@ -15265,11 +16254,12 @@ def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1997.
@@ -15280,11 +16270,12 @@ def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1997.
@@ -15295,11 +16286,12 @@ def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1997.
@@ -15310,11 +16302,12 @@ def test_atomic_g_year_min_inclusive_3_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1974.
@@ -15325,11 +16318,12 @@ def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1974.
@@ -15340,11 +16334,12 @@ def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1974.
@@ -15355,11 +16350,12 @@ def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1974.
@@ -15370,11 +16366,12 @@ def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1974.
@@ -15385,11 +16382,12 @@ def test_atomic_g_year_min_inclusive_2_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2010.
@@ -15400,11 +16398,12 @@ def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2010.
@@ -15415,11 +16414,12 @@ def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2010.
@@ -15430,11 +16430,12 @@ def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2010.
@@ -15445,11 +16446,12 @@ def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 2010.
@@ -15460,6 +16462,6 @@ def test_atomic_g_year_min_inclusive_1_nistxml_sv_iv_atomic_g_year_min_inclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_17000.py
+++ b/tests/test_nist_meta_17000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1970.
@@ -11,11 +14,12 @@ def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1970.
@@ -26,11 +30,12 @@ def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1970.
@@ -41,11 +46,12 @@ def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1970.
@@ -56,11 +62,12 @@ def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minInclusive with value 1970.
@@ -71,11 +78,12 @@ def test_atomic_g_year_min_inclusive_nistxml_sv_iv_atomic_g_year_min_inclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_4_nistxml_sv_iv_atomic_g_year_min_exclusive_5_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2029.
@@ -86,11 +94,12 @@ def test_atomic_g_year_min_exclusive_4_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive_4_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2012.
@@ -101,11 +110,12 @@ def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive_4_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2012.
@@ -116,11 +126,12 @@ def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive_4_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2012.
@@ -131,11 +142,12 @@ def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive_4_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2012.
@@ -146,11 +158,12 @@ def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive_4_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2012.
@@ -161,11 +174,12 @@ def test_atomic_g_year_min_exclusive_3_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive_3_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2025.
@@ -176,11 +190,12 @@ def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive_3_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2025.
@@ -191,11 +206,12 @@ def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive_3_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2025.
@@ -206,11 +222,12 @@ def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive_3_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2025.
@@ -221,11 +238,12 @@ def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive_3_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2025.
@@ -236,11 +254,12 @@ def test_atomic_g_year_min_exclusive_2_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive_2_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2008.
@@ -251,11 +270,12 @@ def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive_2_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2008.
@@ -266,11 +286,12 @@ def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive_2_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2008.
@@ -281,11 +302,12 @@ def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive_2_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2008.
@@ -296,11 +318,12 @@ def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive_2_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 2008.
@@ -311,11 +334,12 @@ def test_atomic_g_year_min_exclusive_1_nistxml_sv_iv_atomic_g_year_min_exclusive
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1_1(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1970.
@@ -326,11 +350,12 @@ def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1_2(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1970.
@@ -341,11 +366,12 @@ def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1_3(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1970.
@@ -356,11 +382,12 @@ def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1_4(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1970.
@@ -371,11 +398,12 @@ def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1_5(save_xml):
     """
     Type atomic/gYear is restricted by facet minExclusive with value 1970.
@@ -386,11 +414,12 @@ def test_atomic_g_year_min_exclusive_nistxml_sv_iv_atomic_g_year_min_exclusive_1
         instance="nistData/atomic/gYear/Schema+Instance/NISTXML-SV-IV-atomic-gYear-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white_space_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet whiteSpace with value
@@ -402,11 +431,12 @@ def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white_space_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet whiteSpace with value
@@ -418,11 +448,12 @@ def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white_space_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet whiteSpace with value
@@ -434,11 +465,12 @@ def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white_space_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet whiteSpace with value
@@ -450,11 +482,12 @@ def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white_space_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet whiteSpace with value
@@ -466,11 +499,12 @@ def test_atomic_g_year_month_white_space_nistxml_sv_iv_atomic_g_year_month_white
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enumeration_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -481,11 +515,12 @@ def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enumeration_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -496,11 +531,12 @@ def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enumeration_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -511,11 +547,12 @@ def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enumeration_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -526,11 +563,12 @@ def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enumeration_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -541,11 +579,12 @@ def test_atomic_g_year_month_enumeration_4_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enumeration_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -556,11 +595,12 @@ def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enumeration_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -571,11 +611,12 @@ def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enumeration_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -586,11 +627,12 @@ def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enumeration_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -601,11 +643,12 @@ def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enumeration_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -616,11 +659,12 @@ def test_atomic_g_year_month_enumeration_3_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enumeration_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -631,11 +675,12 @@ def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enumeration_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -646,11 +691,12 @@ def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enumeration_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -661,11 +707,12 @@ def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enumeration_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -676,11 +723,12 @@ def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enumeration_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -691,11 +739,12 @@ def test_atomic_g_year_month_enumeration_2_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enumeration_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -706,11 +755,12 @@ def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enumeration_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -721,11 +771,12 @@ def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enumeration_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -736,11 +787,12 @@ def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enumeration_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -751,11 +803,12 @@ def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enumeration_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -766,11 +819,12 @@ def test_atomic_g_year_month_enumeration_1_nistxml_sv_iv_atomic_g_year_month_enu
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enumeration_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -781,11 +835,12 @@ def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enume
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enumeration_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -796,11 +851,12 @@ def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enume
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enumeration_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -811,11 +867,12 @@ def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enume
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enumeration_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -826,11 +883,12 @@ def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enume
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enumeration_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet enumeration.
@@ -841,11 +899,12 @@ def test_atomic_g_year_month_enumeration_nistxml_sv_iv_atomic_g_year_month_enume
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern_5_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -857,11 +916,12 @@ def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern_5_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -873,11 +933,12 @@ def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern_5_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -889,11 +950,12 @@ def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern_5_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -905,11 +967,12 @@ def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern_5_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -921,11 +984,12 @@ def test_atomic_g_year_month_pattern_4_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern_4_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -937,11 +1001,12 @@ def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern_4_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -953,11 +1018,12 @@ def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern_4_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -969,11 +1035,12 @@ def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern_4_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -985,11 +1052,12 @@ def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern_4_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1001,11 +1069,12 @@ def test_atomic_g_year_month_pattern_3_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern_3_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1017,11 +1086,12 @@ def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern_3_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1033,11 +1103,12 @@ def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern_3_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1049,11 +1120,12 @@ def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern_3_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1065,11 +1137,12 @@ def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern_3_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1081,11 +1154,12 @@ def test_atomic_g_year_month_pattern_2_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern_2_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1097,11 +1171,12 @@ def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern_2_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1113,11 +1188,12 @@ def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern_2_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1129,11 +1205,12 @@ def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern_2_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1145,11 +1222,12 @@ def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern_2_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1161,11 +1239,12 @@ def test_atomic_g_year_month_pattern_1_nistxml_sv_iv_atomic_g_year_month_pattern
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1_1(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1177,11 +1256,12 @@ def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1_2(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1193,11 +1273,12 @@ def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1_3(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1209,11 +1290,12 @@ def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1_4(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1225,11 +1307,12 @@ def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1_5(save_xml):
     r"""
     Type atomic/gYearMonth is restricted by facet pattern with value
@@ -1241,11 +1324,12 @@ def test_atomic_g_year_month_pattern_nistxml_sv_iv_atomic_g_year_month_pattern_1
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_max_inclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1257,11 +1341,12 @@ def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_max_inclusive_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1273,11 +1358,12 @@ def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_max_inclusive_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1289,11 +1375,12 @@ def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_max_inclusive_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1305,11 +1392,12 @@ def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_max_inclusive_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1321,11 +1409,12 @@ def test_atomic_g_year_month_max_inclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_max_inclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1337,11 +1426,12 @@ def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_max_inclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1353,11 +1443,12 @@ def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_max_inclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1369,11 +1460,12 @@ def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_max_inclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1385,11 +1477,12 @@ def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_max_inclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1401,11 +1494,12 @@ def test_atomic_g_year_month_max_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_max_inclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1417,11 +1511,12 @@ def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_max_inclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1433,11 +1528,12 @@ def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_max_inclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1449,11 +1545,12 @@ def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_max_inclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1465,11 +1562,12 @@ def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_max_inclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1481,11 +1579,12 @@ def test_atomic_g_year_month_max_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_max_inclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1497,11 +1596,12 @@ def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_max_inclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1513,11 +1613,12 @@ def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_max_inclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1529,11 +1630,12 @@ def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_max_inclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1545,11 +1647,12 @@ def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_max_inclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1561,11 +1664,12 @@ def test_atomic_g_year_month_max_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_inclusive_nistxml_sv_iv_atomic_g_year_month_max_inclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxInclusive with value
@@ -1577,11 +1681,12 @@ def test_atomic_g_year_month_max_inclusive_nistxml_sv_iv_atomic_g_year_month_max
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_max_exclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1593,11 +1698,12 @@ def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_max_exclusive_5_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1609,11 +1715,12 @@ def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_max_exclusive_5_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1625,11 +1732,12 @@ def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_max_exclusive_5_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1641,11 +1749,12 @@ def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_max_exclusive_5_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1657,11 +1766,12 @@ def test_atomic_g_year_month_max_exclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_max_exclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1673,11 +1783,12 @@ def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_max_exclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1689,11 +1800,12 @@ def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_max_exclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1705,11 +1817,12 @@ def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_max_exclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1721,11 +1834,12 @@ def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_max_exclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1737,11 +1851,12 @@ def test_atomic_g_year_month_max_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_max_exclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1753,11 +1868,12 @@ def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_max_exclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1769,11 +1885,12 @@ def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_max_exclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1785,11 +1902,12 @@ def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_max_exclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1801,11 +1919,12 @@ def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_max_exclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1817,11 +1936,12 @@ def test_atomic_g_year_month_max_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_max_exclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1833,11 +1953,12 @@ def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_max_exclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1849,11 +1970,12 @@ def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_max_exclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1865,11 +1987,12 @@ def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_max_exclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1881,11 +2004,12 @@ def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_max_exclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1897,11 +2021,12 @@ def test_atomic_g_year_month_max_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_max_exclusive_nistxml_sv_iv_atomic_g_year_month_max_exclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet maxExclusive with value
@@ -1913,11 +2038,12 @@ def test_atomic_g_year_month_max_exclusive_nistxml_sv_iv_atomic_g_year_month_max
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_4_nistxml_sv_iv_atomic_g_year_month_min_inclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -1929,11 +2055,12 @@ def test_atomic_g_year_month_min_inclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_min_inclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -1945,11 +2072,12 @@ def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_min_inclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -1961,11 +2089,12 @@ def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_min_inclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -1977,11 +2106,12 @@ def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_min_inclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -1993,11 +2123,12 @@ def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_min_inclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2009,11 +2140,12 @@ def test_atomic_g_year_month_min_inclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_min_inclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2025,11 +2157,12 @@ def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_min_inclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2041,11 +2174,12 @@ def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_min_inclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2057,11 +2191,12 @@ def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_min_inclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2073,11 +2208,12 @@ def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_min_inclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2089,11 +2225,12 @@ def test_atomic_g_year_month_min_inclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_min_inclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2105,11 +2242,12 @@ def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_min_inclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2121,11 +2259,12 @@ def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_min_inclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2137,11 +2276,12 @@ def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_min_inclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2153,11 +2293,12 @@ def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_min_inclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2169,11 +2310,12 @@ def test_atomic_g_year_month_min_inclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min_inclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2185,11 +2327,12 @@ def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min_inclusive_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2201,11 +2344,12 @@ def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min_inclusive_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2217,11 +2361,12 @@ def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min_inclusive_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2233,11 +2378,12 @@ def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min_inclusive_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minInclusive with value
@@ -2249,11 +2395,12 @@ def test_atomic_g_year_month_min_inclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_4_nistxml_sv_iv_atomic_g_year_month_min_exclusive_5_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2265,11 +2412,12 @@ def test_atomic_g_year_month_min_exclusive_4_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_min_exclusive_4_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2281,11 +2429,12 @@ def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_min_exclusive_4_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2297,11 +2446,12 @@ def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_min_exclusive_4_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2313,11 +2463,12 @@ def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_min_exclusive_4_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2329,11 +2480,12 @@ def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_min_exclusive_4_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2345,11 +2497,12 @@ def test_atomic_g_year_month_min_exclusive_3_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_min_exclusive_3_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2361,11 +2514,12 @@ def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_min_exclusive_3_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2377,11 +2531,12 @@ def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_min_exclusive_3_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2393,11 +2548,12 @@ def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_min_exclusive_3_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2409,11 +2565,12 @@ def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_min_exclusive_3_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2425,11 +2582,12 @@ def test_atomic_g_year_month_min_exclusive_2_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_min_exclusive_2_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2441,11 +2599,12 @@ def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_min_exclusive_2_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2457,11 +2616,12 @@ def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_min_exclusive_2_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2473,11 +2633,12 @@ def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_min_exclusive_2_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2489,11 +2650,12 @@ def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_min_exclusive_2_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2505,11 +2667,12 @@ def test_atomic_g_year_month_min_exclusive_1_nistxml_sv_iv_atomic_g_year_month_m
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min_exclusive_1_1(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2521,11 +2684,12 @@ def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min_exclusive_1_2(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2537,11 +2701,12 @@ def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min_exclusive_1_3(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2553,11 +2718,12 @@ def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min_exclusive_1_4(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2569,11 +2735,12 @@ def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min_exclusive_1_5(save_xml):
     """
     Type atomic/gYearMonth is restricted by facet minExclusive with value
@@ -2585,11 +2752,12 @@ def test_atomic_g_year_month_min_exclusive_nistxml_sv_iv_atomic_g_year_month_min
         instance="nistData/atomic/gYearMonth/Schema+Instance/NISTXML-SV-IV-atomic-gYearMonth-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicGYearMonthMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_1(save_xml):
     """
     Type atomic/date is restricted by facet whiteSpace with value
@@ -2601,11 +2769,12 @@ def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_1(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_2(save_xml):
     """
     Type atomic/date is restricted by facet whiteSpace with value
@@ -2617,11 +2786,12 @@ def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_2(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_3(save_xml):
     """
     Type atomic/date is restricted by facet whiteSpace with value
@@ -2633,11 +2803,12 @@ def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_3(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_4(save_xml):
     """
     Type atomic/date is restricted by facet whiteSpace with value
@@ -2649,11 +2820,12 @@ def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_4(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_5(save_xml):
     """
     Type atomic/date is restricted by facet whiteSpace with value
@@ -2665,11 +2837,12 @@ def test_atomic_date_white_space_nistxml_sv_iv_atomic_date_white_space_1_5(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2680,11 +2853,12 @@ def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2695,11 +2869,12 @@ def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2710,11 +2885,12 @@ def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2725,11 +2901,12 @@ def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2740,11 +2917,12 @@ def test_atomic_date_enumeration_4_nistxml_sv_iv_atomic_date_enumeration_5_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2755,11 +2933,12 @@ def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2770,11 +2949,12 @@ def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2785,11 +2965,12 @@ def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2800,11 +2981,12 @@ def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2815,11 +2997,12 @@ def test_atomic_date_enumeration_3_nistxml_sv_iv_atomic_date_enumeration_4_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2830,11 +3013,12 @@ def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2845,11 +3029,12 @@ def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2860,11 +3045,12 @@ def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2875,11 +3061,12 @@ def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2890,11 +3077,12 @@ def test_atomic_date_enumeration_2_nistxml_sv_iv_atomic_date_enumeration_3_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2905,11 +3093,12 @@ def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_1(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2920,11 +3109,12 @@ def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_2(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2935,11 +3125,12 @@ def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_3(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2950,11 +3141,12 @@ def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_4(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2965,11 +3157,12 @@ def test_atomic_date_enumeration_1_nistxml_sv_iv_atomic_date_enumeration_2_5(sav
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_1(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2980,11 +3173,12 @@ def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_1(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_2(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -2995,11 +3189,12 @@ def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_2(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_3(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -3010,11 +3205,12 @@ def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_3(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_4(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -3025,11 +3221,12 @@ def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_4(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_5(save_xml):
     """
     Type atomic/date is restricted by facet enumeration.
@@ -3040,11 +3237,12 @@ def test_atomic_date_enumeration_nistxml_sv_iv_atomic_date_enumeration_1_5(save_
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3056,11 +3254,12 @@ def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3072,11 +3271,12 @@ def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3088,11 +3288,12 @@ def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3104,11 +3305,12 @@ def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3120,11 +3322,12 @@ def test_atomic_date_pattern_4_nistxml_sv_iv_atomic_date_pattern_5_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3136,11 +3339,12 @@ def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3152,11 +3356,12 @@ def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3168,11 +3373,12 @@ def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3184,11 +3390,12 @@ def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3200,11 +3407,12 @@ def test_atomic_date_pattern_3_nistxml_sv_iv_atomic_date_pattern_4_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3216,11 +3424,12 @@ def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3232,11 +3441,12 @@ def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3248,11 +3458,12 @@ def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3264,11 +3475,12 @@ def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3280,11 +3492,12 @@ def test_atomic_date_pattern_2_nistxml_sv_iv_atomic_date_pattern_3_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3296,11 +3509,12 @@ def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3312,11 +3526,12 @@ def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3328,11 +3543,12 @@ def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3344,11 +3560,12 @@ def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3360,11 +3577,12 @@ def test_atomic_date_pattern_1_nistxml_sv_iv_atomic_date_pattern_2_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_1(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3376,11 +3594,12 @@ def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_1(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_2(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3392,11 +3611,12 @@ def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_2(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_3(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3408,11 +3628,12 @@ def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_3(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_4(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3424,11 +3645,12 @@ def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_4(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_5(save_xml):
     r"""
     Type atomic/date is restricted by facet pattern with value
@@ -3440,11 +3662,12 @@ def test_atomic_date_pattern_nistxml_sv_iv_atomic_date_pattern_1_5(save_xml):
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3456,11 +3679,12 @@ def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3472,11 +3696,12 @@ def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3488,11 +3713,12 @@ def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3504,11 +3730,12 @@ def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3520,11 +3747,12 @@ def test_atomic_date_max_inclusive_4_nistxml_sv_iv_atomic_date_max_inclusive_5_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3536,11 +3764,12 @@ def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3552,11 +3781,12 @@ def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3568,11 +3798,12 @@ def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3584,11 +3815,12 @@ def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3600,11 +3832,12 @@ def test_atomic_date_max_inclusive_3_nistxml_sv_iv_atomic_date_max_inclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3616,11 +3849,12 @@ def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3632,11 +3866,12 @@ def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3648,11 +3883,12 @@ def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3664,11 +3900,12 @@ def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3680,11 +3917,12 @@ def test_atomic_date_max_inclusive_2_nistxml_sv_iv_atomic_date_max_inclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3696,11 +3934,12 @@ def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3712,11 +3951,12 @@ def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3728,11 +3968,12 @@ def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3744,11 +3985,12 @@ def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3760,11 +4002,12 @@ def test_atomic_date_max_inclusive_1_nistxml_sv_iv_atomic_date_max_inclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_inclusive_nistxml_sv_iv_atomic_date_max_inclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet maxInclusive with value
@@ -3776,11 +4019,12 @@ def test_atomic_date_max_inclusive_nistxml_sv_iv_atomic_date_max_inclusive_1_1(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3792,11 +4036,12 @@ def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3808,11 +4053,12 @@ def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3824,11 +4070,12 @@ def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3840,11 +4087,12 @@ def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3856,11 +4104,12 @@ def test_atomic_date_max_exclusive_4_nistxml_sv_iv_atomic_date_max_exclusive_5_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3872,11 +4121,12 @@ def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3888,11 +4138,12 @@ def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3904,11 +4155,12 @@ def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3920,11 +4172,12 @@ def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3936,11 +4189,12 @@ def test_atomic_date_max_exclusive_3_nistxml_sv_iv_atomic_date_max_exclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3952,11 +4206,12 @@ def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3968,11 +4223,12 @@ def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -3984,11 +4240,12 @@ def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4000,11 +4257,12 @@ def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4016,11 +4274,12 @@ def test_atomic_date_max_exclusive_2_nistxml_sv_iv_atomic_date_max_exclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4032,11 +4291,12 @@ def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4048,11 +4308,12 @@ def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4064,11 +4325,12 @@ def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4080,11 +4342,12 @@ def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4096,11 +4359,12 @@ def test_atomic_date_max_exclusive_1_nistxml_sv_iv_atomic_date_max_exclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_max_exclusive_nistxml_sv_iv_atomic_date_max_exclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet maxExclusive with value
@@ -4112,11 +4376,12 @@ def test_atomic_date_max_exclusive_nistxml_sv_iv_atomic_date_max_exclusive_1_1(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_4_nistxml_sv_iv_atomic_date_min_inclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4128,11 +4393,12 @@ def test_atomic_date_min_inclusive_4_nistxml_sv_iv_atomic_date_min_inclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4144,11 +4410,12 @@ def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4160,11 +4427,12 @@ def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4176,11 +4444,12 @@ def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4192,11 +4461,12 @@ def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4208,11 +4478,12 @@ def test_atomic_date_min_inclusive_3_nistxml_sv_iv_atomic_date_min_inclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4224,11 +4495,12 @@ def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4240,11 +4512,12 @@ def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4256,11 +4529,12 @@ def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4272,11 +4546,12 @@ def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4288,11 +4563,12 @@ def test_atomic_date_min_inclusive_2_nistxml_sv_iv_atomic_date_min_inclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4304,11 +4580,12 @@ def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4320,11 +4597,12 @@ def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4336,11 +4614,12 @@ def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4352,11 +4631,12 @@ def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4368,11 +4648,12 @@ def test_atomic_date_min_inclusive_1_nistxml_sv_iv_atomic_date_min_inclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4384,11 +4665,12 @@ def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_1(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_2(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4400,11 +4682,12 @@ def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_2(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_3(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4416,11 +4699,12 @@ def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_3(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_4(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4432,11 +4716,12 @@ def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_4(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_5(save_xml):
     """
     Type atomic/date is restricted by facet minInclusive with value
@@ -4448,11 +4733,12 @@ def test_atomic_date_min_inclusive_nistxml_sv_iv_atomic_date_min_inclusive_1_5(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_4_nistxml_sv_iv_atomic_date_min_exclusive_5_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4464,11 +4750,12 @@ def test_atomic_date_min_exclusive_4_nistxml_sv_iv_atomic_date_min_exclusive_5_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4480,11 +4767,12 @@ def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4496,11 +4784,12 @@ def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4512,11 +4801,12 @@ def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4528,11 +4818,12 @@ def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4544,11 +4835,12 @@ def test_atomic_date_min_exclusive_3_nistxml_sv_iv_atomic_date_min_exclusive_4_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4560,11 +4852,12 @@ def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4576,11 +4869,12 @@ def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4592,11 +4886,12 @@ def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4608,11 +4903,12 @@ def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4624,11 +4920,12 @@ def test_atomic_date_min_exclusive_2_nistxml_sv_iv_atomic_date_min_exclusive_3_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4640,11 +4937,12 @@ def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_1
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4656,11 +4954,12 @@ def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_2
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4672,11 +4971,12 @@ def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_3
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4688,11 +4988,12 @@ def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_4
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4704,11 +5005,12 @@ def test_atomic_date_min_exclusive_1_nistxml_sv_iv_atomic_date_min_exclusive_2_5
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_1(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4720,11 +5022,12 @@ def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_1(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_2(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4736,11 +5039,12 @@ def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_2(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_3(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4752,11 +5056,12 @@ def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_3(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_4(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4768,11 +5073,12 @@ def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_4(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_5(save_xml):
     """
     Type atomic/date is restricted by facet minExclusive with value
@@ -4784,11 +5090,12 @@ def test_atomic_date_min_exclusive_nistxml_sv_iv_atomic_date_min_exclusive_1_5(s
         instance="nistData/atomic/date/Schema+Instance/NISTXML-SV-IV-atomic-date-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_1(save_xml):
     """
     Type atomic/time is restricted by facet whiteSpace with value
@@ -4800,11 +5107,12 @@ def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_1(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_2(save_xml):
     """
     Type atomic/time is restricted by facet whiteSpace with value
@@ -4816,11 +5124,12 @@ def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_2(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_3(save_xml):
     """
     Type atomic/time is restricted by facet whiteSpace with value
@@ -4832,11 +5141,12 @@ def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_3(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_4(save_xml):
     """
     Type atomic/time is restricted by facet whiteSpace with value
@@ -4848,11 +5158,12 @@ def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_4(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_5(save_xml):
     """
     Type atomic/time is restricted by facet whiteSpace with value
@@ -4864,11 +5175,12 @@ def test_atomic_time_white_space_nistxml_sv_iv_atomic_time_white_space_1_5(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4879,11 +5191,12 @@ def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4894,11 +5207,12 @@ def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4909,11 +5223,12 @@ def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4924,11 +5239,12 @@ def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4939,11 +5255,12 @@ def test_atomic_time_enumeration_4_nistxml_sv_iv_atomic_time_enumeration_5_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4954,11 +5271,12 @@ def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4969,11 +5287,12 @@ def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4984,11 +5303,12 @@ def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -4999,11 +5319,12 @@ def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5014,11 +5335,12 @@ def test_atomic_time_enumeration_3_nistxml_sv_iv_atomic_time_enumeration_4_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5029,11 +5351,12 @@ def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5044,11 +5367,12 @@ def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5059,11 +5383,12 @@ def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5074,11 +5399,12 @@ def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5089,11 +5415,12 @@ def test_atomic_time_enumeration_2_nistxml_sv_iv_atomic_time_enumeration_3_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5104,11 +5431,12 @@ def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_1(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5119,11 +5447,12 @@ def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_2(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5134,11 +5463,12 @@ def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_3(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5149,11 +5479,12 @@ def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_4(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5164,11 +5495,12 @@ def test_atomic_time_enumeration_1_nistxml_sv_iv_atomic_time_enumeration_2_5(sav
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_1(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5179,11 +5511,12 @@ def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_1(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_2(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5194,11 +5527,12 @@ def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_2(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_3(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5209,11 +5543,12 @@ def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_3(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_4(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5224,11 +5559,12 @@ def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_4(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_5(save_xml):
     """
     Type atomic/time is restricted by facet enumeration.
@@ -5239,11 +5575,12 @@ def test_atomic_time_enumeration_nistxml_sv_iv_atomic_time_enumeration_1_5(save_
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5255,11 +5592,12 @@ def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5271,11 +5609,12 @@ def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5287,11 +5626,12 @@ def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5303,11 +5643,12 @@ def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5319,11 +5660,12 @@ def test_atomic_time_pattern_4_nistxml_sv_iv_atomic_time_pattern_5_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5335,11 +5677,12 @@ def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5351,11 +5694,12 @@ def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5367,11 +5711,12 @@ def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5383,11 +5728,12 @@ def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5399,11 +5745,12 @@ def test_atomic_time_pattern_3_nistxml_sv_iv_atomic_time_pattern_4_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5415,11 +5762,12 @@ def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5431,11 +5779,12 @@ def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5447,11 +5796,12 @@ def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5463,11 +5813,12 @@ def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5479,11 +5830,12 @@ def test_atomic_time_pattern_2_nistxml_sv_iv_atomic_time_pattern_3_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5495,11 +5847,12 @@ def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5511,11 +5864,12 @@ def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5527,11 +5881,12 @@ def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5543,11 +5898,12 @@ def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5559,11 +5915,12 @@ def test_atomic_time_pattern_1_nistxml_sv_iv_atomic_time_pattern_2_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_1(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5575,11 +5932,12 @@ def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_1(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_2(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5591,11 +5949,12 @@ def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_2(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_3(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5607,11 +5966,12 @@ def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_3(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_4(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5623,11 +5983,12 @@ def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_4(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_5(save_xml):
     r"""
     Type atomic/time is restricted by facet pattern with value
@@ -5639,11 +6000,12 @@ def test_atomic_time_pattern_nistxml_sv_iv_atomic_time_pattern_1_5(save_xml):
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5655,11 +6017,12 @@ def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5671,11 +6034,12 @@ def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5687,11 +6051,12 @@ def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5703,11 +6068,12 @@ def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5719,11 +6085,12 @@ def test_atomic_time_max_inclusive_4_nistxml_sv_iv_atomic_time_max_inclusive_5_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5735,11 +6102,12 @@ def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5751,11 +6119,12 @@ def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5767,11 +6136,12 @@ def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5783,11 +6153,12 @@ def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5799,11 +6170,12 @@ def test_atomic_time_max_inclusive_3_nistxml_sv_iv_atomic_time_max_inclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5815,11 +6187,12 @@ def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5831,11 +6204,12 @@ def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5847,11 +6221,12 @@ def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5863,11 +6238,12 @@ def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5879,11 +6255,12 @@ def test_atomic_time_max_inclusive_2_nistxml_sv_iv_atomic_time_max_inclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5895,11 +6272,12 @@ def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5911,11 +6289,12 @@ def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5927,11 +6306,12 @@ def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5943,11 +6323,12 @@ def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5959,11 +6340,12 @@ def test_atomic_time_max_inclusive_1_nistxml_sv_iv_atomic_time_max_inclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_inclusive_nistxml_sv_iv_atomic_time_max_inclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet maxInclusive with value
@@ -5975,11 +6357,12 @@ def test_atomic_time_max_inclusive_nistxml_sv_iv_atomic_time_max_inclusive_1_1(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -5991,11 +6374,12 @@ def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6007,11 +6391,12 @@ def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6023,11 +6408,12 @@ def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6039,11 +6425,12 @@ def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6055,11 +6442,12 @@ def test_atomic_time_max_exclusive_4_nistxml_sv_iv_atomic_time_max_exclusive_5_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6071,11 +6459,12 @@ def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6087,11 +6476,12 @@ def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6103,11 +6493,12 @@ def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6119,11 +6510,12 @@ def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6135,11 +6527,12 @@ def test_atomic_time_max_exclusive_3_nistxml_sv_iv_atomic_time_max_exclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6151,11 +6544,12 @@ def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6167,11 +6561,12 @@ def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6183,11 +6578,12 @@ def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6199,11 +6595,12 @@ def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6215,11 +6612,12 @@ def test_atomic_time_max_exclusive_2_nistxml_sv_iv_atomic_time_max_exclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6231,11 +6629,12 @@ def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6247,11 +6646,12 @@ def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6263,11 +6663,12 @@ def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6279,11 +6680,12 @@ def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6295,11 +6697,12 @@ def test_atomic_time_max_exclusive_1_nistxml_sv_iv_atomic_time_max_exclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_max_exclusive_nistxml_sv_iv_atomic_time_max_exclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet maxExclusive with value
@@ -6311,11 +6714,12 @@ def test_atomic_time_max_exclusive_nistxml_sv_iv_atomic_time_max_exclusive_1_1(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_4_nistxml_sv_iv_atomic_time_min_inclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6327,11 +6731,12 @@ def test_atomic_time_min_inclusive_4_nistxml_sv_iv_atomic_time_min_inclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6343,11 +6748,12 @@ def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6359,11 +6765,12 @@ def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6375,11 +6782,12 @@ def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6391,11 +6799,12 @@ def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6407,11 +6816,12 @@ def test_atomic_time_min_inclusive_3_nistxml_sv_iv_atomic_time_min_inclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6423,11 +6833,12 @@ def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6439,11 +6850,12 @@ def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6455,11 +6867,12 @@ def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6471,11 +6884,12 @@ def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6487,11 +6901,12 @@ def test_atomic_time_min_inclusive_2_nistxml_sv_iv_atomic_time_min_inclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6503,11 +6918,12 @@ def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6519,11 +6935,12 @@ def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6535,11 +6952,12 @@ def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6551,11 +6969,12 @@ def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6567,11 +6986,12 @@ def test_atomic_time_min_inclusive_1_nistxml_sv_iv_atomic_time_min_inclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6583,11 +7003,12 @@ def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_1(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_2(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6599,11 +7020,12 @@ def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_2(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_3(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6615,11 +7037,12 @@ def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_3(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_4(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6631,11 +7054,12 @@ def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_4(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_5(save_xml):
     """
     Type atomic/time is restricted by facet minInclusive with value
@@ -6647,11 +7071,12 @@ def test_atomic_time_min_inclusive_nistxml_sv_iv_atomic_time_min_inclusive_1_5(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_4_nistxml_sv_iv_atomic_time_min_exclusive_5_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6663,11 +7088,12 @@ def test_atomic_time_min_exclusive_4_nistxml_sv_iv_atomic_time_min_exclusive_5_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6679,11 +7105,12 @@ def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6695,11 +7122,12 @@ def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6711,11 +7139,12 @@ def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6727,11 +7156,12 @@ def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6743,11 +7173,12 @@ def test_atomic_time_min_exclusive_3_nistxml_sv_iv_atomic_time_min_exclusive_4_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6759,11 +7190,12 @@ def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6775,11 +7207,12 @@ def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6791,11 +7224,12 @@ def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6807,11 +7241,12 @@ def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6823,11 +7258,12 @@ def test_atomic_time_min_exclusive_2_nistxml_sv_iv_atomic_time_min_exclusive_3_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6839,11 +7275,12 @@ def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_1
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6855,11 +7292,12 @@ def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_2
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6871,11 +7309,12 @@ def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_3
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6887,11 +7326,12 @@ def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_4
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6903,11 +7343,12 @@ def test_atomic_time_min_exclusive_1_nistxml_sv_iv_atomic_time_min_exclusive_2_5
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_1(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6919,11 +7360,12 @@ def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_1(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_2(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6935,11 +7377,12 @@ def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_2(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_3(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6951,11 +7394,12 @@ def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_3(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_4(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6967,11 +7411,12 @@ def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_4(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_5(save_xml):
     """
     Type atomic/time is restricted by facet minExclusive with value
@@ -6983,11 +7428,12 @@ def test_atomic_time_min_exclusive_nistxml_sv_iv_atomic_time_min_exclusive_1_5(s
         instance="nistData/atomic/time/Schema+Instance/NISTXML-SV-IV-atomic-time-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet whiteSpace with value
@@ -6999,11 +7445,12 @@ def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet whiteSpace with value
@@ -7015,11 +7462,12 @@ def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet whiteSpace with value
@@ -7031,11 +7479,12 @@ def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet whiteSpace with value
@@ -7047,11 +7496,12 @@ def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet whiteSpace with value
@@ -7063,11 +7513,12 @@ def test_atomic_date_time_white_space_nistxml_sv_iv_atomic_date_time_white_space
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumeration_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7078,11 +7529,12 @@ def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumeration_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7093,11 +7545,12 @@ def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumeration_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7108,11 +7561,12 @@ def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumeration_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7123,11 +7577,12 @@ def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumeration_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7138,11 +7593,12 @@ def test_atomic_date_time_enumeration_4_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumeration_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7153,11 +7609,12 @@ def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumeration_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7168,11 +7625,12 @@ def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumeration_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7183,11 +7641,12 @@ def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumeration_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7198,11 +7657,12 @@ def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumeration_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7213,11 +7673,12 @@ def test_atomic_date_time_enumeration_3_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumeration_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7228,11 +7689,12 @@ def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumeration_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7243,11 +7705,12 @@ def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumeration_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7258,11 +7721,12 @@ def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumeration_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7273,11 +7737,12 @@ def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumeration_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7288,11 +7753,12 @@ def test_atomic_date_time_enumeration_2_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumeration_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7303,11 +7769,12 @@ def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumeration_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7318,11 +7785,12 @@ def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumeration_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7333,11 +7801,12 @@ def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumeration_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7348,11 +7817,12 @@ def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumeration_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7363,11 +7833,12 @@ def test_atomic_date_time_enumeration_1_nistxml_sv_iv_atomic_date_time_enumerati
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7378,11 +7849,12 @@ def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7393,11 +7865,12 @@ def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7408,11 +7881,12 @@ def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7423,11 +7897,12 @@ def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet enumeration.
@@ -7438,11 +7913,12 @@ def test_atomic_date_time_enumeration_nistxml_sv_iv_atomic_date_time_enumeration
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7454,11 +7930,12 @@ def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7470,11 +7947,12 @@ def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7486,11 +7964,12 @@ def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7502,11 +7981,12 @@ def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7518,11 +7998,12 @@ def test_atomic_date_time_pattern_4_nistxml_sv_iv_atomic_date_time_pattern_5_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7534,11 +8015,12 @@ def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7550,11 +8032,12 @@ def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7566,11 +8049,12 @@ def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7582,11 +8066,12 @@ def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7598,11 +8083,12 @@ def test_atomic_date_time_pattern_3_nistxml_sv_iv_atomic_date_time_pattern_4_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7614,11 +8100,12 @@ def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7630,11 +8117,12 @@ def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7646,11 +8134,12 @@ def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7662,11 +8151,12 @@ def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7678,11 +8168,12 @@ def test_atomic_date_time_pattern_2_nistxml_sv_iv_atomic_date_time_pattern_3_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7694,11 +8185,12 @@ def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_1(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7710,11 +8202,12 @@ def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_2(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7726,11 +8219,12 @@ def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_3(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7742,11 +8236,12 @@ def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_4(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7758,11 +8253,12 @@ def test_atomic_date_time_pattern_1_nistxml_sv_iv_atomic_date_time_pattern_2_5(s
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_1(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7774,11 +8270,12 @@ def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_1(sav
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_2(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7790,11 +8287,12 @@ def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_2(sav
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_3(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7806,11 +8304,12 @@ def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_3(sav
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_4(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7822,11 +8321,12 @@ def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_4(sav
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_5(save_xml):
     r"""
     Type atomic/dateTime is restricted by facet pattern with value
@@ -7838,11 +8338,12 @@ def test_atomic_date_time_pattern_nistxml_sv_iv_atomic_date_time_pattern_1_5(sav
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7854,11 +8355,12 @@ def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inclusive_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7870,11 +8372,12 @@ def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inclusive_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7886,11 +8389,12 @@ def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inclusive_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7902,11 +8406,12 @@ def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inclusive_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7918,11 +8423,12 @@ def test_atomic_date_time_max_inclusive_4_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7934,11 +8440,12 @@ def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7950,11 +8457,12 @@ def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7966,11 +8474,12 @@ def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7982,11 +8491,12 @@ def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -7998,11 +8508,12 @@ def test_atomic_date_time_max_inclusive_3_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8014,11 +8525,12 @@ def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8030,11 +8542,12 @@ def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8046,11 +8559,12 @@ def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8062,11 +8576,12 @@ def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8078,11 +8593,12 @@ def test_atomic_date_time_max_inclusive_2_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8094,11 +8610,12 @@ def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8110,11 +8627,12 @@ def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8126,11 +8644,12 @@ def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8142,11 +8661,12 @@ def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8158,11 +8678,12 @@ def test_atomic_date_time_max_inclusive_1_nistxml_sv_iv_atomic_date_time_max_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_inclusive_nistxml_sv_iv_atomic_date_time_max_inclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxInclusive with value
@@ -8174,11 +8695,12 @@ def test_atomic_date_time_max_inclusive_nistxml_sv_iv_atomic_date_time_max_inclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8190,11 +8712,12 @@ def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exclusive_5_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8206,11 +8729,12 @@ def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exclusive_5_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8222,11 +8746,12 @@ def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exclusive_5_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8238,11 +8763,12 @@ def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exclusive_5_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8254,11 +8780,12 @@ def test_atomic_date_time_max_exclusive_4_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8270,11 +8797,12 @@ def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8286,11 +8814,12 @@ def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8302,11 +8831,12 @@ def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8318,11 +8848,12 @@ def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8334,11 +8865,12 @@ def test_atomic_date_time_max_exclusive_3_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8350,11 +8882,12 @@ def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8366,11 +8899,12 @@ def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8382,11 +8916,12 @@ def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8398,11 +8933,12 @@ def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8414,11 +8950,12 @@ def test_atomic_date_time_max_exclusive_2_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8430,11 +8967,12 @@ def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8446,11 +8984,12 @@ def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8462,11 +9001,12 @@ def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8478,11 +9018,12 @@ def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8494,11 +9035,12 @@ def test_atomic_date_time_max_exclusive_1_nistxml_sv_iv_atomic_date_time_max_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_max_exclusive_nistxml_sv_iv_atomic_date_time_max_exclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet maxExclusive with value
@@ -8510,11 +9052,12 @@ def test_atomic_date_time_max_exclusive_nistxml_sv_iv_atomic_date_time_max_exclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_4_nistxml_sv_iv_atomic_date_time_min_inclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8526,11 +9069,12 @@ def test_atomic_date_time_min_inclusive_4_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8542,11 +9086,12 @@ def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8558,11 +9103,12 @@ def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8574,11 +9120,12 @@ def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8590,11 +9137,12 @@ def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8606,11 +9154,12 @@ def test_atomic_date_time_min_inclusive_3_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8622,11 +9171,12 @@ def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8638,11 +9188,12 @@ def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8654,11 +9205,12 @@ def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8670,11 +9222,12 @@ def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8686,11 +9239,12 @@ def test_atomic_date_time_min_inclusive_2_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8702,11 +9256,12 @@ def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8718,11 +9273,12 @@ def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8734,11 +9290,12 @@ def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8750,11 +9307,12 @@ def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8766,11 +9324,12 @@ def test_atomic_date_time_min_inclusive_1_nistxml_sv_iv_atomic_date_time_min_inc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8782,11 +9341,12 @@ def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclusive_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8798,11 +9358,12 @@ def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclusive_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8814,11 +9375,12 @@ def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclusive_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8830,11 +9392,12 @@ def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclusive_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minInclusive with value
@@ -8846,11 +9409,12 @@ def test_atomic_date_time_min_inclusive_nistxml_sv_iv_atomic_date_time_min_inclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_4_nistxml_sv_iv_atomic_date_time_min_exclusive_5_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8862,11 +9426,12 @@ def test_atomic_date_time_min_exclusive_4_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exclusive_4_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8878,11 +9443,12 @@ def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exclusive_4_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8894,11 +9460,12 @@ def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exclusive_4_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8910,11 +9477,12 @@ def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exclusive_4_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8926,11 +9494,12 @@ def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exclusive_4_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8942,11 +9511,12 @@ def test_atomic_date_time_min_exclusive_3_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exclusive_3_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8958,11 +9528,12 @@ def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exclusive_3_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8974,11 +9545,12 @@ def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exclusive_3_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -8990,11 +9562,12 @@ def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exclusive_3_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9006,11 +9579,12 @@ def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exclusive_3_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9022,11 +9596,12 @@ def test_atomic_date_time_min_exclusive_2_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exclusive_2_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9038,11 +9613,12 @@ def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exclusive_2_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9054,11 +9630,12 @@ def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exclusive_2_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9070,11 +9647,12 @@ def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exclusive_2_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9086,11 +9664,12 @@ def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exclusive_2_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9102,11 +9681,12 @@ def test_atomic_date_time_min_exclusive_1_nistxml_sv_iv_atomic_date_time_min_exc
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclusive_1_1(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9118,11 +9698,12 @@ def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclusive_1_2(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9134,11 +9715,12 @@ def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclusive_1_3(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9150,11 +9732,12 @@ def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclusive_1_4(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9166,11 +9749,12 @@ def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclusive_1_5(save_xml):
     """
     Type atomic/dateTime is restricted by facet minExclusive with value
@@ -9182,11 +9766,12 @@ def test_atomic_date_time_min_exclusive_nistxml_sv_iv_atomic_date_time_min_exclu
         instance="nistData/atomic/dateTime/Schema+Instance/NISTXML-SV-IV-atomic-dateTime-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDateTimeMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet whiteSpace with value
@@ -9198,11 +9783,12 @@ def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet whiteSpace with value
@@ -9214,11 +9800,12 @@ def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet whiteSpace with value
@@ -9230,11 +9817,12 @@ def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet whiteSpace with value
@@ -9246,11 +9834,12 @@ def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet whiteSpace with value
@@ -9262,11 +9851,12 @@ def test_atomic_duration_white_space_nistxml_sv_iv_atomic_duration_white_space_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9277,11 +9867,12 @@ def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9292,11 +9883,12 @@ def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9307,11 +9899,12 @@ def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9322,11 +9915,12 @@ def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9337,11 +9931,12 @@ def test_atomic_duration_enumeration_4_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9352,11 +9947,12 @@ def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9367,11 +9963,12 @@ def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9382,11 +9979,12 @@ def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9397,11 +9995,12 @@ def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9412,11 +10011,12 @@ def test_atomic_duration_enumeration_3_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9427,11 +10027,12 @@ def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9442,11 +10043,12 @@ def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9457,11 +10059,12 @@ def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9472,11 +10075,12 @@ def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9487,11 +10091,12 @@ def test_atomic_duration_enumeration_2_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9502,11 +10107,12 @@ def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9517,11 +10123,12 @@ def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9532,11 +10139,12 @@ def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9547,11 +10155,12 @@ def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9562,11 +10171,12 @@ def test_atomic_duration_enumeration_1_nistxml_sv_iv_atomic_duration_enumeration
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9577,11 +10187,12 @@ def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9592,11 +10203,12 @@ def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9607,11 +10219,12 @@ def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9622,11 +10235,12 @@ def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet enumeration.
@@ -9637,11 +10251,12 @@ def test_atomic_duration_enumeration_nistxml_sv_iv_atomic_duration_enumeration_1
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9653,11 +10268,12 @@ def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9669,11 +10285,12 @@ def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9685,11 +10302,12 @@ def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9701,11 +10319,12 @@ def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9717,11 +10336,12 @@ def test_atomic_duration_pattern_4_nistxml_sv_iv_atomic_duration_pattern_5_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9733,11 +10353,12 @@ def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9749,11 +10370,12 @@ def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9765,11 +10387,12 @@ def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9781,11 +10404,12 @@ def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9797,11 +10421,12 @@ def test_atomic_duration_pattern_3_nistxml_sv_iv_atomic_duration_pattern_4_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9813,11 +10438,12 @@ def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9829,11 +10455,12 @@ def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9845,11 +10472,12 @@ def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9861,11 +10489,12 @@ def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9877,11 +10506,12 @@ def test_atomic_duration_pattern_2_nistxml_sv_iv_atomic_duration_pattern_3_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9893,11 +10523,12 @@ def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_1(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9909,11 +10540,12 @@ def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_2(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9925,11 +10557,12 @@ def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_3(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9941,11 +10574,12 @@ def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_4(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9957,11 +10591,12 @@ def test_atomic_duration_pattern_1_nistxml_sv_iv_atomic_duration_pattern_2_5(sav
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_1(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9973,11 +10608,12 @@ def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_1(save_
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_2(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -9989,11 +10625,12 @@ def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_2(save_
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_3(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -10005,11 +10642,12 @@ def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_3(save_
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_4(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -10021,11 +10659,12 @@ def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_4(save_
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_5(save_xml):
     r"""
     Type atomic/duration is restricted by facet pattern with value
@@ -10037,11 +10676,12 @@ def test_atomic_duration_pattern_nistxml_sv_iv_atomic_duration_pattern_1_5(save_
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10053,11 +10693,12 @@ def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclusive_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10069,11 +10710,12 @@ def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclusive_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10085,11 +10727,12 @@ def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclusive_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10101,11 +10744,12 @@ def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclusive_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10117,11 +10761,12 @@ def test_atomic_duration_max_inclusive_4_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10133,11 +10778,12 @@ def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10149,11 +10795,12 @@ def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10165,11 +10812,12 @@ def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10181,11 +10829,12 @@ def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10197,11 +10846,12 @@ def test_atomic_duration_max_inclusive_3_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10213,11 +10863,12 @@ def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10229,11 +10880,12 @@ def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10245,11 +10897,12 @@ def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10261,11 +10914,12 @@ def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10277,11 +10931,12 @@ def test_atomic_duration_max_inclusive_2_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10293,11 +10948,12 @@ def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10309,11 +10965,12 @@ def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10325,11 +10982,12 @@ def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10341,11 +10999,12 @@ def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10357,11 +11016,12 @@ def test_atomic_duration_max_inclusive_1_nistxml_sv_iv_atomic_duration_max_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_inclusive_nistxml_sv_iv_atomic_duration_max_inclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxInclusive with value
@@ -10373,11 +11033,12 @@ def test_atomic_duration_max_inclusive_nistxml_sv_iv_atomic_duration_max_inclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10389,11 +11050,12 @@ def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclusive_5_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10405,11 +11067,12 @@ def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclusive_5_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10421,11 +11084,12 @@ def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclusive_5_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10437,11 +11101,12 @@ def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclusive_5_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10453,11 +11118,12 @@ def test_atomic_duration_max_exclusive_4_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10469,11 +11135,12 @@ def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10485,11 +11152,12 @@ def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10501,11 +11169,12 @@ def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10517,11 +11186,12 @@ def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10533,11 +11203,12 @@ def test_atomic_duration_max_exclusive_3_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10549,11 +11220,12 @@ def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10565,11 +11237,12 @@ def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10581,11 +11254,12 @@ def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10597,11 +11271,12 @@ def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10613,11 +11288,12 @@ def test_atomic_duration_max_exclusive_2_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10629,11 +11305,12 @@ def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10645,11 +11322,12 @@ def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10661,11 +11339,12 @@ def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10677,11 +11356,12 @@ def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10693,11 +11373,12 @@ def test_atomic_duration_max_exclusive_1_nistxml_sv_iv_atomic_duration_max_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_max_exclusive_nistxml_sv_iv_atomic_duration_max_exclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet maxExclusive with value
@@ -10709,11 +11390,12 @@ def test_atomic_duration_max_exclusive_nistxml_sv_iv_atomic_duration_max_exclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_4_nistxml_sv_iv_atomic_duration_min_inclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10725,11 +11407,12 @@ def test_atomic_duration_min_inclusive_4_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10741,11 +11424,12 @@ def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10757,11 +11441,12 @@ def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10773,11 +11458,12 @@ def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10789,11 +11475,12 @@ def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10805,11 +11492,12 @@ def test_atomic_duration_min_inclusive_3_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10821,11 +11509,12 @@ def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10837,11 +11526,12 @@ def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10853,11 +11543,12 @@ def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10869,11 +11560,12 @@ def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10885,11 +11577,12 @@ def test_atomic_duration_min_inclusive_2_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10901,11 +11594,12 @@ def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10917,11 +11611,12 @@ def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10933,11 +11628,12 @@ def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10949,11 +11645,12 @@ def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10965,11 +11662,12 @@ def test_atomic_duration_min_inclusive_1_nistxml_sv_iv_atomic_duration_min_inclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10981,11 +11679,12 @@ def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusive_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -10997,11 +11696,12 @@ def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusive_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11013,11 +11713,12 @@ def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusive_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11029,11 +11730,12 @@ def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusive_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet minInclusive with value
@@ -11045,11 +11747,12 @@ def test_atomic_duration_min_inclusive_nistxml_sv_iv_atomic_duration_min_inclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_4_nistxml_sv_iv_atomic_duration_min_exclusive_5_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11061,11 +11764,12 @@ def test_atomic_duration_min_exclusive_4_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclusive_4_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11077,11 +11781,12 @@ def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclusive_4_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11093,11 +11798,12 @@ def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclusive_4_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11109,11 +11815,12 @@ def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclusive_4_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11125,11 +11832,12 @@ def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclusive_4_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11141,11 +11849,12 @@ def test_atomic_duration_min_exclusive_3_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclusive_3_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11157,11 +11866,12 @@ def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclusive_3_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11173,11 +11883,12 @@ def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclusive_3_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11189,11 +11900,12 @@ def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclusive_3_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11205,11 +11917,12 @@ def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclusive_3_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11221,11 +11934,12 @@ def test_atomic_duration_min_exclusive_2_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclusive_2_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11237,11 +11951,12 @@ def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclusive_2_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11253,11 +11968,12 @@ def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclusive_2_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11269,11 +11985,12 @@ def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclusive_2_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11285,11 +12002,12 @@ def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclusive_2_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11301,11 +12019,12 @@ def test_atomic_duration_min_exclusive_1_nistxml_sv_iv_atomic_duration_min_exclu
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusive_1_1(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11317,11 +12036,12 @@ def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusive_1_2(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11333,11 +12053,12 @@ def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusive_1_3(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11349,11 +12070,12 @@ def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusive_1_4(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11365,11 +12087,12 @@ def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusive_1_5(save_xml):
     """
     Type atomic/duration is restricted by facet minExclusive with value
@@ -11381,11 +12104,12 @@ def test_atomic_duration_min_exclusive_nistxml_sv_iv_atomic_duration_min_exclusi
         instance="nistData/atomic/duration/Schema+Instance/NISTXML-SV-IV-atomic-duration-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDurationMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_1(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11397,11 +12121,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_1(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_2(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11413,11 +12138,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_2(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_3(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11429,11 +12155,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_3(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_4(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11445,11 +12172,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_4(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_5(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11461,11 +12189,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_5(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_6(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11477,11 +12206,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_6(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-6.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_7(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11493,11 +12223,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_7(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-7.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_8(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11509,11 +12240,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_8(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-8.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_9(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11525,11 +12257,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_9(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-9.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_10(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11541,11 +12274,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_10(sa
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-10.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_11(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11557,11 +12291,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_11(sa
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-11.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_12(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11573,11 +12308,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_12(sa
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-12.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_13(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11589,11 +12325,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_13(sa
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-13.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_14(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11605,11 +12342,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_14(sa
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-14.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_15(save_xml):
     """
     Type atomic/float is restricted by facet whiteSpace with value
@@ -11621,11 +12359,12 @@ def test_atomic_float_white_space_nistxml_sv_iv_atomic_float_white_space_1_15(sa
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-whiteSpace-1-15.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11636,11 +12375,12 @@ def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11651,11 +12391,12 @@ def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11666,11 +12407,12 @@ def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11681,11 +12423,12 @@ def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11696,11 +12439,12 @@ def test_atomic_float_enumeration_4_nistxml_sv_iv_atomic_float_enumeration_5_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11711,11 +12455,12 @@ def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11726,11 +12471,12 @@ def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11741,11 +12487,12 @@ def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11756,11 +12503,12 @@ def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11771,11 +12519,12 @@ def test_atomic_float_enumeration_3_nistxml_sv_iv_atomic_float_enumeration_4_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11786,11 +12535,12 @@ def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11801,11 +12551,12 @@ def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11816,11 +12567,12 @@ def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11831,11 +12583,12 @@ def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11846,11 +12599,12 @@ def test_atomic_float_enumeration_2_nistxml_sv_iv_atomic_float_enumeration_3_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11861,11 +12615,12 @@ def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_1(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11876,11 +12631,12 @@ def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_2(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11891,11 +12647,12 @@ def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_3(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11906,11 +12663,12 @@ def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_4(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11921,11 +12679,12 @@ def test_atomic_float_enumeration_1_nistxml_sv_iv_atomic_float_enumeration_2_5(s
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_1(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11936,11 +12695,12 @@ def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_1(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_2(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11951,11 +12711,12 @@ def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_2(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_3(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11966,11 +12727,12 @@ def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_3(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_4(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11981,11 +12743,12 @@ def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_4(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_5(save_xml):
     """
     Type atomic/float is restricted by facet enumeration.
@@ -11996,11 +12759,12 @@ def test_atomic_float_enumeration_nistxml_sv_iv_atomic_float_enumeration_1_5(sav
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12012,11 +12776,12 @@ def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12028,11 +12793,12 @@ def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12044,11 +12810,12 @@ def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12060,11 +12827,12 @@ def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12076,11 +12844,12 @@ def test_atomic_float_pattern_4_nistxml_sv_iv_atomic_float_pattern_5_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12092,11 +12861,12 @@ def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12108,11 +12878,12 @@ def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12124,11 +12895,12 @@ def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12140,11 +12912,12 @@ def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12156,11 +12929,12 @@ def test_atomic_float_pattern_3_nistxml_sv_iv_atomic_float_pattern_4_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12172,11 +12946,12 @@ def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12188,11 +12963,12 @@ def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12204,11 +12980,12 @@ def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12220,11 +12997,12 @@ def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12236,11 +13014,12 @@ def test_atomic_float_pattern_2_nistxml_sv_iv_atomic_float_pattern_3_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12252,11 +13031,12 @@ def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_1(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12268,11 +13048,12 @@ def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_2(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12284,11 +13065,12 @@ def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_3(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12300,11 +13082,12 @@ def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_4(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12316,11 +13099,12 @@ def test_atomic_float_pattern_1_nistxml_sv_iv_atomic_float_pattern_2_5(save_xml)
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_1(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12332,11 +13116,12 @@ def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_1(save_xml):
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_2(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12348,11 +13133,12 @@ def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_2(save_xml):
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_3(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12364,11 +13150,12 @@ def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_3(save_xml):
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_4(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12380,11 +13167,12 @@ def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_4(save_xml):
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_5(save_xml):
     r"""
     Type atomic/float is restricted by facet pattern with value
@@ -12396,11 +13184,12 @@ def test_atomic_float_pattern_nistxml_sv_iv_atomic_float_pattern_1_5(save_xml):
         instance="nistData/atomic/float/Schema+Instance/NISTXML-SV-IV-atomic-float-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_1(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12412,11 +13201,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_1(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_2(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12428,11 +13218,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_2(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_3(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12444,11 +13235,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_3(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_4(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12460,11 +13252,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_4(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_5(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12476,11 +13269,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_5(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_6(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12492,11 +13286,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_6(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-6.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_7(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12508,11 +13303,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_7(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-7.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_8(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12524,11 +13320,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_8(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-8.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_9(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12540,11 +13337,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_9(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-9.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_10(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12556,11 +13354,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_10(
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-10.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_11(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12572,11 +13371,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_11(
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-11.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_12(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12588,11 +13388,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_12(
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-12.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_13(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12604,11 +13405,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_13(
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-13.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_14(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12620,11 +13422,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_14(
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-14.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_15(save_xml):
     """
     Type atomic/double is restricted by facet whiteSpace with value
@@ -12636,11 +13439,12 @@ def test_atomic_double_white_space_nistxml_sv_iv_atomic_double_white_space_1_15(
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-whiteSpace-1-15.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12651,11 +13455,12 @@ def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12666,11 +13471,12 @@ def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12681,11 +13487,12 @@ def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12696,11 +13503,12 @@ def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12711,11 +13519,12 @@ def test_atomic_double_enumeration_4_nistxml_sv_iv_atomic_double_enumeration_5_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12726,11 +13535,12 @@ def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12741,11 +13551,12 @@ def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12756,11 +13567,12 @@ def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12771,11 +13583,12 @@ def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12786,11 +13599,12 @@ def test_atomic_double_enumeration_3_nistxml_sv_iv_atomic_double_enumeration_4_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12801,11 +13615,12 @@ def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12816,11 +13631,12 @@ def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12831,11 +13647,12 @@ def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12846,11 +13663,12 @@ def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12861,11 +13679,12 @@ def test_atomic_double_enumeration_2_nistxml_sv_iv_atomic_double_enumeration_3_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12876,11 +13695,12 @@ def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_1
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12891,11 +13711,12 @@ def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_2
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12906,11 +13727,12 @@ def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_3
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12921,11 +13743,12 @@ def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_4
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12936,11 +13759,12 @@ def test_atomic_double_enumeration_1_nistxml_sv_iv_atomic_double_enumeration_2_5
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_1(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12951,11 +13775,12 @@ def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_1(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_2(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12966,11 +13791,12 @@ def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_2(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_3(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12981,11 +13807,12 @@ def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_3(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_4(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -12996,11 +13823,12 @@ def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_4(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_5(save_xml):
     """
     Type atomic/double is restricted by facet enumeration.
@@ -13011,11 +13839,12 @@ def test_atomic_double_enumeration_nistxml_sv_iv_atomic_double_enumeration_1_5(s
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13027,11 +13856,12 @@ def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13043,11 +13873,12 @@ def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13059,11 +13890,12 @@ def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13075,11 +13907,12 @@ def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13091,11 +13924,12 @@ def test_atomic_double_pattern_4_nistxml_sv_iv_atomic_double_pattern_5_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13107,11 +13941,12 @@ def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13123,11 +13958,12 @@ def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13139,11 +13975,12 @@ def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13155,11 +13992,12 @@ def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13171,11 +14009,12 @@ def test_atomic_double_pattern_3_nistxml_sv_iv_atomic_double_pattern_4_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13187,11 +14026,12 @@ def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13203,11 +14043,12 @@ def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13219,11 +14060,12 @@ def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13235,11 +14077,12 @@ def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13251,11 +14094,12 @@ def test_atomic_double_pattern_2_nistxml_sv_iv_atomic_double_pattern_3_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13267,11 +14111,12 @@ def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_1(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13283,11 +14128,12 @@ def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_2(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13299,11 +14145,12 @@ def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_3(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13315,11 +14162,12 @@ def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_4(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13331,11 +14179,12 @@ def test_atomic_double_pattern_1_nistxml_sv_iv_atomic_double_pattern_2_5(save_xm
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_1(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13347,11 +14196,12 @@ def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_1(save_xml)
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_2(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13363,11 +14213,12 @@ def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_2(save_xml)
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_3(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13379,11 +14230,12 @@ def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_3(save_xml)
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_4(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13395,11 +14247,12 @@ def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_4(save_xml)
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_5(save_xml):
     r"""
     Type atomic/double is restricted by facet pattern with value
@@ -13411,11 +14264,12 @@ def test_atomic_double_pattern_nistxml_sv_iv_atomic_double_pattern_1_5(save_xml)
         instance="nistData/atomic/double/Schema+Instance/NISTXML-SV-IV-atomic-double-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integer_white_space_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet whiteSpace with
@@ -13427,11 +14281,12 @@ def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integer_white_space_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet whiteSpace with
@@ -13443,11 +14298,12 @@ def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integer_white_space_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet whiteSpace with
@@ -13459,11 +14315,12 @@ def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integer_white_space_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet whiteSpace with
@@ -13475,11 +14332,12 @@ def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integer_white_space_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet whiteSpace with
@@ -13491,11 +14349,12 @@ def test_atomic_positive_integer_white_space_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_integer_enumeration_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13506,11 +14365,12 @@ def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_integer_enumeration_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13521,11 +14381,12 @@ def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_integer_enumeration_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13536,11 +14397,12 @@ def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_integer_enumeration_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13551,11 +14413,12 @@ def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_integer_enumeration_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13566,11 +14429,12 @@ def test_atomic_positive_integer_enumeration_4_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_integer_enumeration_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13581,11 +14445,12 @@ def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_integer_enumeration_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13596,11 +14461,12 @@ def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_integer_enumeration_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13611,11 +14477,12 @@ def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_integer_enumeration_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13626,11 +14493,12 @@ def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_integer_enumeration_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13641,11 +14509,12 @@ def test_atomic_positive_integer_enumeration_3_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_integer_enumeration_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13656,11 +14525,12 @@ def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_integer_enumeration_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13671,11 +14541,12 @@ def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_integer_enumeration_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13686,11 +14557,12 @@ def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_integer_enumeration_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13701,11 +14573,12 @@ def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_integer_enumeration_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13716,11 +14589,12 @@ def test_atomic_positive_integer_enumeration_2_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_integer_enumeration_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13731,11 +14605,12 @@ def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_integer_enumeration_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13746,11 +14621,12 @@ def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_integer_enumeration_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13761,11 +14637,12 @@ def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_integer_enumeration_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13776,11 +14653,12 @@ def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_integer_enumeration_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13791,11 +14669,12 @@ def test_atomic_positive_integer_enumeration_1_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integer_enumeration_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13806,11 +14685,12 @@ def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integer_enumeration_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13821,11 +14701,12 @@ def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integer_enumeration_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13836,11 +14717,12 @@ def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integer_enumeration_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13851,11 +14733,12 @@ def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integer_enumeration_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet enumeration.
@@ -13866,11 +14749,12 @@ def test_atomic_positive_integer_enumeration_nistxml_sv_iv_atomic_positive_integ
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13882,11 +14766,12 @@ def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13898,11 +14783,12 @@ def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13914,11 +14800,12 @@ def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13930,11 +14817,12 @@ def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13946,11 +14834,12 @@ def test_atomic_positive_integer_pattern_4_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13962,11 +14851,12 @@ def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13978,11 +14868,12 @@ def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -13994,11 +14885,12 @@ def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14010,11 +14902,12 @@ def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14026,11 +14919,12 @@ def test_atomic_positive_integer_pattern_3_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14042,11 +14936,12 @@ def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14058,11 +14953,12 @@ def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14074,11 +14970,12 @@ def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14090,11 +14987,12 @@ def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14106,11 +15004,12 @@ def test_atomic_positive_integer_pattern_2_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14122,11 +15021,12 @@ def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14138,11 +15038,12 @@ def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14154,11 +15055,12 @@ def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14170,11 +15072,12 @@ def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14186,11 +15089,12 @@ def test_atomic_positive_integer_pattern_1_nistxml_sv_iv_atomic_positive_integer
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14202,11 +15106,12 @@ def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_p
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14218,11 +15123,12 @@ def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_p
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14234,11 +15140,12 @@ def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_p
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14250,11 +15157,12 @@ def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_p
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/positiveInteger is restricted by facet pattern with value
@@ -14266,11 +15174,12 @@ def test_atomic_positive_integer_pattern_nistxml_sv_iv_atomic_positive_integer_p
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_integer_total_digits_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14282,11 +15191,12 @@ def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_integer_total_digits_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14298,11 +15208,12 @@ def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_integer_total_digits_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14314,11 +15225,12 @@ def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_integer_total_digits_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14330,11 +15242,12 @@ def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_integer_total_digits_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14346,11 +15259,12 @@ def test_atomic_positive_integer_total_digits_4_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_integer_total_digits_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14362,11 +15276,12 @@ def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_integer_total_digits_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14378,11 +15293,12 @@ def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_integer_total_digits_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14394,11 +15310,12 @@ def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_integer_total_digits_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14410,11 +15327,12 @@ def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_integer_total_digits_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14426,11 +15344,12 @@ def test_atomic_positive_integer_total_digits_3_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_integer_total_digits_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14442,11 +15361,12 @@ def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_integer_total_digits_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14458,11 +15378,12 @@ def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_integer_total_digits_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14474,11 +15395,12 @@ def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_integer_total_digits_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14490,11 +15412,12 @@ def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_integer_total_digits_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14506,11 +15429,12 @@ def test_atomic_positive_integer_total_digits_2_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_integer_total_digits_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14522,11 +15446,12 @@ def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_integer_total_digits_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14538,11 +15463,12 @@ def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_integer_total_digits_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14554,11 +15480,12 @@ def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_integer_total_digits_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14570,11 +15497,12 @@ def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_integer_total_digits_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14586,11 +15514,12 @@ def test_atomic_positive_integer_total_digits_1_nistxml_sv_iv_atomic_positive_in
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_integer_total_digits_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14602,11 +15531,12 @@ def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_inte
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_integer_total_digits_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14618,11 +15548,12 @@ def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_inte
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_integer_total_digits_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14634,11 +15565,12 @@ def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_inte
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_integer_total_digits_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14650,11 +15582,12 @@ def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_inte
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_integer_total_digits_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet totalDigits with
@@ -14666,11 +15599,12 @@ def test_atomic_positive_integer_total_digits_nistxml_sv_iv_atomic_positive_inte
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_integer_fraction_digits_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet fractionDigits with
@@ -14682,11 +15616,12 @@ def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_integer_fraction_digits_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet fractionDigits with
@@ -14698,11 +15633,12 @@ def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_integer_fraction_digits_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet fractionDigits with
@@ -14714,11 +15650,12 @@ def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_integer_fraction_digits_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet fractionDigits with
@@ -14730,11 +15667,12 @@ def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_integer_fraction_digits_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet fractionDigits with
@@ -14746,11 +15684,12 @@ def test_atomic_positive_integer_fraction_digits_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14762,11 +15701,12 @@ def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14778,11 +15718,12 @@ def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14794,11 +15735,12 @@ def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14810,11 +15752,12 @@ def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14826,11 +15769,12 @@ def test_atomic_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14842,11 +15786,12 @@ def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14858,11 +15803,12 @@ def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14874,11 +15820,12 @@ def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14890,11 +15837,12 @@ def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14906,11 +15854,12 @@ def test_atomic_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14922,11 +15871,12 @@ def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14938,11 +15888,12 @@ def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14954,11 +15905,12 @@ def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14970,11 +15922,12 @@ def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -14986,11 +15939,12 @@ def test_atomic_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -15002,11 +15956,12 @@ def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -15018,11 +15973,12 @@ def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -15034,11 +15990,12 @@ def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -15050,11 +16007,12 @@ def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -15066,11 +16024,12 @@ def test_atomic_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_inclusive_nistxml_sv_iv_atomic_positive_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxInclusive with
@@ -15082,11 +16041,12 @@ def test_atomic_positive_integer_max_inclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15098,11 +16058,12 @@ def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_integer_max_exclusive_5_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15114,11 +16075,12 @@ def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_integer_max_exclusive_5_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15130,11 +16092,12 @@ def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_integer_max_exclusive_5_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15146,11 +16109,12 @@ def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_integer_max_exclusive_5_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15162,11 +16126,12 @@ def test_atomic_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15178,11 +16143,12 @@ def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15194,11 +16160,12 @@ def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15210,11 +16177,12 @@ def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15226,11 +16194,12 @@ def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15242,11 +16211,12 @@ def test_atomic_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15258,11 +16228,12 @@ def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15274,11 +16245,12 @@ def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15290,11 +16262,12 @@ def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15306,11 +16279,12 @@ def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15322,11 +16296,12 @@ def test_atomic_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15338,11 +16313,12 @@ def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15354,11 +16330,12 @@ def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15370,11 +16347,12 @@ def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15386,11 +16364,12 @@ def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15402,11 +16381,12 @@ def test_atomic_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_max_exclusive_nistxml_sv_iv_atomic_positive_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet maxExclusive with
@@ -15418,11 +16398,12 @@ def test_atomic_positive_integer_max_exclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_4_nistxml_sv_iv_atomic_positive_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15434,11 +16415,12 @@ def test_atomic_positive_integer_min_inclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15450,11 +16432,12 @@ def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15466,11 +16449,12 @@ def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15482,11 +16466,12 @@ def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15498,11 +16483,12 @@ def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15514,11 +16500,12 @@ def test_atomic_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15530,11 +16517,12 @@ def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15546,11 +16534,12 @@ def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15562,11 +16551,12 @@ def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15578,11 +16568,12 @@ def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15594,11 +16585,12 @@ def test_atomic_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15610,11 +16602,12 @@ def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15626,11 +16619,12 @@ def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15642,11 +16636,12 @@ def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15658,11 +16653,12 @@ def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15674,11 +16670,12 @@ def test_atomic_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_integer_min_inclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15690,11 +16687,12 @@ def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_integer_min_inclusive_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15706,11 +16704,12 @@ def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_integer_min_inclusive_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15722,11 +16721,12 @@ def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_integer_min_inclusive_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15738,11 +16738,12 @@ def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_integer_min_inclusive_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minInclusive with
@@ -15754,11 +16755,12 @@ def test_atomic_positive_integer_min_inclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_4_nistxml_sv_iv_atomic_positive_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -15770,6 +16772,6 @@ def test_atomic_positive_integer_min_exclusive_4_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_18000.py
+++ b/tests/test_nist_meta_18000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -12,11 +15,12 @@ def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -28,11 +32,12 @@ def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -44,11 +49,12 @@ def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -60,11 +66,12 @@ def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -76,11 +83,12 @@ def test_atomic_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -92,11 +100,12 @@ def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -108,11 +117,12 @@ def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -124,11 +134,12 @@ def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -140,11 +151,12 @@ def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -156,11 +168,12 @@ def test_atomic_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -172,11 +185,12 @@ def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -188,11 +202,12 @@ def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -204,11 +219,12 @@ def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -220,11 +236,12 @@ def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -236,11 +253,12 @@ def test_atomic_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_positive_i
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -252,11 +270,12 @@ def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_integer_min_exclusive_1_2(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -268,11 +287,12 @@ def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_integer_min_exclusive_1_3(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -284,11 +304,12 @@ def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_integer_min_exclusive_1_4(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -300,11 +321,12 @@ def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_integer_min_exclusive_1_5(save_xml):
     """
     Type atomic/positiveInteger is restricted by facet minExclusive with
@@ -316,11 +338,12 @@ def test_atomic_positive_integer_min_exclusive_nistxml_sv_iv_atomic_positive_int
         instance="nistData/atomic/positiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-positiveInteger-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_white_space_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet whiteSpace with value
@@ -332,11 +355,12 @@ def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_whi
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_white_space_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet whiteSpace with value
@@ -348,11 +372,12 @@ def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_whi
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_white_space_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet whiteSpace with value
@@ -364,11 +389,12 @@ def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_whi
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_white_space_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet whiteSpace with value
@@ -380,11 +406,12 @@ def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_whi
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_white_space_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet whiteSpace with value
@@ -396,11 +423,12 @@ def test_atomic_unsigned_byte_white_space_nistxml_sv_iv_atomic_unsigned_byte_whi
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -411,11 +439,12 @@ def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -426,11 +455,12 @@ def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -441,11 +471,12 @@ def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -456,11 +487,12 @@ def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -471,11 +503,12 @@ def test_atomic_unsigned_byte_enumeration_4_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -486,11 +519,12 @@ def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -501,11 +535,12 @@ def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -516,11 +551,12 @@ def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -531,11 +567,12 @@ def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -546,11 +583,12 @@ def test_atomic_unsigned_byte_enumeration_3_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -561,11 +599,12 @@ def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -576,11 +615,12 @@ def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -591,11 +631,12 @@ def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -606,11 +647,12 @@ def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -621,11 +663,12 @@ def test_atomic_unsigned_byte_enumeration_2_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -636,11 +679,12 @@ def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -651,11 +695,12 @@ def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -666,11 +711,12 @@ def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -681,11 +727,12 @@ def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -696,11 +743,12 @@ def test_atomic_unsigned_byte_enumeration_1_nistxml_sv_iv_atomic_unsigned_byte_e
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -711,11 +759,12 @@ def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enu
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -726,11 +775,12 @@ def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enu
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -741,11 +791,12 @@ def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enu
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -756,11 +807,12 @@ def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enu
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet enumeration.
@@ -771,11 +823,12 @@ def test_atomic_unsigned_byte_enumeration_nistxml_sv_iv_atomic_unsigned_byte_enu
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -787,11 +840,12 @@ def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -803,11 +857,12 @@ def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -819,11 +874,12 @@ def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -835,11 +891,12 @@ def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -851,11 +908,12 @@ def test_atomic_unsigned_byte_pattern_4_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -867,11 +925,12 @@ def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -883,11 +942,12 @@ def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -899,11 +959,12 @@ def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -915,11 +976,12 @@ def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -931,11 +993,12 @@ def test_atomic_unsigned_byte_pattern_3_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -947,11 +1010,12 @@ def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -963,11 +1027,12 @@ def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -979,11 +1044,12 @@ def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -995,11 +1061,12 @@ def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1011,11 +1078,12 @@ def test_atomic_unsigned_byte_pattern_2_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1027,11 +1095,12 @@ def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1043,11 +1112,12 @@ def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1059,11 +1129,12 @@ def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1075,11 +1146,12 @@ def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1091,11 +1163,12 @@ def test_atomic_unsigned_byte_pattern_1_nistxml_sv_iv_atomic_unsigned_byte_patte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1107,11 +1180,12 @@ def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1123,11 +1197,12 @@ def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1139,11 +1214,12 @@ def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1155,11 +1231,12 @@ def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedByte is restricted by facet pattern with value
@@ -1171,11 +1248,12 @@ def test_atomic_unsigned_byte_pattern_nistxml_sv_iv_atomic_unsigned_byte_pattern
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1187,11 +1265,12 @@ def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1203,11 +1282,12 @@ def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1219,11 +1299,12 @@ def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1235,11 +1316,12 @@ def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1251,11 +1333,12 @@ def test_atomic_unsigned_byte_total_digits_2_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1267,11 +1350,12 @@ def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1283,11 +1367,12 @@ def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1299,11 +1384,12 @@ def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1315,11 +1401,12 @@ def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1331,11 +1418,12 @@ def test_atomic_unsigned_byte_total_digits_1_nistxml_sv_iv_atomic_unsigned_byte_
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1347,11 +1435,12 @@ def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_to
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1363,11 +1452,12 @@ def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_to
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1379,11 +1469,12 @@ def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_to
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1395,11 +1486,12 @@ def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_to
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet totalDigits with value
@@ -1411,11 +1503,12 @@ def test_atomic_unsigned_byte_total_digits_nistxml_sv_iv_atomic_unsigned_byte_to
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte_fraction_digits_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet fractionDigits with
@@ -1427,11 +1520,12 @@ def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte_fraction_digits_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet fractionDigits with
@@ -1443,11 +1537,12 @@ def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte_fraction_digits_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet fractionDigits with
@@ -1459,11 +1554,12 @@ def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte_fraction_digits_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet fractionDigits with
@@ -1475,11 +1571,12 @@ def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte_fraction_digits_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet fractionDigits with
@@ -1491,11 +1588,12 @@ def test_atomic_unsigned_byte_fraction_digits_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1507,11 +1605,12 @@ def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1523,11 +1622,12 @@ def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1539,11 +1639,12 @@ def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1555,11 +1656,12 @@ def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1571,11 +1673,12 @@ def test_atomic_unsigned_byte_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1587,11 +1690,12 @@ def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1603,11 +1707,12 @@ def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1619,11 +1724,12 @@ def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1635,11 +1741,12 @@ def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1651,11 +1758,12 @@ def test_atomic_unsigned_byte_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1667,11 +1775,12 @@ def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1683,11 +1792,12 @@ def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1699,11 +1809,12 @@ def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1715,11 +1826,12 @@ def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1731,11 +1843,12 @@ def test_atomic_unsigned_byte_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1747,11 +1860,12 @@ def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1763,11 +1877,12 @@ def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1779,11 +1894,12 @@ def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1795,11 +1911,12 @@ def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1811,11 +1928,12 @@ def test_atomic_unsigned_byte_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_inclusive_nistxml_sv_iv_atomic_unsigned_byte_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxInclusive with
@@ -1827,11 +1945,12 @@ def test_atomic_unsigned_byte_max_inclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1843,11 +1962,12 @@ def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1859,11 +1979,12 @@ def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1875,11 +1996,12 @@ def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1891,11 +2013,12 @@ def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1907,11 +2030,12 @@ def test_atomic_unsigned_byte_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1923,11 +2047,12 @@ def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1939,11 +2064,12 @@ def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1955,11 +2081,12 @@ def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1971,11 +2098,12 @@ def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -1987,11 +2115,12 @@ def test_atomic_unsigned_byte_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2003,11 +2132,12 @@ def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2019,11 +2149,12 @@ def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2035,11 +2166,12 @@ def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2051,11 +2183,12 @@ def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2067,11 +2200,12 @@ def test_atomic_unsigned_byte_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2083,11 +2217,12 @@ def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2099,11 +2234,12 @@ def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2115,11 +2251,12 @@ def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2131,11 +2268,12 @@ def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2147,11 +2285,12 @@ def test_atomic_unsigned_byte_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_max_exclusive_nistxml_sv_iv_atomic_unsigned_byte_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet maxExclusive with
@@ -2163,11 +2302,12 @@ def test_atomic_unsigned_byte_max_exclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2179,11 +2319,12 @@ def test_atomic_unsigned_byte_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2195,11 +2336,12 @@ def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2211,11 +2353,12 @@ def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2227,11 +2370,12 @@ def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2243,11 +2387,12 @@ def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2259,11 +2404,12 @@ def test_atomic_unsigned_byte_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2275,11 +2421,12 @@ def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2291,11 +2438,12 @@ def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2307,11 +2455,12 @@ def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2323,11 +2472,12 @@ def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2339,11 +2489,12 @@ def test_atomic_unsigned_byte_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2355,11 +2506,12 @@ def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2371,11 +2523,12 @@ def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2387,11 +2540,12 @@ def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2403,11 +2557,12 @@ def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2419,11 +2574,12 @@ def test_atomic_unsigned_byte_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2435,11 +2591,12 @@ def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2451,11 +2608,12 @@ def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2467,11 +2625,12 @@ def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2483,11 +2642,12 @@ def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_min_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minInclusive with
@@ -2499,11 +2659,12 @@ def test_atomic_unsigned_byte_min_inclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2515,11 +2676,12 @@ def test_atomic_unsigned_byte_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2531,11 +2693,12 @@ def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2547,11 +2710,12 @@ def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2563,11 +2727,12 @@ def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2579,11 +2744,12 @@ def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2595,11 +2761,12 @@ def test_atomic_unsigned_byte_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2611,11 +2778,12 @@ def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2627,11 +2795,12 @@ def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2643,11 +2812,12 @@ def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2659,11 +2829,12 @@ def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2675,11 +2846,12 @@ def test_atomic_unsigned_byte_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2691,11 +2863,12 @@ def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2707,11 +2880,12 @@ def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2723,11 +2897,12 @@ def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2739,11 +2914,12 @@ def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2755,11 +2931,12 @@ def test_atomic_unsigned_byte_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_byte
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2771,11 +2948,12 @@ def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2787,11 +2965,12 @@ def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2803,11 +2982,12 @@ def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2819,11 +2999,12 @@ def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_min_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedByte is restricted by facet minExclusive with
@@ -2835,11 +3016,12 @@ def test_atomic_unsigned_byte_min_exclusive_nistxml_sv_iv_atomic_unsigned_byte_m
         instance="nistData/atomic/unsignedByte/Schema+Instance/NISTXML-SV-IV-atomic-unsignedByte-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_white_space_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet whiteSpace with value
@@ -2851,11 +3033,12 @@ def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_w
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_white_space_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet whiteSpace with value
@@ -2867,11 +3050,12 @@ def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_w
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_white_space_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet whiteSpace with value
@@ -2883,11 +3067,12 @@ def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_w
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_white_space_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet whiteSpace with value
@@ -2899,11 +3084,12 @@ def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_w
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_white_space_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet whiteSpace with value
@@ -2915,11 +3101,12 @@ def test_atomic_unsigned_short_white_space_nistxml_sv_iv_atomic_unsigned_short_w
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2930,11 +3117,12 @@ def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2945,11 +3133,12 @@ def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2960,11 +3149,12 @@ def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2975,11 +3165,12 @@ def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -2990,11 +3181,12 @@ def test_atomic_unsigned_short_enumeration_4_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3005,11 +3197,12 @@ def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3020,11 +3213,12 @@ def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3035,11 +3229,12 @@ def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3050,11 +3245,12 @@ def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3065,11 +3261,12 @@ def test_atomic_unsigned_short_enumeration_3_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3080,11 +3277,12 @@ def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3095,11 +3293,12 @@ def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3110,11 +3309,12 @@ def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3125,11 +3325,12 @@ def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3140,11 +3341,12 @@ def test_atomic_unsigned_short_enumeration_2_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3155,11 +3357,12 @@ def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3170,11 +3373,12 @@ def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3185,11 +3389,12 @@ def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3200,11 +3405,12 @@ def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3215,11 +3421,12 @@ def test_atomic_unsigned_short_enumeration_1_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3230,11 +3437,12 @@ def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_e
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3245,11 +3453,12 @@ def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_e
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3260,11 +3469,12 @@ def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_e
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3275,11 +3485,12 @@ def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_e
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet enumeration.
@@ -3290,11 +3501,12 @@ def test_atomic_unsigned_short_enumeration_nistxml_sv_iv_atomic_unsigned_short_e
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3306,11 +3518,12 @@ def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3322,11 +3535,12 @@ def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3338,11 +3552,12 @@ def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3354,11 +3569,12 @@ def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3370,11 +3586,12 @@ def test_atomic_unsigned_short_pattern_4_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3386,11 +3603,12 @@ def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3402,11 +3620,12 @@ def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3418,11 +3637,12 @@ def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3434,11 +3654,12 @@ def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3450,11 +3671,12 @@ def test_atomic_unsigned_short_pattern_3_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3466,11 +3688,12 @@ def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3482,11 +3705,12 @@ def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3498,11 +3722,12 @@ def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3514,11 +3739,12 @@ def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3530,11 +3756,12 @@ def test_atomic_unsigned_short_pattern_2_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3546,11 +3773,12 @@ def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3562,11 +3790,12 @@ def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3578,11 +3807,12 @@ def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3594,11 +3824,12 @@ def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3610,11 +3841,12 @@ def test_atomic_unsigned_short_pattern_1_nistxml_sv_iv_atomic_unsigned_short_pat
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3626,11 +3858,12 @@ def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_patte
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3642,11 +3875,12 @@ def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_patte
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3658,11 +3892,12 @@ def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_patte
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3674,11 +3909,12 @@ def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_patte
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedShort is restricted by facet pattern with value
@@ -3690,11 +3926,12 @@ def test_atomic_unsigned_short_pattern_nistxml_sv_iv_atomic_unsigned_short_patte
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_short_total_digits_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3706,11 +3943,12 @@ def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_short_total_digits_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3722,11 +3960,12 @@ def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_short_total_digits_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3738,11 +3977,12 @@ def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_short_total_digits_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3754,11 +3994,12 @@ def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_short_total_digits_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3770,11 +4011,12 @@ def test_atomic_unsigned_short_total_digits_4_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_short_total_digits_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3786,11 +4028,12 @@ def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_short_total_digits_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3802,11 +4045,12 @@ def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_short_total_digits_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3818,11 +4062,12 @@ def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_short_total_digits_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3834,11 +4079,12 @@ def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_short_total_digits_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3850,11 +4096,12 @@ def test_atomic_unsigned_short_total_digits_3_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_short_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3866,11 +4113,12 @@ def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_short_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3882,11 +4130,12 @@ def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_short_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3898,11 +4147,12 @@ def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_short_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3914,11 +4164,12 @@ def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_short_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3930,11 +4181,12 @@ def test_atomic_unsigned_short_total_digits_2_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_short_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3946,11 +4198,12 @@ def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_short_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3962,11 +4215,12 @@ def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_short_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3978,11 +4232,12 @@ def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_short_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -3994,11 +4249,12 @@ def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_short_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -4010,11 +4266,12 @@ def test_atomic_unsigned_short_total_digits_1_nistxml_sv_iv_atomic_unsigned_shor
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -4026,11 +4283,12 @@ def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -4042,11 +4300,12 @@ def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -4058,11 +4317,12 @@ def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -4074,11 +4334,12 @@ def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet totalDigits with
@@ -4090,11 +4351,12 @@ def test_atomic_unsigned_short_total_digits_nistxml_sv_iv_atomic_unsigned_short_
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_short_fraction_digits_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet fractionDigits with
@@ -4106,11 +4368,12 @@ def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_short_fraction_digits_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet fractionDigits with
@@ -4122,11 +4385,12 @@ def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_short_fraction_digits_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet fractionDigits with
@@ -4138,11 +4402,12 @@ def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_short_fraction_digits_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet fractionDigits with
@@ -4154,11 +4419,12 @@ def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_short_fraction_digits_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet fractionDigits with
@@ -4170,11 +4436,12 @@ def test_atomic_unsigned_short_fraction_digits_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4186,11 +4453,12 @@ def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4202,11 +4470,12 @@ def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4218,11 +4487,12 @@ def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4234,11 +4504,12 @@ def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4250,11 +4521,12 @@ def test_atomic_unsigned_short_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4266,11 +4538,12 @@ def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4282,11 +4555,12 @@ def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4298,11 +4572,12 @@ def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4314,11 +4589,12 @@ def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4330,11 +4606,12 @@ def test_atomic_unsigned_short_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4346,11 +4623,12 @@ def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4362,11 +4640,12 @@ def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4378,11 +4657,12 @@ def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4394,11 +4674,12 @@ def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4410,11 +4691,12 @@ def test_atomic_unsigned_short_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4426,11 +4708,12 @@ def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4442,11 +4725,12 @@ def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4458,11 +4742,12 @@ def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4474,11 +4759,12 @@ def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4490,11 +4776,12 @@ def test_atomic_unsigned_short_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_inclusive_nistxml_sv_iv_atomic_unsigned_short_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxInclusive with
@@ -4506,11 +4793,12 @@ def test_atomic_unsigned_short_max_inclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4522,11 +4810,12 @@ def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4538,11 +4827,12 @@ def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4554,11 +4844,12 @@ def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4570,11 +4861,12 @@ def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4586,11 +4878,12 @@ def test_atomic_unsigned_short_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4602,11 +4895,12 @@ def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4618,11 +4912,12 @@ def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4634,11 +4929,12 @@ def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4650,11 +4946,12 @@ def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4666,11 +4963,12 @@ def test_atomic_unsigned_short_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4682,11 +4980,12 @@ def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4698,11 +4997,12 @@ def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4714,11 +5014,12 @@ def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4730,11 +5031,12 @@ def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4746,11 +5048,12 @@ def test_atomic_unsigned_short_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4762,11 +5065,12 @@ def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4778,11 +5082,12 @@ def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4794,11 +5099,12 @@ def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4810,11 +5116,12 @@ def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4826,11 +5133,12 @@ def test_atomic_unsigned_short_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_max_exclusive_nistxml_sv_iv_atomic_unsigned_short_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet maxExclusive with
@@ -4842,11 +5150,12 @@ def test_atomic_unsigned_short_max_exclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4858,11 +5167,12 @@ def test_atomic_unsigned_short_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4874,11 +5184,12 @@ def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4890,11 +5201,12 @@ def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4906,11 +5218,12 @@ def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4922,11 +5235,12 @@ def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4938,11 +5252,12 @@ def test_atomic_unsigned_short_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4954,11 +5269,12 @@ def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4970,11 +5286,12 @@ def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -4986,11 +5303,12 @@ def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5002,11 +5320,12 @@ def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5018,11 +5337,12 @@ def test_atomic_unsigned_short_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5034,11 +5354,12 @@ def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5050,11 +5371,12 @@ def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5066,11 +5388,12 @@ def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5082,11 +5405,12 @@ def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5098,11 +5422,12 @@ def test_atomic_unsigned_short_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5114,11 +5439,12 @@ def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5130,11 +5456,12 @@ def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5146,11 +5473,12 @@ def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5162,11 +5490,12 @@ def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short_min_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minInclusive with
@@ -5178,11 +5507,12 @@ def test_atomic_unsigned_short_min_inclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5194,11 +5524,12 @@ def test_atomic_unsigned_short_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5210,11 +5541,12 @@ def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5226,11 +5558,12 @@ def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5242,11 +5575,12 @@ def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5258,11 +5592,12 @@ def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5274,11 +5609,12 @@ def test_atomic_unsigned_short_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5290,11 +5626,12 @@ def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5306,11 +5643,12 @@ def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5322,11 +5660,12 @@ def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5338,11 +5677,12 @@ def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5354,11 +5694,12 @@ def test_atomic_unsigned_short_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5370,11 +5711,12 @@ def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5386,11 +5728,12 @@ def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5402,11 +5745,12 @@ def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5418,11 +5762,12 @@ def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5434,11 +5779,12 @@ def test_atomic_unsigned_short_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_sho
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5450,11 +5796,12 @@ def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5466,11 +5813,12 @@ def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5482,11 +5830,12 @@ def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5498,11 +5847,12 @@ def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short_min_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedShort is restricted by facet minExclusive with
@@ -5514,11 +5864,12 @@ def test_atomic_unsigned_short_min_exclusive_nistxml_sv_iv_atomic_unsigned_short
         instance="nistData/atomic/unsignedShort/Schema+Instance/NISTXML-SV-IV-atomic-unsignedShort-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white_space_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet whiteSpace with value
@@ -5530,11 +5881,12 @@ def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white_space_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet whiteSpace with value
@@ -5546,11 +5898,12 @@ def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white_space_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet whiteSpace with value
@@ -5562,11 +5915,12 @@ def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white_space_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet whiteSpace with value
@@ -5578,11 +5932,12 @@ def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white_space_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet whiteSpace with value
@@ -5594,11 +5949,12 @@ def test_atomic_unsigned_int_white_space_nistxml_sv_iv_atomic_unsigned_int_white
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5609,11 +5965,12 @@ def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5624,11 +5981,12 @@ def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5639,11 +5997,12 @@ def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5654,11 +6013,12 @@ def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5669,11 +6029,12 @@ def test_atomic_unsigned_int_enumeration_4_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5684,11 +6045,12 @@ def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5699,11 +6061,12 @@ def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5714,11 +6077,12 @@ def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5729,11 +6093,12 @@ def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5744,11 +6109,12 @@ def test_atomic_unsigned_int_enumeration_3_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5759,11 +6125,12 @@ def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5774,11 +6141,12 @@ def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5789,11 +6157,12 @@ def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5804,11 +6173,12 @@ def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5819,11 +6189,12 @@ def test_atomic_unsigned_int_enumeration_2_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5834,11 +6205,12 @@ def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5849,11 +6221,12 @@ def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5864,11 +6237,12 @@ def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5879,11 +6253,12 @@ def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5894,11 +6269,12 @@ def test_atomic_unsigned_int_enumeration_1_nistxml_sv_iv_atomic_unsigned_int_enu
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5909,11 +6285,12 @@ def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enume
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5924,11 +6301,12 @@ def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enume
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5939,11 +6317,12 @@ def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enume
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5954,11 +6333,12 @@ def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enume
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet enumeration.
@@ -5969,11 +6349,12 @@ def test_atomic_unsigned_int_enumeration_nistxml_sv_iv_atomic_unsigned_int_enume
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -5985,11 +6366,12 @@ def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6001,11 +6383,12 @@ def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6017,11 +6400,12 @@ def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6033,11 +6417,12 @@ def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6049,11 +6434,12 @@ def test_atomic_unsigned_int_pattern_4_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6065,11 +6451,12 @@ def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6081,11 +6468,12 @@ def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6097,11 +6485,12 @@ def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6113,11 +6502,12 @@ def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6129,11 +6519,12 @@ def test_atomic_unsigned_int_pattern_3_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6145,11 +6536,12 @@ def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6161,11 +6553,12 @@ def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6177,11 +6570,12 @@ def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6193,11 +6587,12 @@ def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6209,11 +6604,12 @@ def test_atomic_unsigned_int_pattern_2_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6225,11 +6621,12 @@ def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6241,11 +6638,12 @@ def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6257,11 +6655,12 @@ def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6273,11 +6672,12 @@ def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6289,11 +6689,12 @@ def test_atomic_unsigned_int_pattern_1_nistxml_sv_iv_atomic_unsigned_int_pattern
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6305,11 +6706,12 @@ def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6321,11 +6723,12 @@ def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6337,11 +6740,12 @@ def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6353,11 +6757,12 @@ def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedInt is restricted by facet pattern with value
@@ -6369,11 +6774,12 @@ def test_atomic_unsigned_int_pattern_nistxml_sv_iv_atomic_unsigned_int_pattern_1
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_total_digits_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6385,11 +6791,12 @@ def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_total_digits_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6401,11 +6808,12 @@ def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_total_digits_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6417,11 +6825,12 @@ def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_total_digits_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6433,11 +6842,12 @@ def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_total_digits_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6449,11 +6859,12 @@ def test_atomic_unsigned_int_total_digits_4_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_total_digits_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6465,11 +6876,12 @@ def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_total_digits_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6481,11 +6893,12 @@ def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_total_digits_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6497,11 +6910,12 @@ def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_total_digits_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6513,11 +6927,12 @@ def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_total_digits_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6529,11 +6944,12 @@ def test_atomic_unsigned_int_total_digits_3_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6545,11 +6961,12 @@ def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6561,11 +6978,12 @@ def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6577,11 +6995,12 @@ def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6593,11 +7012,12 @@ def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6609,11 +7029,12 @@ def test_atomic_unsigned_int_total_digits_2_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6625,11 +7046,12 @@ def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6641,11 +7063,12 @@ def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6657,11 +7080,12 @@ def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6673,11 +7097,12 @@ def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6689,11 +7114,12 @@ def test_atomic_unsigned_int_total_digits_1_nistxml_sv_iv_atomic_unsigned_int_to
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6705,11 +7131,12 @@ def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_tota
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6721,11 +7148,12 @@ def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_tota
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6737,11 +7165,12 @@ def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_tota
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6753,11 +7182,12 @@ def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_tota
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet totalDigits with value
@@ -6769,11 +7199,12 @@ def test_atomic_unsigned_int_total_digits_nistxml_sv_iv_atomic_unsigned_int_tota
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_fraction_digits_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet fractionDigits with
@@ -6785,11 +7216,12 @@ def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_f
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_fraction_digits_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet fractionDigits with
@@ -6801,11 +7233,12 @@ def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_f
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_fraction_digits_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet fractionDigits with
@@ -6817,11 +7250,12 @@ def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_f
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_fraction_digits_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet fractionDigits with
@@ -6833,11 +7267,12 @@ def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_f
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_fraction_digits_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet fractionDigits with
@@ -6849,11 +7284,12 @@ def test_atomic_unsigned_int_fraction_digits_nistxml_sv_iv_atomic_unsigned_int_f
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6865,11 +7301,12 @@ def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6881,11 +7318,12 @@ def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6897,11 +7335,12 @@ def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6913,11 +7352,12 @@ def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6929,11 +7369,12 @@ def test_atomic_unsigned_int_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6945,11 +7386,12 @@ def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6961,11 +7403,12 @@ def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6977,11 +7420,12 @@ def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -6993,11 +7437,12 @@ def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7009,11 +7454,12 @@ def test_atomic_unsigned_int_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7025,11 +7471,12 @@ def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7041,11 +7488,12 @@ def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7057,11 +7505,12 @@ def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7073,11 +7522,12 @@ def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7089,11 +7539,12 @@ def test_atomic_unsigned_int_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7105,11 +7556,12 @@ def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7121,11 +7573,12 @@ def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7137,11 +7590,12 @@ def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7153,11 +7607,12 @@ def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7169,11 +7624,12 @@ def test_atomic_unsigned_int_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_inclusive_nistxml_sv_iv_atomic_unsigned_int_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxInclusive with value
@@ -7185,11 +7641,12 @@ def test_atomic_unsigned_int_max_inclusive_nistxml_sv_iv_atomic_unsigned_int_max
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7201,11 +7658,12 @@ def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7217,11 +7675,12 @@ def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7233,11 +7692,12 @@ def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7249,11 +7709,12 @@ def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7265,11 +7726,12 @@ def test_atomic_unsigned_int_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7281,11 +7743,12 @@ def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7297,11 +7760,12 @@ def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7313,11 +7777,12 @@ def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7329,11 +7794,12 @@ def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7345,11 +7811,12 @@ def test_atomic_unsigned_int_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7361,11 +7828,12 @@ def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7377,11 +7845,12 @@ def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7393,11 +7862,12 @@ def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7409,11 +7879,12 @@ def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7425,11 +7896,12 @@ def test_atomic_unsigned_int_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7441,11 +7913,12 @@ def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7457,11 +7930,12 @@ def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7473,11 +7947,12 @@ def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7489,11 +7964,12 @@ def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7505,11 +7981,12 @@ def test_atomic_unsigned_int_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_max_exclusive_nistxml_sv_iv_atomic_unsigned_int_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet maxExclusive with value
@@ -7521,11 +7998,12 @@ def test_atomic_unsigned_int_max_exclusive_nistxml_sv_iv_atomic_unsigned_int_max
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7537,11 +8015,12 @@ def test_atomic_unsigned_int_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7553,11 +8032,12 @@ def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7569,11 +8049,12 @@ def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7585,11 +8066,12 @@ def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7601,11 +8083,12 @@ def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7617,11 +8100,12 @@ def test_atomic_unsigned_int_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7633,11 +8117,12 @@ def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7649,11 +8134,12 @@ def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7665,11 +8151,12 @@ def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7681,11 +8168,12 @@ def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7697,11 +8185,12 @@ def test_atomic_unsigned_int_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7713,11 +8202,12 @@ def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7729,11 +8219,12 @@ def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7745,11 +8236,12 @@ def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7761,11 +8253,12 @@ def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7777,11 +8270,12 @@ def test_atomic_unsigned_int_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7793,11 +8287,12 @@ def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7809,11 +8304,12 @@ def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7825,11 +8321,12 @@ def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7841,11 +8338,12 @@ def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minInclusive with value
@@ -7857,11 +8355,12 @@ def test_atomic_unsigned_int_min_inclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7873,11 +8372,12 @@ def test_atomic_unsigned_int_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7889,11 +8389,12 @@ def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7905,11 +8406,12 @@ def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7921,11 +8423,12 @@ def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7937,11 +8440,12 @@ def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7953,11 +8457,12 @@ def test_atomic_unsigned_int_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7969,11 +8474,12 @@ def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -7985,11 +8491,12 @@ def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8001,11 +8508,12 @@ def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8017,11 +8525,12 @@ def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8033,11 +8542,12 @@ def test_atomic_unsigned_int_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8049,11 +8559,12 @@ def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8065,11 +8576,12 @@ def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8081,11 +8593,12 @@ def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8097,11 +8610,12 @@ def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8113,11 +8627,12 @@ def test_atomic_unsigned_int_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_int_m
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8129,11 +8644,12 @@ def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8145,11 +8661,12 @@ def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8161,11 +8678,12 @@ def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8177,11 +8695,12 @@ def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedInt is restricted by facet minExclusive with value
@@ -8193,11 +8712,12 @@ def test_atomic_unsigned_int_min_exclusive_nistxml_sv_iv_atomic_unsigned_int_min
         instance="nistData/atomic/unsignedInt/Schema+Instance/NISTXML-SV-IV-atomic-unsignedInt-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_white_space_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet whiteSpace with value
@@ -8209,11 +8729,12 @@ def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_whi
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_white_space_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet whiteSpace with value
@@ -8225,11 +8746,12 @@ def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_whi
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_white_space_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet whiteSpace with value
@@ -8241,11 +8763,12 @@ def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_whi
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_white_space_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet whiteSpace with value
@@ -8257,11 +8780,12 @@ def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_whi
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_white_space_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet whiteSpace with value
@@ -8273,11 +8797,12 @@ def test_atomic_unsigned_long_white_space_nistxml_sv_iv_atomic_unsigned_long_whi
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_enumeration_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8288,11 +8813,12 @@ def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_enumeration_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8303,11 +8829,12 @@ def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_enumeration_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8318,11 +8845,12 @@ def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_enumeration_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8333,11 +8861,12 @@ def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_enumeration_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8348,11 +8877,12 @@ def test_atomic_unsigned_long_enumeration_4_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_enumeration_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8363,11 +8893,12 @@ def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_enumeration_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8378,11 +8909,12 @@ def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_enumeration_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8393,11 +8925,12 @@ def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_enumeration_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8408,11 +8941,12 @@ def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_enumeration_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8423,11 +8957,12 @@ def test_atomic_unsigned_long_enumeration_3_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_enumeration_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8438,11 +8973,12 @@ def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_enumeration_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8453,11 +8989,12 @@ def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_enumeration_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8468,11 +9005,12 @@ def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_enumeration_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8483,11 +9021,12 @@ def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_enumeration_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8498,11 +9037,12 @@ def test_atomic_unsigned_long_enumeration_2_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_enumeration_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8513,11 +9053,12 @@ def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_enumeration_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8528,11 +9069,12 @@ def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_enumeration_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8543,11 +9085,12 @@ def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_enumeration_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8558,11 +9101,12 @@ def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_enumeration_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8573,11 +9117,12 @@ def test_atomic_unsigned_long_enumeration_1_nistxml_sv_iv_atomic_unsigned_long_e
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enumeration_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8588,11 +9133,12 @@ def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enu
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enumeration_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8603,11 +9149,12 @@ def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enu
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enumeration_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8618,11 +9165,12 @@ def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enu
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enumeration_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8633,11 +9181,12 @@ def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enu
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enumeration_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet enumeration.
@@ -8648,11 +9197,12 @@ def test_atomic_unsigned_long_enumeration_nistxml_sv_iv_atomic_unsigned_long_enu
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_pattern_5_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8664,11 +9214,12 @@ def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_pattern_5_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8680,11 +9231,12 @@ def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_pattern_5_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8696,11 +9248,12 @@ def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_pattern_5_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8712,11 +9265,12 @@ def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_pattern_5_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8728,11 +9282,12 @@ def test_atomic_unsigned_long_pattern_4_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_pattern_4_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8744,11 +9299,12 @@ def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_pattern_4_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8760,11 +9316,12 @@ def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_pattern_4_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8776,11 +9333,12 @@ def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_pattern_4_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8792,11 +9350,12 @@ def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_pattern_4_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8808,11 +9367,12 @@ def test_atomic_unsigned_long_pattern_3_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_pattern_3_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8824,11 +9384,12 @@ def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_pattern_3_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8840,11 +9401,12 @@ def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_pattern_3_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8856,11 +9418,12 @@ def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_pattern_3_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8872,11 +9435,12 @@ def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_pattern_3_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8888,11 +9452,12 @@ def test_atomic_unsigned_long_pattern_2_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_pattern_2_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8904,11 +9469,12 @@ def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_pattern_2_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8920,11 +9486,12 @@ def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_pattern_2_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8936,11 +9503,12 @@ def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_pattern_2_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8952,11 +9520,12 @@ def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_pattern_2_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8968,11 +9537,12 @@ def test_atomic_unsigned_long_pattern_1_nistxml_sv_iv_atomic_unsigned_long_patte
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern_1_1(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -8984,11 +9554,12 @@ def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern_1_2(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -9000,11 +9571,12 @@ def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern_1_3(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -9016,11 +9588,12 @@ def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern_1_4(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -9032,11 +9605,12 @@ def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern_1_5(save_xml):
     r"""
     Type atomic/unsignedLong is restricted by facet pattern with value
@@ -9048,11 +9622,12 @@ def test_atomic_unsigned_long_pattern_nistxml_sv_iv_atomic_unsigned_long_pattern
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_total_digits_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9064,11 +9639,12 @@ def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_total_digits_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9080,11 +9656,12 @@ def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_total_digits_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9096,11 +9673,12 @@ def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_total_digits_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9112,11 +9690,12 @@ def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_total_digits_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9128,11 +9707,12 @@ def test_atomic_unsigned_long_total_digits_4_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_total_digits_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9144,11 +9724,12 @@ def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_total_digits_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9160,11 +9741,12 @@ def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_total_digits_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9176,11 +9758,12 @@ def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_total_digits_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9192,11 +9775,12 @@ def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_total_digits_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9208,11 +9792,12 @@ def test_atomic_unsigned_long_total_digits_3_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_total_digits_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9224,11 +9809,12 @@ def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_total_digits_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9240,11 +9826,12 @@ def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_total_digits_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9256,11 +9843,12 @@ def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_total_digits_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9272,11 +9860,12 @@ def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_total_digits_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9288,11 +9877,12 @@ def test_atomic_unsigned_long_total_digits_2_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_total_digits_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9304,11 +9894,12 @@ def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_total_digits_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9320,11 +9911,12 @@ def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_total_digits_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9336,11 +9928,12 @@ def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_total_digits_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9352,11 +9945,12 @@ def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_total_digits_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9368,11 +9962,12 @@ def test_atomic_unsigned_long_total_digits_1_nistxml_sv_iv_atomic_unsigned_long_
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_total_digits_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9384,11 +9979,12 @@ def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_to
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_total_digits_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9400,11 +9996,12 @@ def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_to
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_total_digits_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9416,11 +10013,12 @@ def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_to
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_total_digits_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9432,11 +10030,12 @@ def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_to
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_total_digits_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet totalDigits with value
@@ -9448,11 +10047,12 @@ def test_atomic_unsigned_long_total_digits_nistxml_sv_iv_atomic_unsigned_long_to
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long_fraction_digits_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet fractionDigits with
@@ -9464,11 +10064,12 @@ def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long_fraction_digits_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet fractionDigits with
@@ -9480,11 +10081,12 @@ def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long_fraction_digits_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet fractionDigits with
@@ -9496,11 +10098,12 @@ def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long_fraction_digits_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet fractionDigits with
@@ -9512,11 +10115,12 @@ def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long_fraction_digits_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet fractionDigits with
@@ -9528,11 +10132,12 @@ def test_atomic_unsigned_long_fraction_digits_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9544,11 +10149,12 @@ def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9560,11 +10166,12 @@ def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9576,11 +10183,12 @@ def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9592,11 +10200,12 @@ def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9608,11 +10217,12 @@ def test_atomic_unsigned_long_max_inclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9624,11 +10234,12 @@ def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9640,11 +10251,12 @@ def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9656,11 +10268,12 @@ def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9672,11 +10285,12 @@ def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9688,11 +10302,12 @@ def test_atomic_unsigned_long_max_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9704,11 +10319,12 @@ def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9720,11 +10336,12 @@ def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9736,11 +10353,12 @@ def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9752,11 +10370,12 @@ def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9768,11 +10387,12 @@ def test_atomic_unsigned_long_max_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9784,11 +10404,12 @@ def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9800,11 +10421,12 @@ def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9816,11 +10438,12 @@ def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9832,11 +10455,12 @@ def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9848,11 +10472,12 @@ def test_atomic_unsigned_long_max_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_inclusive_nistxml_sv_iv_atomic_unsigned_long_max_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxInclusive with
@@ -9864,11 +10489,12 @@ def test_atomic_unsigned_long_max_inclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9880,11 +10506,12 @@ def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_5_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9896,11 +10523,12 @@ def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_5_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9912,11 +10540,12 @@ def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_5_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9928,11 +10557,12 @@ def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_5_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9944,11 +10574,12 @@ def test_atomic_unsigned_long_max_exclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9960,11 +10591,12 @@ def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9976,11 +10608,12 @@ def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -9992,11 +10625,12 @@ def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10008,11 +10642,12 @@ def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10024,11 +10659,12 @@ def test_atomic_unsigned_long_max_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10040,11 +10676,12 @@ def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10056,11 +10693,12 @@ def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10072,11 +10710,12 @@ def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10088,11 +10727,12 @@ def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10104,11 +10744,12 @@ def test_atomic_unsigned_long_max_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10120,11 +10761,12 @@ def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10136,11 +10778,12 @@ def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10152,11 +10795,12 @@ def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10168,11 +10812,12 @@ def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10184,11 +10829,12 @@ def test_atomic_unsigned_long_max_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_max_exclusive_nistxml_sv_iv_atomic_unsigned_long_max_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet maxExclusive with
@@ -10200,11 +10846,12 @@ def test_atomic_unsigned_long_max_exclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10216,11 +10863,12 @@ def test_atomic_unsigned_long_min_inclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10232,11 +10880,12 @@ def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10248,11 +10897,12 @@ def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10264,11 +10914,12 @@ def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10280,11 +10931,12 @@ def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10296,11 +10948,12 @@ def test_atomic_unsigned_long_min_inclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10312,11 +10965,12 @@ def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10328,11 +10982,12 @@ def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10344,11 +10999,12 @@ def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10360,11 +11016,12 @@ def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10376,11 +11033,12 @@ def test_atomic_unsigned_long_min_inclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10392,11 +11050,12 @@ def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10408,11 +11067,12 @@ def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10424,11 +11084,12 @@ def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10440,11 +11101,12 @@ def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10456,11 +11118,12 @@ def test_atomic_unsigned_long_min_inclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10472,11 +11135,12 @@ def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10488,11 +11152,12 @@ def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10504,11 +11169,12 @@ def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10520,11 +11186,12 @@ def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_min_inclusive_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minInclusive with
@@ -10536,11 +11203,12 @@ def test_atomic_unsigned_long_min_inclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_5_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10552,11 +11220,12 @@ def test_atomic_unsigned_long_min_exclusive_4_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_4_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10568,11 +11237,12 @@ def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_4_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10584,11 +11254,12 @@ def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_4_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10600,11 +11271,12 @@ def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_4_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10616,11 +11288,12 @@ def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_4_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10632,11 +11305,12 @@ def test_atomic_unsigned_long_min_exclusive_3_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_3_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10648,11 +11322,12 @@ def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_3_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10664,11 +11339,12 @@ def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_3_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10680,11 +11356,12 @@ def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_3_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10696,11 +11373,12 @@ def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_3_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10712,11 +11390,12 @@ def test_atomic_unsigned_long_min_exclusive_2_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_2_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10728,11 +11407,12 @@ def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_2_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10744,11 +11424,12 @@ def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_2_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10760,11 +11441,12 @@ def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_2_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10776,11 +11458,12 @@ def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_2_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10792,11 +11475,12 @@ def test_atomic_unsigned_long_min_exclusive_1_nistxml_sv_iv_atomic_unsigned_long
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_1_1(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10808,11 +11492,12 @@ def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_1_2(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10824,11 +11509,12 @@ def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_1_3(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10840,11 +11526,12 @@ def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_1_4(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10856,11 +11543,12 @@ def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_min_exclusive_1_5(save_xml):
     """
     Type atomic/unsignedLong is restricted by facet minExclusive with
@@ -10872,11 +11560,12 @@ def test_atomic_unsigned_long_min_exclusive_nistxml_sv_iv_atomic_unsigned_long_m
         instance="nistData/atomic/unsignedLong/Schema+Instance/NISTXML-SV-IV-atomic-unsignedLong-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicUnsignedLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negative_integer_white_space_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet whiteSpace with
@@ -10888,11 +11577,12 @@ def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negative_integer_white_space_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet whiteSpace with
@@ -10904,11 +11594,12 @@ def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negative_integer_white_space_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet whiteSpace with
@@ -10920,11 +11611,12 @@ def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negative_integer_white_space_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet whiteSpace with
@@ -10936,11 +11628,12 @@ def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negative_integer_white_space_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet whiteSpace with
@@ -10952,11 +11645,12 @@ def test_atomic_non_negative_integer_white_space_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_negative_integer_enumeration_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -10967,11 +11661,12 @@ def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_negative_integer_enumeration_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -10982,11 +11677,12 @@ def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_negative_integer_enumeration_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -10997,11 +11693,12 @@ def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_negative_integer_enumeration_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11012,11 +11709,12 @@ def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_negative_integer_enumeration_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11027,11 +11725,12 @@ def test_atomic_non_negative_integer_enumeration_4_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_negative_integer_enumeration_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11042,11 +11741,12 @@ def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_negative_integer_enumeration_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11057,11 +11757,12 @@ def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_negative_integer_enumeration_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11072,11 +11773,12 @@ def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_negative_integer_enumeration_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11087,11 +11789,12 @@ def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_negative_integer_enumeration_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11102,11 +11805,12 @@ def test_atomic_non_negative_integer_enumeration_3_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_negative_integer_enumeration_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11117,11 +11821,12 @@ def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_negative_integer_enumeration_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11132,11 +11837,12 @@ def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_negative_integer_enumeration_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11147,11 +11853,12 @@ def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_negative_integer_enumeration_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11162,11 +11869,12 @@ def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_negative_integer_enumeration_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11177,11 +11885,12 @@ def test_atomic_non_negative_integer_enumeration_2_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_negative_integer_enumeration_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11192,11 +11901,12 @@ def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_negative_integer_enumeration_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11207,11 +11917,12 @@ def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_negative_integer_enumeration_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11222,11 +11933,12 @@ def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_negative_integer_enumeration_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11237,11 +11949,12 @@ def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_negative_integer_enumeration_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11252,11 +11965,12 @@ def test_atomic_non_negative_integer_enumeration_1_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negative_integer_enumeration_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11267,11 +11981,12 @@ def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negative_integer_enumeration_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11282,11 +11997,12 @@ def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negative_integer_enumeration_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11297,11 +12013,12 @@ def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negative_integer_enumeration_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11312,11 +12029,12 @@ def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negative_integer_enumeration_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet enumeration.
@@ -11327,11 +12045,12 @@ def test_atomic_non_negative_integer_enumeration_nistxml_sv_iv_atomic_non_negati
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11343,11 +12062,12 @@ def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11359,11 +12079,12 @@ def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11375,11 +12096,12 @@ def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11391,11 +12113,12 @@ def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11407,11 +12130,12 @@ def test_atomic_non_negative_integer_pattern_4_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11423,11 +12147,12 @@ def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11439,11 +12164,12 @@ def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11455,11 +12181,12 @@ def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11471,11 +12198,12 @@ def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11487,11 +12215,12 @@ def test_atomic_non_negative_integer_pattern_3_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11503,11 +12232,12 @@ def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11519,11 +12249,12 @@ def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11535,11 +12266,12 @@ def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11551,11 +12283,12 @@ def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11567,11 +12300,12 @@ def test_atomic_non_negative_integer_pattern_2_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11583,11 +12317,12 @@ def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11599,11 +12334,12 @@ def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11615,11 +12351,12 @@ def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11631,11 +12368,12 @@ def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11647,11 +12385,12 @@ def test_atomic_non_negative_integer_pattern_1_nistxml_sv_iv_atomic_non_negative
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11663,11 +12402,12 @@ def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_i
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11679,11 +12419,12 @@ def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_i
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11695,11 +12436,12 @@ def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_i
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11711,11 +12453,12 @@ def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_i
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/nonNegativeInteger is restricted by facet pattern with
@@ -11727,11 +12470,12 @@ def test_atomic_non_negative_integer_pattern_nistxml_sv_iv_atomic_non_negative_i
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_negative_integer_total_digits_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11743,11 +12487,12 @@ def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_negative_integer_total_digits_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11759,11 +12504,12 @@ def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_negative_integer_total_digits_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11775,11 +12521,12 @@ def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_negative_integer_total_digits_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11791,11 +12538,12 @@ def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_negative_integer_total_digits_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11807,11 +12555,12 @@ def test_atomic_non_negative_integer_total_digits_4_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_negative_integer_total_digits_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11823,11 +12572,12 @@ def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_negative_integer_total_digits_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11839,11 +12589,12 @@ def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_negative_integer_total_digits_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11855,11 +12606,12 @@ def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_negative_integer_total_digits_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11871,11 +12623,12 @@ def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_negative_integer_total_digits_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11887,11 +12640,12 @@ def test_atomic_non_negative_integer_total_digits_3_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_negative_integer_total_digits_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11903,11 +12657,12 @@ def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_negative_integer_total_digits_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11919,11 +12674,12 @@ def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_negative_integer_total_digits_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11935,11 +12691,12 @@ def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_negative_integer_total_digits_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11951,11 +12708,12 @@ def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_negative_integer_total_digits_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11967,11 +12725,12 @@ def test_atomic_non_negative_integer_total_digits_2_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_negative_integer_total_digits_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11983,11 +12742,12 @@ def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_negative_integer_total_digits_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -11999,11 +12759,12 @@ def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_negative_integer_total_digits_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12015,11 +12776,12 @@ def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_negative_integer_total_digits_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12031,11 +12793,12 @@ def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_negative_integer_total_digits_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12047,11 +12810,12 @@ def test_atomic_non_negative_integer_total_digits_1_nistxml_sv_iv_atomic_non_neg
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negative_integer_total_digits_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12063,11 +12827,12 @@ def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negat
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negative_integer_total_digits_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12079,11 +12844,12 @@ def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negat
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negative_integer_total_digits_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12095,11 +12861,12 @@ def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negat
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negative_integer_total_digits_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12111,11 +12878,12 @@ def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negat
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negative_integer_total_digits_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet totalDigits with
@@ -12127,11 +12895,12 @@ def test_atomic_non_negative_integer_total_digits_nistxml_sv_iv_atomic_non_negat
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_negative_integer_fraction_digits_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet fractionDigits
@@ -12143,11 +12912,12 @@ def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_negative_integer_fraction_digits_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet fractionDigits
@@ -12159,11 +12929,12 @@ def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_negative_integer_fraction_digits_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet fractionDigits
@@ -12175,11 +12946,12 @@ def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_negative_integer_fraction_digits_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet fractionDigits
@@ -12191,11 +12963,12 @@ def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_negative_integer_fraction_digits_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet fractionDigits
@@ -12207,11 +12980,12 @@ def test_atomic_non_negative_integer_fraction_digits_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12223,11 +12997,12 @@ def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12239,11 +13014,12 @@ def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12255,11 +13031,12 @@ def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12271,11 +13048,12 @@ def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12287,11 +13065,12 @@ def test_atomic_non_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12303,11 +13082,12 @@ def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12319,11 +13099,12 @@ def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12335,11 +13116,12 @@ def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12351,11 +13133,12 @@ def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12367,11 +13150,12 @@ def test_atomic_non_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12383,11 +13167,12 @@ def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12399,11 +13184,12 @@ def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12415,11 +13201,12 @@ def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12431,11 +13218,12 @@ def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12447,11 +13235,12 @@ def test_atomic_non_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12463,11 +13252,12 @@ def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12479,11 +13269,12 @@ def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12495,11 +13286,12 @@ def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12511,11 +13303,12 @@ def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12527,11 +13320,12 @@ def test_atomic_non_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_inclusive_nistxml_sv_iv_atomic_non_negative_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxInclusive
@@ -12543,11 +13337,12 @@ def test_atomic_non_negative_integer_max_inclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12559,11 +13354,12 @@ def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_5_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12575,11 +13371,12 @@ def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_5_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12591,11 +13388,12 @@ def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_5_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12607,11 +13405,12 @@ def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_5_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12623,11 +13422,12 @@ def test_atomic_non_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12639,11 +13439,12 @@ def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12655,11 +13456,12 @@ def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12671,11 +13473,12 @@ def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12687,11 +13490,12 @@ def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12703,11 +13507,12 @@ def test_atomic_non_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12719,11 +13524,12 @@ def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12735,11 +13541,12 @@ def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12751,11 +13558,12 @@ def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12767,11 +13575,12 @@ def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12783,11 +13592,12 @@ def test_atomic_non_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12799,11 +13609,12 @@ def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12815,11 +13626,12 @@ def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12831,11 +13643,12 @@ def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12847,11 +13660,12 @@ def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12863,11 +13677,12 @@ def test_atomic_non_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_max_exclusive_nistxml_sv_iv_atomic_non_negative_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet maxExclusive
@@ -12879,11 +13694,12 @@ def test_atomic_non_negative_integer_max_exclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_4_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12895,11 +13711,12 @@ def test_atomic_non_negative_integer_min_inclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12911,11 +13728,12 @@ def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12927,11 +13745,12 @@ def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12943,11 +13762,12 @@ def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12959,11 +13779,12 @@ def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12975,11 +13796,12 @@ def test_atomic_non_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -12991,11 +13813,12 @@ def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13007,11 +13830,12 @@ def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13023,11 +13847,12 @@ def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13039,11 +13864,12 @@ def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13055,11 +13881,12 @@ def test_atomic_non_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13071,11 +13898,12 @@ def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13087,11 +13915,12 @@ def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13103,11 +13932,12 @@ def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13119,11 +13949,12 @@ def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13135,11 +13966,12 @@ def test_atomic_non_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13151,11 +13983,12 @@ def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13167,11 +14000,12 @@ def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13183,11 +14017,12 @@ def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13199,11 +14034,12 @@ def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_negative_integer_min_inclusive_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minInclusive
@@ -13215,11 +14051,12 @@ def test_atomic_non_negative_integer_min_inclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_4_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13231,11 +14068,12 @@ def test_atomic_non_negative_integer_min_exclusive_4_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13247,11 +14085,12 @@ def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13263,11 +14102,12 @@ def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13279,11 +14119,12 @@ def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13295,11 +14136,12 @@ def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13311,11 +14153,12 @@ def test_atomic_non_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13327,11 +14170,12 @@ def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13343,11 +14187,12 @@ def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13359,11 +14204,12 @@ def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13375,11 +14221,12 @@ def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13391,11 +14238,12 @@ def test_atomic_non_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13407,11 +14255,12 @@ def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13423,11 +14272,12 @@ def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13439,11 +14289,12 @@ def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13455,11 +14306,12 @@ def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13471,11 +14323,12 @@ def test_atomic_non_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_ne
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13487,11 +14340,12 @@ def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_1_2(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13503,11 +14357,12 @@ def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_1_3(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13519,11 +14374,12 @@ def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_1_4(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13535,11 +14391,12 @@ def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_negative_integer_min_exclusive_1_5(save_xml):
     """
     Type atomic/nonNegativeInteger is restricted by facet minExclusive
@@ -13551,11 +14408,12 @@ def test_atomic_non_negative_integer_min_exclusive_nistxml_sv_iv_atomic_non_nega
         instance="nistData/atomic/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonNegativeInteger-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet whiteSpace with value
@@ -13567,11 +14425,12 @@ def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_1(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet whiteSpace with value
@@ -13583,11 +14442,12 @@ def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_2(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet whiteSpace with value
@@ -13599,11 +14459,12 @@ def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_3(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet whiteSpace with value
@@ -13615,11 +14476,12 @@ def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_4(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet whiteSpace with value
@@ -13631,11 +14493,12 @@ def test_atomic_byte_white_space_nistxml_sv_iv_atomic_byte_white_space_1_5(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13646,11 +14509,12 @@ def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13661,11 +14525,12 @@ def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13676,11 +14541,12 @@ def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13691,11 +14557,12 @@ def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13706,11 +14573,12 @@ def test_atomic_byte_enumeration_4_nistxml_sv_iv_atomic_byte_enumeration_5_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13721,11 +14589,12 @@ def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13736,11 +14605,12 @@ def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13751,11 +14621,12 @@ def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13766,11 +14637,12 @@ def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13781,11 +14653,12 @@ def test_atomic_byte_enumeration_3_nistxml_sv_iv_atomic_byte_enumeration_4_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13796,11 +14669,12 @@ def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13811,11 +14685,12 @@ def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13826,11 +14701,12 @@ def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13841,11 +14717,12 @@ def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13856,11 +14733,12 @@ def test_atomic_byte_enumeration_2_nistxml_sv_iv_atomic_byte_enumeration_3_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13871,11 +14749,12 @@ def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13886,11 +14765,12 @@ def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13901,11 +14781,12 @@ def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13916,11 +14797,12 @@ def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13931,11 +14813,12 @@ def test_atomic_byte_enumeration_1_nistxml_sv_iv_atomic_byte_enumeration_2_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13946,11 +14829,12 @@ def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_1(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13961,11 +14845,12 @@ def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_2(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13976,11 +14861,12 @@ def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_3(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -13991,11 +14877,12 @@ def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_4(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet enumeration.
@@ -14006,11 +14893,12 @@ def test_atomic_byte_enumeration_nistxml_sv_iv_atomic_byte_enumeration_1_5(save_
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -14021,11 +14909,12 @@ def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -14036,11 +14925,12 @@ def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -14051,11 +14941,12 @@ def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -14066,11 +14957,12 @@ def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{3}.
@@ -14081,11 +14973,12 @@ def test_atomic_byte_pattern_4_nistxml_sv_iv_atomic_byte_pattern_5_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -14096,11 +14989,12 @@ def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -14111,11 +15005,12 @@ def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -14126,11 +15021,12 @@ def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -14141,11 +15037,12 @@ def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \d{1}.
@@ -14156,11 +15053,12 @@ def test_atomic_byte_pattern_3_nistxml_sv_iv_atomic_byte_pattern_4_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -14171,11 +15069,12 @@ def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -14186,11 +15085,12 @@ def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -14201,11 +15101,12 @@ def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -14216,11 +15117,12 @@ def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{1}.
@@ -14231,11 +15133,12 @@ def test_atomic_byte_pattern_2_nistxml_sv_iv_atomic_byte_pattern_3_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -14246,11 +15149,12 @@ def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -14261,11 +15165,12 @@ def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -14276,11 +15181,12 @@ def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -14291,11 +15197,12 @@ def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{2}.
@@ -14306,11 +15213,12 @@ def test_atomic_byte_pattern_1_nistxml_sv_iv_atomic_byte_pattern_2_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_1(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -14321,11 +15229,12 @@ def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_1(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_2(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -14336,11 +15245,12 @@ def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_2(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_3(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -14351,11 +15261,12 @@ def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_3(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_4(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -14366,11 +15277,12 @@ def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_4(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_5(save_xml):
     r"""
     Type atomic/byte is restricted by facet pattern with value \-\d{3}.
@@ -14381,11 +15293,12 @@ def test_atomic_byte_pattern_nistxml_sv_iv_atomic_byte_pattern_1_5(save_xml):
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 3.
@@ -14396,11 +15309,12 @@ def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 3.
@@ -14411,11 +15325,12 @@ def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_2(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 3.
@@ -14426,11 +15341,12 @@ def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_3(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 3.
@@ -14441,11 +15357,12 @@ def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_4(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 3.
@@ -14456,11 +15373,12 @@ def test_atomic_byte_total_digits_2_nistxml_sv_iv_atomic_byte_total_digits_3_5(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -14471,11 +15389,12 @@ def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -14486,11 +15405,12 @@ def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_2(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -14501,11 +15421,12 @@ def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_3(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -14516,11 +15437,12 @@ def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_4(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 2.
@@ -14531,11 +15453,12 @@ def test_atomic_byte_total_digits_1_nistxml_sv_iv_atomic_byte_total_digits_2_5(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -14546,11 +15469,12 @@ def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_1(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -14561,11 +15485,12 @@ def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_2(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -14576,11 +15501,12 @@ def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_3(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -14591,11 +15517,12 @@ def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_4(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet totalDigits with value 1.
@@ -14606,11 +15533,12 @@ def test_atomic_byte_total_digits_nistxml_sv_iv_atomic_byte_total_digits_1_5(sav
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet fractionDigits with value 0.
@@ -14621,11 +15549,12 @@ def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet fractionDigits with value 0.
@@ -14636,11 +15565,12 @@ def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet fractionDigits with value 0.
@@ -14651,11 +15581,12 @@ def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet fractionDigits with value 0.
@@ -14666,11 +15597,12 @@ def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet fractionDigits with value 0.
@@ -14681,11 +15613,12 @@ def test_atomic_byte_fraction_digits_nistxml_sv_iv_atomic_byte_fraction_digits_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 127.
@@ -14696,11 +15629,12 @@ def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 127.
@@ -14711,11 +15645,12 @@ def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 127.
@@ -14726,11 +15661,12 @@ def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 127.
@@ -14741,11 +15677,12 @@ def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 127.
@@ -14756,11 +15693,12 @@ def test_atomic_byte_max_inclusive_4_nistxml_sv_iv_atomic_byte_max_inclusive_5_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -47.
@@ -14771,11 +15709,12 @@ def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -47.
@@ -14786,11 +15725,12 @@ def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -47.
@@ -14801,11 +15741,12 @@ def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -47.
@@ -14816,11 +15757,12 @@ def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -47.
@@ -14831,11 +15773,12 @@ def test_atomic_byte_max_inclusive_3_nistxml_sv_iv_atomic_byte_max_inclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 17.
@@ -14846,11 +15789,12 @@ def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 17.
@@ -14861,11 +15805,12 @@ def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 17.
@@ -14876,11 +15821,12 @@ def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 17.
@@ -14891,11 +15837,12 @@ def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 17.
@@ -14906,11 +15853,12 @@ def test_atomic_byte_max_inclusive_2_nistxml_sv_iv_atomic_byte_max_inclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 123.
@@ -14921,11 +15869,12 @@ def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 123.
@@ -14936,11 +15885,12 @@ def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 123.
@@ -14951,11 +15901,12 @@ def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 123.
@@ -14966,11 +15917,12 @@ def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value 123.
@@ -14981,11 +15933,12 @@ def test_atomic_byte_max_inclusive_1_nistxml_sv_iv_atomic_byte_max_inclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_inclusive_nistxml_sv_iv_atomic_byte_max_inclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxInclusive with value -128.
@@ -14996,11 +15949,12 @@ def test_atomic_byte_max_inclusive_nistxml_sv_iv_atomic_byte_max_inclusive_1_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 127.
@@ -15011,11 +15965,12 @@ def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 127.
@@ -15026,11 +15981,12 @@ def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 127.
@@ -15041,11 +15997,12 @@ def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 127.
@@ -15056,11 +16013,12 @@ def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 127.
@@ -15071,11 +16029,12 @@ def test_atomic_byte_max_exclusive_4_nistxml_sv_iv_atomic_byte_max_exclusive_5_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 110.
@@ -15086,11 +16045,12 @@ def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 110.
@@ -15101,11 +16061,12 @@ def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 110.
@@ -15116,11 +16077,12 @@ def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 110.
@@ -15131,11 +16093,12 @@ def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 110.
@@ -15146,11 +16109,12 @@ def test_atomic_byte_max_exclusive_3_nistxml_sv_iv_atomic_byte_max_exclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 103.
@@ -15161,11 +16125,12 @@ def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 103.
@@ -15176,11 +16141,12 @@ def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 103.
@@ -15191,11 +16157,12 @@ def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 103.
@@ -15206,11 +16173,12 @@ def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value 103.
@@ -15221,11 +16189,12 @@ def test_atomic_byte_max_exclusive_2_nistxml_sv_iv_atomic_byte_max_exclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -15.
@@ -15236,11 +16205,12 @@ def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -15.
@@ -15251,11 +16221,12 @@ def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -15.
@@ -15266,11 +16237,12 @@ def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -15.
@@ -15281,11 +16253,12 @@ def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -15.
@@ -15296,11 +16269,12 @@ def test_atomic_byte_max_exclusive_1_nistxml_sv_iv_atomic_byte_max_exclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_max_exclusive_nistxml_sv_iv_atomic_byte_max_exclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet maxExclusive with value -127.
@@ -15311,11 +16285,12 @@ def test_atomic_byte_max_exclusive_nistxml_sv_iv_atomic_byte_max_exclusive_1_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_4_nistxml_sv_iv_atomic_byte_min_inclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 127.
@@ -15326,11 +16301,12 @@ def test_atomic_byte_min_inclusive_4_nistxml_sv_iv_atomic_byte_min_inclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -50.
@@ -15341,11 +16317,12 @@ def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -50.
@@ -15356,11 +16333,12 @@ def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -50.
@@ -15371,11 +16349,12 @@ def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -50.
@@ -15386,11 +16365,12 @@ def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -50.
@@ -15401,11 +16381,12 @@ def test_atomic_byte_min_inclusive_3_nistxml_sv_iv_atomic_byte_min_inclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 28.
@@ -15416,11 +16397,12 @@ def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 28.
@@ -15431,11 +16413,12 @@ def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 28.
@@ -15446,11 +16429,12 @@ def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 28.
@@ -15461,11 +16445,12 @@ def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 28.
@@ -15476,11 +16461,12 @@ def test_atomic_byte_min_inclusive_2_nistxml_sv_iv_atomic_byte_min_inclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 35.
@@ -15491,11 +16477,12 @@ def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 35.
@@ -15506,11 +16493,12 @@ def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 35.
@@ -15521,11 +16509,12 @@ def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 35.
@@ -15536,11 +16525,12 @@ def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value 35.
@@ -15551,11 +16541,12 @@ def test_atomic_byte_min_inclusive_1_nistxml_sv_iv_atomic_byte_min_inclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -128.
@@ -15566,11 +16557,12 @@ def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -128.
@@ -15581,11 +16573,12 @@ def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_2(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -128.
@@ -15596,11 +16589,12 @@ def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_3(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -128.
@@ -15611,11 +16605,12 @@ def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_4(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet minInclusive with value -128.
@@ -15626,11 +16621,12 @@ def test_atomic_byte_min_inclusive_nistxml_sv_iv_atomic_byte_min_inclusive_1_5(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_4_nistxml_sv_iv_atomic_byte_min_exclusive_5_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 126.
@@ -15641,11 +16637,12 @@ def test_atomic_byte_min_exclusive_4_nistxml_sv_iv_atomic_byte_min_exclusive_5_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 95.
@@ -15656,11 +16653,12 @@ def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 95.
@@ -15671,11 +16669,12 @@ def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 95.
@@ -15686,11 +16685,12 @@ def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 95.
@@ -15701,11 +16701,12 @@ def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 95.
@@ -15716,11 +16717,12 @@ def test_atomic_byte_min_exclusive_3_nistxml_sv_iv_atomic_byte_min_exclusive_4_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 79.
@@ -15731,6 +16733,6 @@ def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_19000.py
+++ b/tests/test_nist_meta_19000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 79.
@@ -11,11 +14,12 @@ def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 79.
@@ -26,11 +30,12 @@ def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 79.
@@ -41,11 +46,12 @@ def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 79.
@@ -56,11 +62,12 @@ def test_atomic_byte_min_exclusive_2_nistxml_sv_iv_atomic_byte_min_exclusive_3_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 32.
@@ -71,11 +78,12 @@ def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_1
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 32.
@@ -86,11 +94,12 @@ def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_2
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 32.
@@ -101,11 +110,12 @@ def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_3
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 32.
@@ -116,11 +126,12 @@ def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_4
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value 32.
@@ -131,11 +142,12 @@ def test_atomic_byte_min_exclusive_1_nistxml_sv_iv_atomic_byte_min_exclusive_2_5
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_1(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -128.
@@ -146,11 +158,12 @@ def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_1(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_2(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -128.
@@ -161,11 +174,12 @@ def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_2(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_3(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -128.
@@ -176,11 +190,12 @@ def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_3(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_4(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -128.
@@ -191,11 +206,12 @@ def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_4(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_5(save_xml):
     """
     Type atomic/byte is restricted by facet minExclusive with value -128.
@@ -206,11 +222,12 @@ def test_atomic_byte_min_exclusive_nistxml_sv_iv_atomic_byte_min_exclusive_1_5(s
         instance="nistData/atomic/byte/Schema+Instance/NISTXML-SV-IV-atomic-byte-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicByteMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_1(save_xml):
     """
     Type atomic/short is restricted by facet whiteSpace with value
@@ -222,11 +239,12 @@ def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_1(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_2(save_xml):
     """
     Type atomic/short is restricted by facet whiteSpace with value
@@ -238,11 +256,12 @@ def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_2(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_3(save_xml):
     """
     Type atomic/short is restricted by facet whiteSpace with value
@@ -254,11 +273,12 @@ def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_3(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_4(save_xml):
     """
     Type atomic/short is restricted by facet whiteSpace with value
@@ -270,11 +290,12 @@ def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_4(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_5(save_xml):
     """
     Type atomic/short is restricted by facet whiteSpace with value
@@ -286,11 +307,12 @@ def test_atomic_short_white_space_nistxml_sv_iv_atomic_short_white_space_1_5(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -301,11 +323,12 @@ def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -316,11 +339,12 @@ def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -331,11 +355,12 @@ def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -346,11 +371,12 @@ def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -361,11 +387,12 @@ def test_atomic_short_enumeration_4_nistxml_sv_iv_atomic_short_enumeration_5_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -376,11 +403,12 @@ def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -391,11 +419,12 @@ def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -406,11 +435,12 @@ def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -421,11 +451,12 @@ def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -436,11 +467,12 @@ def test_atomic_short_enumeration_3_nistxml_sv_iv_atomic_short_enumeration_4_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -451,11 +483,12 @@ def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -466,11 +499,12 @@ def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -481,11 +515,12 @@ def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -496,11 +531,12 @@ def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -511,11 +547,12 @@ def test_atomic_short_enumeration_2_nistxml_sv_iv_atomic_short_enumeration_3_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -526,11 +563,12 @@ def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -541,11 +579,12 @@ def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -556,11 +595,12 @@ def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -571,11 +611,12 @@ def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -586,11 +627,12 @@ def test_atomic_short_enumeration_1_nistxml_sv_iv_atomic_short_enumeration_2_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_1(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -601,11 +643,12 @@ def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_1(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_2(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -616,11 +659,12 @@ def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_2(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_3(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -631,11 +675,12 @@ def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_3(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_4(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -646,11 +691,12 @@ def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_4(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_5(save_xml):
     """
     Type atomic/short is restricted by facet enumeration.
@@ -661,11 +707,12 @@ def test_atomic_short_enumeration_nistxml_sv_iv_atomic_short_enumeration_1_5(sav
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -676,11 +723,12 @@ def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -691,11 +739,12 @@ def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -706,11 +755,12 @@ def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -721,11 +771,12 @@ def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{5}.
@@ -736,11 +787,12 @@ def test_atomic_short_pattern_4_nistxml_sv_iv_atomic_short_pattern_5_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -751,11 +803,12 @@ def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -766,11 +819,12 @@ def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -781,11 +835,12 @@ def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -796,11 +851,12 @@ def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \d{2}.
@@ -811,11 +867,12 @@ def test_atomic_short_pattern_3_nistxml_sv_iv_atomic_short_pattern_4_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -826,11 +883,12 @@ def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -841,11 +899,12 @@ def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -856,11 +915,12 @@ def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -871,11 +931,12 @@ def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{1}.
@@ -886,11 +947,12 @@ def test_atomic_short_pattern_2_nistxml_sv_iv_atomic_short_pattern_3_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -901,11 +963,12 @@ def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_1(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -916,11 +979,12 @@ def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_2(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -931,11 +995,12 @@ def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_3(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -946,11 +1011,12 @@ def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_4(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{3}.
@@ -961,11 +1027,12 @@ def test_atomic_short_pattern_1_nistxml_sv_iv_atomic_short_pattern_2_5(save_xml)
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_1(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -976,11 +1043,12 @@ def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_1(save_xml):
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_2(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -991,11 +1059,12 @@ def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_2(save_xml):
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_3(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -1006,11 +1075,12 @@ def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_3(save_xml):
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_4(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -1021,11 +1091,12 @@ def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_4(save_xml):
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_5(save_xml):
     r"""
     Type atomic/short is restricted by facet pattern with value \-\d{5}.
@@ -1036,11 +1107,12 @@ def test_atomic_short_pattern_nistxml_sv_iv_atomic_short_pattern_1_5(save_xml):
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 5.
@@ -1051,11 +1123,12 @@ def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 5.
@@ -1066,11 +1139,12 @@ def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 5.
@@ -1081,11 +1155,12 @@ def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 5.
@@ -1096,11 +1171,12 @@ def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 5.
@@ -1111,11 +1187,12 @@ def test_atomic_short_total_digits_4_nistxml_sv_iv_atomic_short_total_digits_5_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -1126,11 +1203,12 @@ def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -1141,11 +1219,12 @@ def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -1156,11 +1235,12 @@ def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -1171,11 +1251,12 @@ def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 4.
@@ -1186,11 +1267,12 @@ def test_atomic_short_total_digits_3_nistxml_sv_iv_atomic_short_total_digits_4_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -1201,11 +1283,12 @@ def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -1216,11 +1299,12 @@ def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -1231,11 +1315,12 @@ def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -1246,11 +1331,12 @@ def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 3.
@@ -1261,11 +1347,12 @@ def test_atomic_short_total_digits_2_nistxml_sv_iv_atomic_short_total_digits_3_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -1276,11 +1363,12 @@ def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -1291,11 +1379,12 @@ def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -1306,11 +1395,12 @@ def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -1321,11 +1411,12 @@ def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 2.
@@ -1336,11 +1427,12 @@ def test_atomic_short_total_digits_1_nistxml_sv_iv_atomic_short_total_digits_2_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_1(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -1351,11 +1443,12 @@ def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_1(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_2(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -1366,11 +1459,12 @@ def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_2(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_3(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -1381,11 +1475,12 @@ def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_3(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_4(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -1396,11 +1491,12 @@ def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_4(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_5(save_xml):
     """
     Type atomic/short is restricted by facet totalDigits with value 1.
@@ -1411,11 +1507,12 @@ def test_atomic_short_total_digits_nistxml_sv_iv_atomic_short_total_digits_1_5(s
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits_1_1(save_xml):
     """
     Type atomic/short is restricted by facet fractionDigits with value 0.
@@ -1426,11 +1523,12 @@ def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits_1_2(save_xml):
     """
     Type atomic/short is restricted by facet fractionDigits with value 0.
@@ -1441,11 +1539,12 @@ def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits_1_3(save_xml):
     """
     Type atomic/short is restricted by facet fractionDigits with value 0.
@@ -1456,11 +1555,12 @@ def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits_1_4(save_xml):
     """
     Type atomic/short is restricted by facet fractionDigits with value 0.
@@ -1471,11 +1571,12 @@ def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits_1_5(save_xml):
     """
     Type atomic/short is restricted by facet fractionDigits with value 0.
@@ -1486,11 +1587,12 @@ def test_atomic_short_fraction_digits_nistxml_sv_iv_atomic_short_fraction_digits
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1502,11 +1604,12 @@ def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1518,11 +1621,12 @@ def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1534,11 +1638,12 @@ def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1550,11 +1655,12 @@ def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1566,11 +1672,12 @@ def test_atomic_short_max_inclusive_4_nistxml_sv_iv_atomic_short_max_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1582,11 +1689,12 @@ def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1598,11 +1706,12 @@ def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1614,11 +1723,12 @@ def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1630,11 +1740,12 @@ def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1646,11 +1757,12 @@ def test_atomic_short_max_inclusive_3_nistxml_sv_iv_atomic_short_max_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1662,11 +1774,12 @@ def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1678,11 +1791,12 @@ def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1694,11 +1808,12 @@ def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1710,11 +1825,12 @@ def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1726,11 +1842,12 @@ def test_atomic_short_max_inclusive_2_nistxml_sv_iv_atomic_short_max_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2249.
@@ -1741,11 +1858,12 @@ def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2249.
@@ -1756,11 +1874,12 @@ def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2249.
@@ -1771,11 +1890,12 @@ def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2249.
@@ -1786,11 +1906,12 @@ def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value 2249.
@@ -1801,11 +1922,12 @@ def test_atomic_short_max_inclusive_1_nistxml_sv_iv_atomic_short_max_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_inclusive_nistxml_sv_iv_atomic_short_max_inclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet maxInclusive with value
@@ -1817,11 +1939,12 @@ def test_atomic_short_max_inclusive_nistxml_sv_iv_atomic_short_max_inclusive_1_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1833,11 +1956,12 @@ def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1849,11 +1973,12 @@ def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1865,11 +1990,12 @@ def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1881,11 +2007,12 @@ def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1897,11 +2024,12 @@ def test_atomic_short_max_exclusive_4_nistxml_sv_iv_atomic_short_max_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1913,11 +2041,12 @@ def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1929,11 +2058,12 @@ def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1945,11 +2075,12 @@ def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1961,11 +2092,12 @@ def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1977,11 +2109,12 @@ def test_atomic_short_max_exclusive_3_nistxml_sv_iv_atomic_short_max_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -1993,11 +2126,12 @@ def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2009,11 +2143,12 @@ def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2025,11 +2160,12 @@ def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2041,11 +2177,12 @@ def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2057,11 +2194,12 @@ def test_atomic_short_max_exclusive_2_nistxml_sv_iv_atomic_short_max_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2073,11 +2211,12 @@ def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2089,11 +2228,12 @@ def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2105,11 +2245,12 @@ def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2121,11 +2262,12 @@ def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2137,11 +2279,12 @@ def test_atomic_short_max_exclusive_1_nistxml_sv_iv_atomic_short_max_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_max_exclusive_nistxml_sv_iv_atomic_short_max_exclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet maxExclusive with value
@@ -2153,11 +2296,12 @@ def test_atomic_short_max_exclusive_nistxml_sv_iv_atomic_short_max_exclusive_1_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_4_nistxml_sv_iv_atomic_short_min_inclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2169,11 +2313,12 @@ def test_atomic_short_min_inclusive_4_nistxml_sv_iv_atomic_short_min_inclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2185,11 +2330,12 @@ def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2201,11 +2347,12 @@ def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2217,11 +2364,12 @@ def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2233,11 +2381,12 @@ def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2249,11 +2398,12 @@ def test_atomic_short_min_inclusive_3_nistxml_sv_iv_atomic_short_min_inclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2265,11 +2415,12 @@ def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2281,11 +2432,12 @@ def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2297,11 +2449,12 @@ def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2313,11 +2466,12 @@ def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2329,11 +2483,12 @@ def test_atomic_short_min_inclusive_2_nistxml_sv_iv_atomic_short_min_inclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2345,11 +2500,12 @@ def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2361,11 +2517,12 @@ def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2377,11 +2534,12 @@ def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2393,11 +2551,12 @@ def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2409,11 +2568,12 @@ def test_atomic_short_min_inclusive_1_nistxml_sv_iv_atomic_short_min_inclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2425,11 +2585,12 @@ def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_2(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2441,11 +2602,12 @@ def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_3(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2457,11 +2619,12 @@ def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_4(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2473,11 +2636,12 @@ def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_5(save_xml):
     """
     Type atomic/short is restricted by facet minInclusive with value
@@ -2489,11 +2653,12 @@ def test_atomic_short_min_inclusive_nistxml_sv_iv_atomic_short_min_inclusive_1_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_4_nistxml_sv_iv_atomic_short_min_exclusive_5_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2505,11 +2670,12 @@ def test_atomic_short_min_exclusive_4_nistxml_sv_iv_atomic_short_min_exclusive_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value 6725.
@@ -2520,11 +2686,12 @@ def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value 6725.
@@ -2535,11 +2702,12 @@ def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value 6725.
@@ -2550,11 +2718,12 @@ def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value 6725.
@@ -2565,11 +2734,12 @@ def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value 6725.
@@ -2580,11 +2750,12 @@ def test_atomic_short_min_exclusive_3_nistxml_sv_iv_atomic_short_min_exclusive_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2596,11 +2767,12 @@ def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2612,11 +2784,12 @@ def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2628,11 +2801,12 @@ def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2644,11 +2818,12 @@ def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2660,11 +2835,12 @@ def test_atomic_short_min_exclusive_2_nistxml_sv_iv_atomic_short_min_exclusive_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2676,11 +2852,12 @@ def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2692,11 +2869,12 @@ def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2708,11 +2886,12 @@ def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2724,11 +2903,12 @@ def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2740,11 +2920,12 @@ def test_atomic_short_min_exclusive_1_nistxml_sv_iv_atomic_short_min_exclusive_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_1(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2756,11 +2937,12 @@ def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_1
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_2(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2772,11 +2954,12 @@ def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_2
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_3(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2788,11 +2971,12 @@ def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_3
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_4(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2804,11 +2988,12 @@ def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_4
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_5(save_xml):
     """
     Type atomic/short is restricted by facet minExclusive with value
@@ -2820,11 +3005,12 @@ def test_atomic_short_min_exclusive_nistxml_sv_iv_atomic_short_min_exclusive_1_5
         instance="nistData/atomic/short/Schema+Instance/NISTXML-SV-IV-atomic-short-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicShortMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_1(save_xml):
     """
     Type atomic/int is restricted by facet whiteSpace with value collapse.
@@ -2835,11 +3021,12 @@ def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_1(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_2(save_xml):
     """
     Type atomic/int is restricted by facet whiteSpace with value collapse.
@@ -2850,11 +3037,12 @@ def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_2(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_3(save_xml):
     """
     Type atomic/int is restricted by facet whiteSpace with value collapse.
@@ -2865,11 +3053,12 @@ def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_3(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_4(save_xml):
     """
     Type atomic/int is restricted by facet whiteSpace with value collapse.
@@ -2880,11 +3069,12 @@ def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_4(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_5(save_xml):
     """
     Type atomic/int is restricted by facet whiteSpace with value collapse.
@@ -2895,11 +3085,12 @@ def test_atomic_int_white_space_nistxml_sv_iv_atomic_int_white_space_1_5(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -2910,11 +3101,12 @@ def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -2925,11 +3117,12 @@ def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -2940,11 +3133,12 @@ def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -2955,11 +3149,12 @@ def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -2970,11 +3165,12 @@ def test_atomic_int_enumeration_4_nistxml_sv_iv_atomic_int_enumeration_5_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -2985,11 +3181,12 @@ def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3000,11 +3197,12 @@ def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3015,11 +3213,12 @@ def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3030,11 +3229,12 @@ def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3045,11 +3245,12 @@ def test_atomic_int_enumeration_3_nistxml_sv_iv_atomic_int_enumeration_4_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3060,11 +3261,12 @@ def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3075,11 +3277,12 @@ def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3090,11 +3293,12 @@ def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3105,11 +3309,12 @@ def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3120,11 +3325,12 @@ def test_atomic_int_enumeration_2_nistxml_sv_iv_atomic_int_enumeration_3_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3135,11 +3341,12 @@ def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3150,11 +3357,12 @@ def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3165,11 +3373,12 @@ def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3180,11 +3389,12 @@ def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3195,11 +3405,12 @@ def test_atomic_int_enumeration_1_nistxml_sv_iv_atomic_int_enumeration_2_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_1(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3210,11 +3421,12 @@ def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_1(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_2(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3225,11 +3437,12 @@ def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_2(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_3(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3240,11 +3453,12 @@ def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_3(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_4(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3255,11 +3469,12 @@ def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_4(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_5(save_xml):
     """
     Type atomic/int is restricted by facet enumeration.
@@ -3270,11 +3485,12 @@ def test_atomic_int_enumeration_nistxml_sv_iv_atomic_int_enumeration_1_5(save_xm
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -3285,11 +3501,12 @@ def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -3300,11 +3517,12 @@ def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -3315,11 +3533,12 @@ def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -3330,11 +3549,12 @@ def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{10}.
@@ -3345,11 +3565,12 @@ def test_atomic_int_pattern_4_nistxml_sv_iv_atomic_int_pattern_5_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -3360,11 +3581,12 @@ def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -3375,11 +3597,12 @@ def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -3390,11 +3613,12 @@ def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -3405,11 +3629,12 @@ def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \d{3}.
@@ -3420,11 +3645,12 @@ def test_atomic_int_pattern_3_nistxml_sv_iv_atomic_int_pattern_4_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -3435,11 +3661,12 @@ def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -3450,11 +3677,12 @@ def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -3465,11 +3693,12 @@ def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -3480,11 +3709,12 @@ def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{1}.
@@ -3495,11 +3725,12 @@ def test_atomic_int_pattern_2_nistxml_sv_iv_atomic_int_pattern_3_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -3510,11 +3741,12 @@ def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -3525,11 +3757,12 @@ def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -3540,11 +3773,12 @@ def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -3555,11 +3789,12 @@ def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{5}.
@@ -3570,11 +3805,12 @@ def test_atomic_int_pattern_1_nistxml_sv_iv_atomic_int_pattern_2_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_1(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -3585,11 +3821,12 @@ def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_1(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_2(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -3600,11 +3837,12 @@ def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_2(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_3(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -3615,11 +3853,12 @@ def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_3(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_4(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -3630,11 +3869,12 @@ def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_4(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_5(save_xml):
     r"""
     Type atomic/int is restricted by facet pattern with value \-\d{10}.
@@ -3645,11 +3885,12 @@ def test_atomic_int_pattern_nistxml_sv_iv_atomic_int_pattern_1_5(save_xml):
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 10.
@@ -3660,11 +3901,12 @@ def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 10.
@@ -3675,11 +3917,12 @@ def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 10.
@@ -3690,11 +3933,12 @@ def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 10.
@@ -3705,11 +3949,12 @@ def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 10.
@@ -3720,11 +3965,12 @@ def test_atomic_int_total_digits_4_nistxml_sv_iv_atomic_int_total_digits_5_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 7.
@@ -3735,11 +3981,12 @@ def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 7.
@@ -3750,11 +3997,12 @@ def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 7.
@@ -3765,11 +4013,12 @@ def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 7.
@@ -3780,11 +4029,12 @@ def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 7.
@@ -3795,11 +4045,12 @@ def test_atomic_int_total_digits_3_nistxml_sv_iv_atomic_int_total_digits_4_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -3810,11 +4061,12 @@ def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -3825,11 +4077,12 @@ def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -3840,11 +4093,12 @@ def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -3855,11 +4109,12 @@ def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 5.
@@ -3870,11 +4125,12 @@ def test_atomic_int_total_digits_2_nistxml_sv_iv_atomic_int_total_digits_3_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -3885,11 +4141,12 @@ def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -3900,11 +4157,12 @@ def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -3915,11 +4173,12 @@ def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -3930,11 +4189,12 @@ def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 3.
@@ -3945,11 +4205,12 @@ def test_atomic_int_total_digits_1_nistxml_sv_iv_atomic_int_total_digits_2_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_1(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -3960,11 +4221,12 @@ def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_1(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_2(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -3975,11 +4237,12 @@ def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_2(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_3(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -3990,11 +4253,12 @@ def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_3(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_4(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4005,11 +4269,12 @@ def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_4(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_5(save_xml):
     """
     Type atomic/int is restricted by facet totalDigits with value 1.
@@ -4020,11 +4285,12 @@ def test_atomic_int_total_digits_nistxml_sv_iv_atomic_int_total_digits_1_5(save_
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_1(save_xml):
     """
     Type atomic/int is restricted by facet fractionDigits with value 0.
@@ -4035,11 +4301,12 @@ def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_1
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_2(save_xml):
     """
     Type atomic/int is restricted by facet fractionDigits with value 0.
@@ -4050,11 +4317,12 @@ def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_2
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_3(save_xml):
     """
     Type atomic/int is restricted by facet fractionDigits with value 0.
@@ -4065,11 +4333,12 @@ def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_3
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_4(save_xml):
     """
     Type atomic/int is restricted by facet fractionDigits with value 0.
@@ -4080,11 +4349,12 @@ def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_4
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_5(save_xml):
     """
     Type atomic/int is restricted by facet fractionDigits with value 0.
@@ -4095,11 +4365,12 @@ def test_atomic_int_fraction_digits_nistxml_sv_iv_atomic_int_fraction_digits_1_5
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4111,11 +4382,12 @@ def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4127,11 +4399,12 @@ def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4143,11 +4416,12 @@ def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4159,11 +4433,12 @@ def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4175,11 +4450,12 @@ def test_atomic_int_max_inclusive_4_nistxml_sv_iv_atomic_int_max_inclusive_5_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4191,11 +4467,12 @@ def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4207,11 +4484,12 @@ def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4223,11 +4501,12 @@ def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4239,11 +4518,12 @@ def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4255,11 +4535,12 @@ def test_atomic_int_max_inclusive_3_nistxml_sv_iv_atomic_int_max_inclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4271,11 +4552,12 @@ def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4287,11 +4569,12 @@ def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4303,11 +4586,12 @@ def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4319,11 +4603,12 @@ def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4335,11 +4620,12 @@ def test_atomic_int_max_inclusive_2_nistxml_sv_iv_atomic_int_max_inclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4351,11 +4637,12 @@ def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4367,11 +4654,12 @@ def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4383,11 +4671,12 @@ def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4399,11 +4688,12 @@ def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4415,11 +4705,12 @@ def test_atomic_int_max_inclusive_1_nistxml_sv_iv_atomic_int_max_inclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_inclusive_nistxml_sv_iv_atomic_int_max_inclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet maxInclusive with value
@@ -4431,11 +4722,12 @@ def test_atomic_int_max_inclusive_nistxml_sv_iv_atomic_int_max_inclusive_1_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4447,11 +4739,12 @@ def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4463,11 +4756,12 @@ def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4479,11 +4773,12 @@ def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4495,11 +4790,12 @@ def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4511,11 +4807,12 @@ def test_atomic_int_max_exclusive_4_nistxml_sv_iv_atomic_int_max_exclusive_5_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4527,11 +4824,12 @@ def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4543,11 +4841,12 @@ def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4559,11 +4858,12 @@ def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4575,11 +4875,12 @@ def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4591,11 +4892,12 @@ def test_atomic_int_max_exclusive_3_nistxml_sv_iv_atomic_int_max_exclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4607,11 +4909,12 @@ def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4623,11 +4926,12 @@ def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4639,11 +4943,12 @@ def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4655,11 +4960,12 @@ def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4671,11 +4977,12 @@ def test_atomic_int_max_exclusive_2_nistxml_sv_iv_atomic_int_max_exclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4687,11 +4994,12 @@ def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4703,11 +5011,12 @@ def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4719,11 +5028,12 @@ def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4735,11 +5045,12 @@ def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4751,11 +5062,12 @@ def test_atomic_int_max_exclusive_1_nistxml_sv_iv_atomic_int_max_exclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_max_exclusive_nistxml_sv_iv_atomic_int_max_exclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet maxExclusive with value
@@ -4767,11 +5079,12 @@ def test_atomic_int_max_exclusive_nistxml_sv_iv_atomic_int_max_exclusive_1_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_4_nistxml_sv_iv_atomic_int_min_inclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4783,11 +5096,12 @@ def test_atomic_int_min_inclusive_4_nistxml_sv_iv_atomic_int_min_inclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4799,11 +5113,12 @@ def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4815,11 +5130,12 @@ def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4831,11 +5147,12 @@ def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4847,11 +5164,12 @@ def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4863,11 +5181,12 @@ def test_atomic_int_min_inclusive_3_nistxml_sv_iv_atomic_int_min_inclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4879,11 +5198,12 @@ def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4895,11 +5215,12 @@ def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4911,11 +5232,12 @@ def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4927,11 +5249,12 @@ def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4943,11 +5266,12 @@ def test_atomic_int_min_inclusive_2_nistxml_sv_iv_atomic_int_min_inclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4959,11 +5283,12 @@ def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4975,11 +5300,12 @@ def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -4991,11 +5317,12 @@ def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5007,11 +5334,12 @@ def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5023,11 +5351,12 @@ def test_atomic_int_min_inclusive_1_nistxml_sv_iv_atomic_int_min_inclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5039,11 +5368,12 @@ def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_2(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5055,11 +5385,12 @@ def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_3(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5071,11 +5402,12 @@ def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_4(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5087,11 +5419,12 @@ def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_5(save_xml):
     """
     Type atomic/int is restricted by facet minInclusive with value
@@ -5103,11 +5436,12 @@ def test_atomic_int_min_inclusive_nistxml_sv_iv_atomic_int_min_inclusive_1_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_4_nistxml_sv_iv_atomic_int_min_exclusive_5_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5119,11 +5453,12 @@ def test_atomic_int_min_exclusive_4_nistxml_sv_iv_atomic_int_min_exclusive_5_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5135,11 +5470,12 @@ def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5151,11 +5487,12 @@ def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5167,11 +5504,12 @@ def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5183,11 +5521,12 @@ def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5199,11 +5538,12 @@ def test_atomic_int_min_exclusive_3_nistxml_sv_iv_atomic_int_min_exclusive_4_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5215,11 +5555,12 @@ def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5231,11 +5572,12 @@ def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5247,11 +5589,12 @@ def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5263,11 +5606,12 @@ def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5279,11 +5623,12 @@ def test_atomic_int_min_exclusive_2_nistxml_sv_iv_atomic_int_min_exclusive_3_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5295,11 +5640,12 @@ def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_1(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5311,11 +5657,12 @@ def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_2(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5327,11 +5674,12 @@ def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_3(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5343,11 +5691,12 @@ def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_4(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5359,11 +5708,12 @@ def test_atomic_int_min_exclusive_1_nistxml_sv_iv_atomic_int_min_exclusive_2_5(s
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_1(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5375,11 +5725,12 @@ def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_1(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_2(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5391,11 +5742,12 @@ def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_2(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_3(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5407,11 +5759,12 @@ def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_3(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_4(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5423,11 +5776,12 @@ def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_4(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_5(save_xml):
     """
     Type atomic/int is restricted by facet minExclusive with value
@@ -5439,11 +5793,12 @@ def test_atomic_int_min_exclusive_nistxml_sv_iv_atomic_int_min_exclusive_1_5(sav
         instance="nistData/atomic/int/Schema+Instance/NISTXML-SV-IV-atomic-int-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_1(save_xml):
     """
     Type atomic/long is restricted by facet whiteSpace with value
@@ -5455,11 +5810,12 @@ def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_1(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_2(save_xml):
     """
     Type atomic/long is restricted by facet whiteSpace with value
@@ -5471,11 +5827,12 @@ def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_2(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_3(save_xml):
     """
     Type atomic/long is restricted by facet whiteSpace with value
@@ -5487,11 +5844,12 @@ def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_3(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_4(save_xml):
     """
     Type atomic/long is restricted by facet whiteSpace with value
@@ -5503,11 +5861,12 @@ def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_4(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_5(save_xml):
     """
     Type atomic/long is restricted by facet whiteSpace with value
@@ -5519,11 +5878,12 @@ def test_atomic_long_white_space_nistxml_sv_iv_atomic_long_white_space_1_5(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5534,11 +5894,12 @@ def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5549,11 +5910,12 @@ def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5564,11 +5926,12 @@ def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5579,11 +5942,12 @@ def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5594,11 +5958,12 @@ def test_atomic_long_enumeration_4_nistxml_sv_iv_atomic_long_enumeration_5_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5609,11 +5974,12 @@ def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5624,11 +5990,12 @@ def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5639,11 +6006,12 @@ def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5654,11 +6022,12 @@ def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5669,11 +6038,12 @@ def test_atomic_long_enumeration_3_nistxml_sv_iv_atomic_long_enumeration_4_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5684,11 +6054,12 @@ def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5699,11 +6070,12 @@ def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5714,11 +6086,12 @@ def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5729,11 +6102,12 @@ def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5744,11 +6118,12 @@ def test_atomic_long_enumeration_2_nistxml_sv_iv_atomic_long_enumeration_3_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5759,11 +6134,12 @@ def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5774,11 +6150,12 @@ def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5789,11 +6166,12 @@ def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5804,11 +6182,12 @@ def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5819,11 +6198,12 @@ def test_atomic_long_enumeration_1_nistxml_sv_iv_atomic_long_enumeration_2_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_1(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5834,11 +6214,12 @@ def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_1(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_2(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5849,11 +6230,12 @@ def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_2(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_3(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5864,11 +6246,12 @@ def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_3(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_4(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5879,11 +6262,12 @@ def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_4(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_5(save_xml):
     """
     Type atomic/long is restricted by facet enumeration.
@@ -5894,11 +6278,12 @@ def test_atomic_long_enumeration_nistxml_sv_iv_atomic_long_enumeration_1_5(save_
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -5909,11 +6294,12 @@ def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -5924,11 +6310,12 @@ def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -5939,11 +6326,12 @@ def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -5954,11 +6342,12 @@ def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{18}.
@@ -5969,11 +6358,12 @@ def test_atomic_long_pattern_4_nistxml_sv_iv_atomic_long_pattern_5_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -5984,11 +6374,12 @@ def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -5999,11 +6390,12 @@ def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -6014,11 +6406,12 @@ def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -6029,11 +6422,12 @@ def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \d{5}.
@@ -6044,11 +6438,12 @@ def test_atomic_long_pattern_3_nistxml_sv_iv_atomic_long_pattern_4_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -6059,11 +6454,12 @@ def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -6074,11 +6470,12 @@ def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -6089,11 +6486,12 @@ def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -6104,11 +6502,12 @@ def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{1}.
@@ -6119,11 +6518,12 @@ def test_atomic_long_pattern_2_nistxml_sv_iv_atomic_long_pattern_3_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -6134,11 +6534,12 @@ def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -6149,11 +6550,12 @@ def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -6164,11 +6566,12 @@ def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -6179,11 +6582,12 @@ def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{9}.
@@ -6194,11 +6598,12 @@ def test_atomic_long_pattern_1_nistxml_sv_iv_atomic_long_pattern_2_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_1(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -6209,11 +6614,12 @@ def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_1(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_2(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -6224,11 +6630,12 @@ def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_2(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_3(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -6239,11 +6646,12 @@ def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_3(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_4(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -6254,11 +6662,12 @@ def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_4(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_5(save_xml):
     r"""
     Type atomic/long is restricted by facet pattern with value \-\d{18}.
@@ -6269,11 +6678,12 @@ def test_atomic_long_pattern_nistxml_sv_iv_atomic_long_pattern_1_5(save_xml):
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 18.
@@ -6284,11 +6694,12 @@ def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 18.
@@ -6299,11 +6710,12 @@ def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 18.
@@ -6314,11 +6726,12 @@ def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 18.
@@ -6329,11 +6742,12 @@ def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 18.
@@ -6344,11 +6758,12 @@ def test_atomic_long_total_digits_4_nistxml_sv_iv_atomic_long_total_digits_5_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -6359,11 +6774,12 @@ def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -6374,11 +6790,12 @@ def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -6389,11 +6806,12 @@ def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -6404,11 +6822,12 @@ def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 13.
@@ -6419,11 +6838,12 @@ def test_atomic_long_total_digits_3_nistxml_sv_iv_atomic_long_total_digits_4_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 9.
@@ -6434,11 +6854,12 @@ def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 9.
@@ -6449,11 +6870,12 @@ def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 9.
@@ -6464,11 +6886,12 @@ def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 9.
@@ -6479,11 +6902,12 @@ def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 9.
@@ -6494,11 +6918,12 @@ def test_atomic_long_total_digits_2_nistxml_sv_iv_atomic_long_total_digits_3_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 5.
@@ -6509,11 +6934,12 @@ def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 5.
@@ -6524,11 +6950,12 @@ def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 5.
@@ -6539,11 +6966,12 @@ def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 5.
@@ -6554,11 +6982,12 @@ def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 5.
@@ -6569,11 +6998,12 @@ def test_atomic_long_total_digits_1_nistxml_sv_iv_atomic_long_total_digits_2_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_1(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -6584,11 +7014,12 @@ def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_1(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_2(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -6599,11 +7030,12 @@ def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_2(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_3(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -6614,11 +7046,12 @@ def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_3(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_4(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -6629,11 +7062,12 @@ def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_4(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_5(save_xml):
     """
     Type atomic/long is restricted by facet totalDigits with value 1.
@@ -6644,11 +7078,12 @@ def test_atomic_long_total_digits_nistxml_sv_iv_atomic_long_total_digits_1_5(sav
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1_1(save_xml):
     """
     Type atomic/long is restricted by facet fractionDigits with value 0.
@@ -6659,11 +7094,12 @@ def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1_2(save_xml):
     """
     Type atomic/long is restricted by facet fractionDigits with value 0.
@@ -6674,11 +7110,12 @@ def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1_3(save_xml):
     """
     Type atomic/long is restricted by facet fractionDigits with value 0.
@@ -6689,11 +7126,12 @@ def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1_4(save_xml):
     """
     Type atomic/long is restricted by facet fractionDigits with value 0.
@@ -6704,11 +7142,12 @@ def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1_5(save_xml):
     """
     Type atomic/long is restricted by facet fractionDigits with value 0.
@@ -6719,11 +7158,12 @@ def test_atomic_long_fraction_digits_nistxml_sv_iv_atomic_long_fraction_digits_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6735,11 +7175,12 @@ def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6751,11 +7192,12 @@ def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6767,11 +7209,12 @@ def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6783,11 +7226,12 @@ def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6799,11 +7243,12 @@ def test_atomic_long_max_inclusive_4_nistxml_sv_iv_atomic_long_max_inclusive_5_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6815,11 +7260,12 @@ def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6831,11 +7277,12 @@ def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6847,11 +7294,12 @@ def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6863,11 +7311,12 @@ def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6879,11 +7328,12 @@ def test_atomic_long_max_inclusive_3_nistxml_sv_iv_atomic_long_max_inclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6895,11 +7345,12 @@ def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6911,11 +7362,12 @@ def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6927,11 +7379,12 @@ def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6943,11 +7396,12 @@ def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6959,11 +7413,12 @@ def test_atomic_long_max_inclusive_2_nistxml_sv_iv_atomic_long_max_inclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6975,11 +7430,12 @@ def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -6991,11 +7447,12 @@ def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -7007,11 +7464,12 @@ def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -7023,11 +7481,12 @@ def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -7039,11 +7498,12 @@ def test_atomic_long_max_inclusive_1_nistxml_sv_iv_atomic_long_max_inclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_inclusive_nistxml_sv_iv_atomic_long_max_inclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet maxInclusive with value
@@ -7055,11 +7515,12 @@ def test_atomic_long_max_inclusive_nistxml_sv_iv_atomic_long_max_inclusive_1_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7071,11 +7532,12 @@ def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7087,11 +7549,12 @@ def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7103,11 +7566,12 @@ def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7119,11 +7583,12 @@ def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7135,11 +7600,12 @@ def test_atomic_long_max_exclusive_4_nistxml_sv_iv_atomic_long_max_exclusive_5_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7151,11 +7617,12 @@ def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7167,11 +7634,12 @@ def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7183,11 +7651,12 @@ def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7199,11 +7668,12 @@ def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7215,11 +7685,12 @@ def test_atomic_long_max_exclusive_3_nistxml_sv_iv_atomic_long_max_exclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7231,11 +7702,12 @@ def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7247,11 +7719,12 @@ def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7263,11 +7736,12 @@ def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7279,11 +7753,12 @@ def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7295,11 +7770,12 @@ def test_atomic_long_max_exclusive_2_nistxml_sv_iv_atomic_long_max_exclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7311,11 +7787,12 @@ def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7327,11 +7804,12 @@ def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7343,11 +7821,12 @@ def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7359,11 +7838,12 @@ def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7375,11 +7855,12 @@ def test_atomic_long_max_exclusive_1_nistxml_sv_iv_atomic_long_max_exclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_max_exclusive_nistxml_sv_iv_atomic_long_max_exclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet maxExclusive with value
@@ -7391,11 +7872,12 @@ def test_atomic_long_max_exclusive_nistxml_sv_iv_atomic_long_max_exclusive_1_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_4_nistxml_sv_iv_atomic_long_min_inclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7407,11 +7889,12 @@ def test_atomic_long_min_inclusive_4_nistxml_sv_iv_atomic_long_min_inclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7423,11 +7906,12 @@ def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7439,11 +7923,12 @@ def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7455,11 +7940,12 @@ def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7471,11 +7957,12 @@ def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7487,11 +7974,12 @@ def test_atomic_long_min_inclusive_3_nistxml_sv_iv_atomic_long_min_inclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7503,11 +7991,12 @@ def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7519,11 +8008,12 @@ def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7535,11 +8025,12 @@ def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7551,11 +8042,12 @@ def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7567,11 +8059,12 @@ def test_atomic_long_min_inclusive_2_nistxml_sv_iv_atomic_long_min_inclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7583,11 +8076,12 @@ def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7599,11 +8093,12 @@ def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7615,11 +8110,12 @@ def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7631,11 +8127,12 @@ def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7647,11 +8144,12 @@ def test_atomic_long_min_inclusive_1_nistxml_sv_iv_atomic_long_min_inclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7663,11 +8161,12 @@ def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_2(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7679,11 +8178,12 @@ def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_3(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7695,11 +8195,12 @@ def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_4(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7711,11 +8212,12 @@ def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_5(save_xml):
     """
     Type atomic/long is restricted by facet minInclusive with value
@@ -7727,11 +8229,12 @@ def test_atomic_long_min_inclusive_nistxml_sv_iv_atomic_long_min_inclusive_1_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_4_nistxml_sv_iv_atomic_long_min_exclusive_5_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7743,11 +8246,12 @@ def test_atomic_long_min_exclusive_4_nistxml_sv_iv_atomic_long_min_exclusive_5_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7759,11 +8263,12 @@ def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7775,11 +8280,12 @@ def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7791,11 +8297,12 @@ def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7807,11 +8314,12 @@ def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7823,11 +8331,12 @@ def test_atomic_long_min_exclusive_3_nistxml_sv_iv_atomic_long_min_exclusive_4_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7839,11 +8348,12 @@ def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7855,11 +8365,12 @@ def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7871,11 +8382,12 @@ def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7887,11 +8399,12 @@ def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7903,11 +8416,12 @@ def test_atomic_long_min_exclusive_2_nistxml_sv_iv_atomic_long_min_exclusive_3_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7919,11 +8433,12 @@ def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_1
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7935,11 +8450,12 @@ def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_2
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7951,11 +8467,12 @@ def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_3
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7967,11 +8484,12 @@ def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_4
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7983,11 +8501,12 @@ def test_atomic_long_min_exclusive_1_nistxml_sv_iv_atomic_long_min_exclusive_2_5
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_1(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -7999,11 +8518,12 @@ def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_1(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_2(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -8015,11 +8535,12 @@ def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_2(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_3(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -8031,11 +8552,12 @@ def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_3(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_4(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -8047,11 +8569,12 @@ def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_4(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_5(save_xml):
     """
     Type atomic/long is restricted by facet minExclusive with value
@@ -8063,11 +8586,12 @@ def test_atomic_long_min_exclusive_nistxml_sv_iv_atomic_long_min_exclusive_1_5(s
         instance="nistData/atomic/long/Schema+Instance/NISTXML-SV-IV-atomic-long-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicLongMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integer_white_space_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet whiteSpace with
@@ -8079,11 +8603,12 @@ def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integer_white_space_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet whiteSpace with
@@ -8095,11 +8620,12 @@ def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integer_white_space_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet whiteSpace with
@@ -8111,11 +8637,12 @@ def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integer_white_space_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet whiteSpace with
@@ -8127,11 +8654,12 @@ def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integer_white_space_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet whiteSpace with
@@ -8143,11 +8671,12 @@ def test_atomic_negative_integer_white_space_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_integer_enumeration_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8158,11 +8687,12 @@ def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_integer_enumeration_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8173,11 +8703,12 @@ def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_integer_enumeration_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8188,11 +8719,12 @@ def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_integer_enumeration_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8203,11 +8735,12 @@ def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_integer_enumeration_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8218,11 +8751,12 @@ def test_atomic_negative_integer_enumeration_4_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_integer_enumeration_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8233,11 +8767,12 @@ def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_integer_enumeration_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8248,11 +8783,12 @@ def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_integer_enumeration_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8263,11 +8799,12 @@ def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_integer_enumeration_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8278,11 +8815,12 @@ def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_integer_enumeration_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8293,11 +8831,12 @@ def test_atomic_negative_integer_enumeration_3_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_integer_enumeration_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8308,11 +8847,12 @@ def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_integer_enumeration_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8323,11 +8863,12 @@ def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_integer_enumeration_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8338,11 +8879,12 @@ def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_integer_enumeration_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8353,11 +8895,12 @@ def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_integer_enumeration_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8368,11 +8911,12 @@ def test_atomic_negative_integer_enumeration_2_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_integer_enumeration_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8383,11 +8927,12 @@ def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_integer_enumeration_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8398,11 +8943,12 @@ def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_integer_enumeration_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8413,11 +8959,12 @@ def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_integer_enumeration_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8428,11 +8975,12 @@ def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_integer_enumeration_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8443,11 +8991,12 @@ def test_atomic_negative_integer_enumeration_1_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integer_enumeration_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8458,11 +9007,12 @@ def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integer_enumeration_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8473,11 +9023,12 @@ def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integer_enumeration_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8488,11 +9039,12 @@ def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integer_enumeration_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8503,11 +9055,12 @@ def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integer_enumeration_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet enumeration.
@@ -8518,11 +9071,12 @@ def test_atomic_negative_integer_enumeration_nistxml_sv_iv_atomic_negative_integ
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8534,11 +9088,12 @@ def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8550,11 +9105,12 @@ def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8566,11 +9122,12 @@ def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8582,11 +9139,12 @@ def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8598,11 +9156,12 @@ def test_atomic_negative_integer_pattern_4_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8614,11 +9173,12 @@ def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8630,11 +9190,12 @@ def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8646,11 +9207,12 @@ def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8662,11 +9224,12 @@ def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8678,11 +9241,12 @@ def test_atomic_negative_integer_pattern_3_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8694,11 +9258,12 @@ def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8710,11 +9275,12 @@ def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8726,11 +9292,12 @@ def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8742,11 +9309,12 @@ def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8758,11 +9326,12 @@ def test_atomic_negative_integer_pattern_2_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8774,11 +9343,12 @@ def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8790,11 +9360,12 @@ def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8806,11 +9377,12 @@ def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8822,11 +9394,12 @@ def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8838,11 +9411,12 @@ def test_atomic_negative_integer_pattern_1_nistxml_sv_iv_atomic_negative_integer
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8854,11 +9428,12 @@ def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_p
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8870,11 +9445,12 @@ def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_p
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8886,11 +9462,12 @@ def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_p
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8902,11 +9479,12 @@ def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_p
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/negativeInteger is restricted by facet pattern with value
@@ -8918,11 +9496,12 @@ def test_atomic_negative_integer_pattern_nistxml_sv_iv_atomic_negative_integer_p
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_integer_total_digits_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -8934,11 +9513,12 @@ def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_integer_total_digits_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -8950,11 +9530,12 @@ def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_integer_total_digits_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -8966,11 +9547,12 @@ def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_integer_total_digits_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -8982,11 +9564,12 @@ def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_integer_total_digits_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -8998,11 +9581,12 @@ def test_atomic_negative_integer_total_digits_4_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_integer_total_digits_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9014,11 +9598,12 @@ def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_integer_total_digits_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9030,11 +9615,12 @@ def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_integer_total_digits_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9046,11 +9632,12 @@ def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_integer_total_digits_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9062,11 +9649,12 @@ def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_integer_total_digits_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9078,11 +9666,12 @@ def test_atomic_negative_integer_total_digits_3_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_integer_total_digits_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9094,11 +9683,12 @@ def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_integer_total_digits_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9110,11 +9700,12 @@ def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_integer_total_digits_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9126,11 +9717,12 @@ def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_integer_total_digits_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9142,11 +9734,12 @@ def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_integer_total_digits_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9158,11 +9751,12 @@ def test_atomic_negative_integer_total_digits_2_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_integer_total_digits_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9174,11 +9768,12 @@ def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_integer_total_digits_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9190,11 +9785,12 @@ def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_integer_total_digits_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9206,11 +9802,12 @@ def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_integer_total_digits_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9222,11 +9819,12 @@ def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_integer_total_digits_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9238,11 +9836,12 @@ def test_atomic_negative_integer_total_digits_1_nistxml_sv_iv_atomic_negative_in
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_integer_total_digits_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9254,11 +9853,12 @@ def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_inte
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_integer_total_digits_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9270,11 +9870,12 @@ def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_inte
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_integer_total_digits_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9286,11 +9887,12 @@ def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_inte
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_integer_total_digits_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9302,11 +9904,12 @@ def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_inte
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_integer_total_digits_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet totalDigits with
@@ -9318,11 +9921,12 @@ def test_atomic_negative_integer_total_digits_nistxml_sv_iv_atomic_negative_inte
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_integer_fraction_digits_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet fractionDigits with
@@ -9334,11 +9938,12 @@ def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_integer_fraction_digits_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet fractionDigits with
@@ -9350,11 +9955,12 @@ def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_integer_fraction_digits_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet fractionDigits with
@@ -9366,11 +9972,12 @@ def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_integer_fraction_digits_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet fractionDigits with
@@ -9382,11 +9989,12 @@ def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_integer_fraction_digits_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet fractionDigits with
@@ -9398,11 +10006,12 @@ def test_atomic_negative_integer_fraction_digits_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9414,11 +10023,12 @@ def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9430,11 +10040,12 @@ def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9446,11 +10057,12 @@ def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9462,11 +10074,12 @@ def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9478,11 +10091,12 @@ def test_atomic_negative_integer_max_inclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9494,11 +10108,12 @@ def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9510,11 +10125,12 @@ def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9526,11 +10142,12 @@ def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9542,11 +10159,12 @@ def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9558,11 +10176,12 @@ def test_atomic_negative_integer_max_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9574,11 +10193,12 @@ def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9590,11 +10210,12 @@ def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9606,11 +10227,12 @@ def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9622,11 +10244,12 @@ def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9638,11 +10261,12 @@ def test_atomic_negative_integer_max_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9654,11 +10278,12 @@ def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9670,11 +10295,12 @@ def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9686,11 +10312,12 @@ def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9702,11 +10329,12 @@ def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9718,11 +10346,12 @@ def test_atomic_negative_integer_max_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_inclusive_nistxml_sv_iv_atomic_negative_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxInclusive with
@@ -9734,11 +10363,12 @@ def test_atomic_negative_integer_max_inclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9750,11 +10380,12 @@ def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_integer_max_exclusive_5_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9766,11 +10397,12 @@ def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_integer_max_exclusive_5_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9782,11 +10414,12 @@ def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_integer_max_exclusive_5_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9798,11 +10431,12 @@ def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_integer_max_exclusive_5_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9814,11 +10448,12 @@ def test_atomic_negative_integer_max_exclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9830,11 +10465,12 @@ def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9846,11 +10482,12 @@ def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9862,11 +10499,12 @@ def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9878,11 +10516,12 @@ def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9894,11 +10533,12 @@ def test_atomic_negative_integer_max_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9910,11 +10550,12 @@ def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9926,11 +10567,12 @@ def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9942,11 +10584,12 @@ def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9958,11 +10601,12 @@ def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9974,11 +10618,12 @@ def test_atomic_negative_integer_max_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -9990,11 +10635,12 @@ def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -10006,11 +10652,12 @@ def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -10022,11 +10669,12 @@ def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -10038,11 +10686,12 @@ def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -10054,11 +10703,12 @@ def test_atomic_negative_integer_max_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_max_exclusive_nistxml_sv_iv_atomic_negative_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet maxExclusive with
@@ -10070,11 +10720,12 @@ def test_atomic_negative_integer_max_exclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_4_nistxml_sv_iv_atomic_negative_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10086,11 +10737,12 @@ def test_atomic_negative_integer_min_inclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10102,11 +10754,12 @@ def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10118,11 +10771,12 @@ def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10134,11 +10788,12 @@ def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10150,11 +10805,12 @@ def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10166,11 +10822,12 @@ def test_atomic_negative_integer_min_inclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10182,11 +10839,12 @@ def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10198,11 +10856,12 @@ def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10214,11 +10873,12 @@ def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10230,11 +10890,12 @@ def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10246,11 +10907,12 @@ def test_atomic_negative_integer_min_inclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10262,11 +10924,12 @@ def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10278,11 +10941,12 @@ def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10294,11 +10958,12 @@ def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10310,11 +10975,12 @@ def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10326,11 +10992,12 @@ def test_atomic_negative_integer_min_inclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_integer_min_inclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10342,11 +11009,12 @@ def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_integer_min_inclusive_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10358,11 +11026,12 @@ def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_integer_min_inclusive_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10374,11 +11043,12 @@ def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_integer_min_inclusive_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10390,11 +11060,12 @@ def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_integer_min_inclusive_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minInclusive with
@@ -10406,11 +11077,12 @@ def test_atomic_negative_integer_min_inclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_4_nistxml_sv_iv_atomic_negative_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10422,11 +11094,12 @@ def test_atomic_negative_integer_min_exclusive_4_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10438,11 +11111,12 @@ def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10454,11 +11128,12 @@ def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10470,11 +11145,12 @@ def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10486,11 +11162,12 @@ def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10502,11 +11179,12 @@ def test_atomic_negative_integer_min_exclusive_3_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10518,11 +11196,12 @@ def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10534,11 +11213,12 @@ def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10550,11 +11230,12 @@ def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10566,11 +11247,12 @@ def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10582,11 +11264,12 @@ def test_atomic_negative_integer_min_exclusive_2_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10598,11 +11281,12 @@ def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10614,11 +11298,12 @@ def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10630,11 +11315,12 @@ def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10646,11 +11332,12 @@ def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10662,11 +11349,12 @@ def test_atomic_negative_integer_min_exclusive_1_nistxml_sv_iv_atomic_negative_i
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10678,11 +11366,12 @@ def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_integer_min_exclusive_1_2(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10694,11 +11383,12 @@ def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_integer_min_exclusive_1_3(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10710,11 +11400,12 @@ def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_integer_min_exclusive_1_4(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10726,11 +11417,12 @@ def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_integer_min_exclusive_1_5(save_xml):
     """
     Type atomic/negativeInteger is restricted by facet minExclusive with
@@ -10742,11 +11434,12 @@ def test_atomic_negative_integer_min_exclusive_nistxml_sv_iv_atomic_negative_int
         instance="nistData/atomic/negativeInteger/Schema+Instance/NISTXML-SV-IV-atomic-negativeInteger-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNegativeIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positive_integer_white_space_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet whiteSpace with
@@ -10758,11 +11451,12 @@ def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positive_integer_white_space_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet whiteSpace with
@@ -10774,11 +11468,12 @@ def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positive_integer_white_space_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet whiteSpace with
@@ -10790,11 +11485,12 @@ def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positive_integer_white_space_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet whiteSpace with
@@ -10806,11 +11502,12 @@ def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positive_integer_white_space_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet whiteSpace with
@@ -10822,11 +11519,12 @@ def test_atomic_non_positive_integer_white_space_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_positive_integer_enumeration_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10837,11 +11535,12 @@ def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_positive_integer_enumeration_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10852,11 +11551,12 @@ def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_positive_integer_enumeration_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10867,11 +11567,12 @@ def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_positive_integer_enumeration_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10882,11 +11583,12 @@ def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_positive_integer_enumeration_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10897,11 +11599,12 @@ def test_atomic_non_positive_integer_enumeration_4_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_positive_integer_enumeration_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10912,11 +11615,12 @@ def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_positive_integer_enumeration_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10927,11 +11631,12 @@ def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_positive_integer_enumeration_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10942,11 +11647,12 @@ def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_positive_integer_enumeration_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10957,11 +11663,12 @@ def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_positive_integer_enumeration_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10972,11 +11679,12 @@ def test_atomic_non_positive_integer_enumeration_3_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_positive_integer_enumeration_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -10987,11 +11695,12 @@ def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_positive_integer_enumeration_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11002,11 +11711,12 @@ def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_positive_integer_enumeration_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11017,11 +11727,12 @@ def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_positive_integer_enumeration_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11032,11 +11743,12 @@ def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_positive_integer_enumeration_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11047,11 +11759,12 @@ def test_atomic_non_positive_integer_enumeration_2_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_positive_integer_enumeration_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11062,11 +11775,12 @@ def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_positive_integer_enumeration_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11077,11 +11791,12 @@ def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_positive_integer_enumeration_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11092,11 +11807,12 @@ def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_positive_integer_enumeration_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11107,11 +11823,12 @@ def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_positive_integer_enumeration_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11122,11 +11839,12 @@ def test_atomic_non_positive_integer_enumeration_1_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positive_integer_enumeration_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11137,11 +11855,12 @@ def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positive_integer_enumeration_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11152,11 +11871,12 @@ def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positive_integer_enumeration_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11167,11 +11887,12 @@ def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positive_integer_enumeration_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11182,11 +11903,12 @@ def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positive_integer_enumeration_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet enumeration.
@@ -11197,11 +11919,12 @@ def test_atomic_non_positive_integer_enumeration_nistxml_sv_iv_atomic_non_positi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11213,11 +11936,12 @@ def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11229,11 +11953,12 @@ def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11245,11 +11970,12 @@ def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11261,11 +11987,12 @@ def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11277,11 +12004,12 @@ def test_atomic_non_positive_integer_pattern_4_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11293,11 +12021,12 @@ def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11309,11 +12038,12 @@ def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11325,11 +12055,12 @@ def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11341,11 +12072,12 @@ def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11357,11 +12089,12 @@ def test_atomic_non_positive_integer_pattern_3_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11373,11 +12106,12 @@ def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11389,11 +12123,12 @@ def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11405,11 +12140,12 @@ def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11421,11 +12157,12 @@ def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11437,11 +12174,12 @@ def test_atomic_non_positive_integer_pattern_2_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11453,11 +12191,12 @@ def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11469,11 +12208,12 @@ def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11485,11 +12225,12 @@ def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11501,11 +12242,12 @@ def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11517,11 +12259,12 @@ def test_atomic_non_positive_integer_pattern_1_nistxml_sv_iv_atomic_non_positive
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11533,11 +12276,12 @@ def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_i
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11549,11 +12293,12 @@ def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_i
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11565,11 +12310,12 @@ def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_i
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11581,11 +12327,12 @@ def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_i
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/nonPositiveInteger is restricted by facet pattern with
@@ -11597,11 +12344,12 @@ def test_atomic_non_positive_integer_pattern_nistxml_sv_iv_atomic_non_positive_i
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_positive_integer_total_digits_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11613,11 +12361,12 @@ def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_positive_integer_total_digits_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11629,11 +12378,12 @@ def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_positive_integer_total_digits_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11645,11 +12395,12 @@ def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_positive_integer_total_digits_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11661,11 +12412,12 @@ def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_positive_integer_total_digits_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11677,11 +12429,12 @@ def test_atomic_non_positive_integer_total_digits_4_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_positive_integer_total_digits_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11693,11 +12446,12 @@ def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_positive_integer_total_digits_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11709,11 +12463,12 @@ def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_positive_integer_total_digits_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11725,11 +12480,12 @@ def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_positive_integer_total_digits_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11741,11 +12497,12 @@ def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_positive_integer_total_digits_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11757,11 +12514,12 @@ def test_atomic_non_positive_integer_total_digits_3_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_positive_integer_total_digits_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11773,11 +12531,12 @@ def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_positive_integer_total_digits_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11789,11 +12548,12 @@ def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_positive_integer_total_digits_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11805,11 +12565,12 @@ def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_positive_integer_total_digits_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11821,11 +12582,12 @@ def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_positive_integer_total_digits_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11837,11 +12599,12 @@ def test_atomic_non_positive_integer_total_digits_2_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_positive_integer_total_digits_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11853,11 +12616,12 @@ def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_positive_integer_total_digits_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11869,11 +12633,12 @@ def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_positive_integer_total_digits_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11885,11 +12650,12 @@ def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_positive_integer_total_digits_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11901,11 +12667,12 @@ def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_positive_integer_total_digits_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11917,11 +12684,12 @@ def test_atomic_non_positive_integer_total_digits_1_nistxml_sv_iv_atomic_non_pos
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_positive_integer_total_digits_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11933,11 +12701,12 @@ def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_posit
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_positive_integer_total_digits_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11949,11 +12718,12 @@ def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_posit
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_positive_integer_total_digits_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11965,11 +12735,12 @@ def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_posit
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_positive_integer_total_digits_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11981,11 +12752,12 @@ def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_posit
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_positive_integer_total_digits_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet totalDigits with
@@ -11997,11 +12769,12 @@ def test_atomic_non_positive_integer_total_digits_nistxml_sv_iv_atomic_non_posit
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_positive_integer_fraction_digits_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet fractionDigits
@@ -12013,11 +12786,12 @@ def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_positive_integer_fraction_digits_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet fractionDigits
@@ -12029,11 +12803,12 @@ def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_positive_integer_fraction_digits_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet fractionDigits
@@ -12045,11 +12820,12 @@ def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_positive_integer_fraction_digits_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet fractionDigits
@@ -12061,11 +12837,12 @@ def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_positive_integer_fraction_digits_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet fractionDigits
@@ -12077,11 +12854,12 @@ def test_atomic_non_positive_integer_fraction_digits_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12093,11 +12871,12 @@ def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12109,11 +12888,12 @@ def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12125,11 +12905,12 @@ def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12141,11 +12922,12 @@ def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12157,11 +12939,12 @@ def test_atomic_non_positive_integer_max_inclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12173,11 +12956,12 @@ def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12189,11 +12973,12 @@ def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12205,11 +12990,12 @@ def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12221,11 +13007,12 @@ def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12237,11 +13024,12 @@ def test_atomic_non_positive_integer_max_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12253,11 +13041,12 @@ def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12269,11 +13058,12 @@ def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12285,11 +13075,12 @@ def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12301,11 +13092,12 @@ def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12317,11 +13109,12 @@ def test_atomic_non_positive_integer_max_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12333,11 +13126,12 @@ def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12349,11 +13143,12 @@ def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12365,11 +13160,12 @@ def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12381,11 +13177,12 @@ def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12397,11 +13194,12 @@ def test_atomic_non_positive_integer_max_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_inclusive_nistxml_sv_iv_atomic_non_positive_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxInclusive
@@ -12413,11 +13211,12 @@ def test_atomic_non_positive_integer_max_inclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12429,11 +13228,12 @@ def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_5_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12445,11 +13245,12 @@ def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_5_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12461,11 +13262,12 @@ def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_5_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12477,11 +13279,12 @@ def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_5_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12493,11 +13296,12 @@ def test_atomic_non_positive_integer_max_exclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12509,11 +13313,12 @@ def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12525,11 +13330,12 @@ def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12541,11 +13347,12 @@ def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12557,11 +13364,12 @@ def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12573,11 +13381,12 @@ def test_atomic_non_positive_integer_max_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12589,11 +13398,12 @@ def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12605,11 +13415,12 @@ def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12621,11 +13432,12 @@ def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12637,11 +13449,12 @@ def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12653,11 +13466,12 @@ def test_atomic_non_positive_integer_max_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12669,11 +13483,12 @@ def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12685,11 +13500,12 @@ def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12701,11 +13517,12 @@ def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12717,11 +13534,12 @@ def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12733,11 +13551,12 @@ def test_atomic_non_positive_integer_max_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_max_exclusive_nistxml_sv_iv_atomic_non_positive_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet maxExclusive
@@ -12749,11 +13568,12 @@ def test_atomic_non_positive_integer_max_exclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_4_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12765,11 +13585,12 @@ def test_atomic_non_positive_integer_min_inclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12781,11 +13602,12 @@ def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12797,11 +13619,12 @@ def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12813,11 +13636,12 @@ def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12829,11 +13653,12 @@ def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12845,11 +13670,12 @@ def test_atomic_non_positive_integer_min_inclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12861,11 +13687,12 @@ def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12877,11 +13704,12 @@ def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12893,11 +13721,12 @@ def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12909,11 +13738,12 @@ def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12925,11 +13755,12 @@ def test_atomic_non_positive_integer_min_inclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12941,11 +13772,12 @@ def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12957,11 +13789,12 @@ def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12973,11 +13806,12 @@ def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -12989,11 +13823,12 @@ def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -13005,11 +13840,12 @@ def test_atomic_non_positive_integer_min_inclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -13021,11 +13857,12 @@ def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -13037,11 +13874,12 @@ def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -13053,11 +13891,12 @@ def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -13069,11 +13908,12 @@ def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_positive_integer_min_inclusive_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minInclusive
@@ -13085,11 +13925,12 @@ def test_atomic_non_positive_integer_min_inclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_4_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13101,11 +13942,12 @@ def test_atomic_non_positive_integer_min_exclusive_4_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13117,11 +13959,12 @@ def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13133,11 +13976,12 @@ def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13149,11 +13993,12 @@ def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13165,11 +14010,12 @@ def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13181,11 +14027,12 @@ def test_atomic_non_positive_integer_min_exclusive_3_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13197,11 +14044,12 @@ def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13213,11 +14061,12 @@ def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13229,11 +14078,12 @@ def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13245,11 +14095,12 @@ def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13261,11 +14112,12 @@ def test_atomic_non_positive_integer_min_exclusive_2_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13277,11 +14129,12 @@ def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13293,11 +14146,12 @@ def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13309,11 +14163,12 @@ def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13325,11 +14180,12 @@ def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13341,11 +14197,12 @@ def test_atomic_non_positive_integer_min_exclusive_1_nistxml_sv_iv_atomic_non_po
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13357,11 +14214,12 @@ def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_1_2(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13373,11 +14231,12 @@ def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_1_3(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13389,11 +14248,12 @@ def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_1_4(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13405,11 +14265,12 @@ def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_positive_integer_min_exclusive_1_5(save_xml):
     """
     Type atomic/nonPositiveInteger is restricted by facet minExclusive
@@ -13421,11 +14282,12 @@ def test_atomic_non_positive_integer_min_exclusive_nistxml_sv_iv_atomic_non_posi
         instance="nistData/atomic/nonPositiveInteger/Schema+Instance/NISTXML-SV-IV-atomic-nonPositiveInteger-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicNonPositiveIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet whiteSpace with value
@@ -13437,11 +14299,12 @@ def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet whiteSpace with value
@@ -13453,11 +14316,12 @@ def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet whiteSpace with value
@@ -13469,11 +14333,12 @@ def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet whiteSpace with value
@@ -13485,11 +14350,12 @@ def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet whiteSpace with value
@@ -13501,11 +14367,12 @@ def test_atomic_integer_white_space_nistxml_sv_iv_atomic_integer_white_space_1_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13516,11 +14383,12 @@ def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13531,11 +14399,12 @@ def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13546,11 +14415,12 @@ def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13561,11 +14431,12 @@ def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13576,11 +14447,12 @@ def test_atomic_integer_enumeration_4_nistxml_sv_iv_atomic_integer_enumeration_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13591,11 +14463,12 @@ def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13606,11 +14479,12 @@ def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13621,11 +14495,12 @@ def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13636,11 +14511,12 @@ def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13651,11 +14527,12 @@ def test_atomic_integer_enumeration_3_nistxml_sv_iv_atomic_integer_enumeration_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13666,11 +14543,12 @@ def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13681,11 +14559,12 @@ def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13696,11 +14575,12 @@ def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13711,11 +14591,12 @@ def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13726,11 +14607,12 @@ def test_atomic_integer_enumeration_2_nistxml_sv_iv_atomic_integer_enumeration_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13741,11 +14623,12 @@ def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13756,11 +14639,12 @@ def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13771,11 +14655,12 @@ def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13786,11 +14671,12 @@ def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13801,11 +14687,12 @@ def test_atomic_integer_enumeration_1_nistxml_sv_iv_atomic_integer_enumeration_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13816,11 +14703,12 @@ def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13831,11 +14719,12 @@ def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_2
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13846,11 +14735,12 @@ def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_3
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13861,11 +14751,12 @@ def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_4
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet enumeration.
@@ -13876,11 +14767,12 @@ def test_atomic_integer_enumeration_nistxml_sv_iv_atomic_integer_enumeration_1_5
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -13891,11 +14783,12 @@ def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -13906,11 +14799,12 @@ def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -13921,11 +14815,12 @@ def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -13936,11 +14831,12 @@ def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{18}.
@@ -13951,11 +14847,12 @@ def test_atomic_integer_pattern_4_nistxml_sv_iv_atomic_integer_pattern_5_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -13966,11 +14863,12 @@ def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -13981,11 +14879,12 @@ def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -13996,11 +14895,12 @@ def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -14011,11 +14911,12 @@ def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \d{5}.
@@ -14026,11 +14927,12 @@ def test_atomic_integer_pattern_3_nistxml_sv_iv_atomic_integer_pattern_4_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -14041,11 +14943,12 @@ def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -14056,11 +14959,12 @@ def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -14071,11 +14975,12 @@ def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -14086,11 +14991,12 @@ def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{1}.
@@ -14101,11 +15007,12 @@ def test_atomic_integer_pattern_2_nistxml_sv_iv_atomic_integer_pattern_3_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -14116,11 +15023,12 @@ def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_1(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -14131,11 +15039,12 @@ def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_2(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -14146,11 +15055,12 @@ def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_3(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -14161,11 +15071,12 @@ def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_4(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value \-\d{9}.
@@ -14176,11 +15087,12 @@ def test_atomic_integer_pattern_1_nistxml_sv_iv_atomic_integer_pattern_2_5(save_
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_1(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -14192,11 +15104,12 @@ def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_1(save_xm
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_2(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -14208,11 +15121,12 @@ def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_2(save_xm
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_3(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -14224,11 +15138,12 @@ def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_3(save_xm
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_4(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -14240,11 +15155,12 @@ def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_4(save_xm
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_5(save_xml):
     r"""
     Type atomic/integer is restricted by facet pattern with value
@@ -14256,11 +15172,12 @@ def test_atomic_integer_pattern_nistxml_sv_iv_atomic_integer_pattern_1_5(save_xm
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 18.
@@ -14271,11 +15188,12 @@ def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 18.
@@ -14286,11 +15204,12 @@ def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 18.
@@ -14301,11 +15220,12 @@ def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 18.
@@ -14316,11 +15236,12 @@ def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 18.
@@ -14331,11 +15252,12 @@ def test_atomic_integer_total_digits_4_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -14346,11 +15268,12 @@ def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -14361,11 +15284,12 @@ def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -14376,11 +15300,12 @@ def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -14391,11 +15316,12 @@ def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 13.
@@ -14406,11 +15332,12 @@ def test_atomic_integer_total_digits_3_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 9.
@@ -14421,11 +15348,12 @@ def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 9.
@@ -14436,11 +15364,12 @@ def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 9.
@@ -14451,11 +15380,12 @@ def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 9.
@@ -14466,11 +15396,12 @@ def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 9.
@@ -14481,11 +15412,12 @@ def test_atomic_integer_total_digits_2_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 5.
@@ -14496,11 +15428,12 @@ def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 5.
@@ -14511,11 +15444,12 @@ def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 5.
@@ -14526,11 +15460,12 @@ def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 5.
@@ -14541,11 +15476,12 @@ def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 5.
@@ -14556,11 +15492,12 @@ def test_atomic_integer_total_digits_1_nistxml_sv_iv_atomic_integer_total_digits
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -14571,11 +15508,12 @@ def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -14586,11 +15524,12 @@ def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -14601,11 +15540,12 @@ def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -14616,11 +15556,12 @@ def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet totalDigits with value 1.
@@ -14631,11 +15572,12 @@ def test_atomic_integer_total_digits_nistxml_sv_iv_atomic_integer_total_digits_1
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_digits_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet fractionDigits with value
@@ -14647,11 +15589,12 @@ def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_di
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_digits_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet fractionDigits with value
@@ -14663,11 +15606,12 @@ def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_di
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_digits_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet fractionDigits with value
@@ -14679,11 +15623,12 @@ def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_di
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_digits_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet fractionDigits with value
@@ -14695,11 +15640,12 @@ def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_di
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_digits_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet fractionDigits with value
@@ -14711,11 +15657,12 @@ def test_atomic_integer_fraction_digits_nistxml_sv_iv_atomic_integer_fraction_di
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14727,11 +15674,12 @@ def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusive_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14743,11 +15691,12 @@ def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusive_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14759,11 +15708,12 @@ def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusive_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14775,11 +15725,12 @@ def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusive_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14791,11 +15742,12 @@ def test_atomic_integer_max_inclusive_4_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14807,11 +15759,12 @@ def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14823,11 +15776,12 @@ def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14839,11 +15793,12 @@ def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14855,11 +15810,12 @@ def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14871,11 +15827,12 @@ def test_atomic_integer_max_inclusive_3_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14887,11 +15844,12 @@ def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14903,11 +15861,12 @@ def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14919,11 +15878,12 @@ def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14935,11 +15895,12 @@ def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14951,11 +15912,12 @@ def test_atomic_integer_max_inclusive_2_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14967,11 +15929,12 @@ def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14983,11 +15946,12 @@ def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -14999,11 +15963,12 @@ def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -15015,11 +15980,12 @@ def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -15031,11 +15997,12 @@ def test_atomic_integer_max_inclusive_1_nistxml_sv_iv_atomic_integer_max_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_inclusive_nistxml_sv_iv_atomic_integer_max_inclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxInclusive with value
@@ -15047,11 +16014,12 @@ def test_atomic_integer_max_inclusive_nistxml_sv_iv_atomic_integer_max_inclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15063,11 +16031,12 @@ def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusive_5_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15079,11 +16048,12 @@ def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusive_5_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15095,11 +16065,12 @@ def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusive_5_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15111,11 +16082,12 @@ def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusive_5_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15127,11 +16099,12 @@ def test_atomic_integer_max_exclusive_4_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15143,11 +16116,12 @@ def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15159,11 +16133,12 @@ def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15175,11 +16150,12 @@ def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15191,11 +16167,12 @@ def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15207,11 +16184,12 @@ def test_atomic_integer_max_exclusive_3_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15223,11 +16201,12 @@ def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15239,11 +16218,12 @@ def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15255,11 +16235,12 @@ def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15271,11 +16252,12 @@ def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15287,11 +16269,12 @@ def test_atomic_integer_max_exclusive_2_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15303,11 +16286,12 @@ def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15319,11 +16303,12 @@ def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15335,11 +16320,12 @@ def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15351,11 +16337,12 @@ def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15367,11 +16354,12 @@ def test_atomic_integer_max_exclusive_1_nistxml_sv_iv_atomic_integer_max_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_max_exclusive_nistxml_sv_iv_atomic_integer_max_exclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet maxExclusive with value
@@ -15383,11 +16371,12 @@ def test_atomic_integer_max_exclusive_nistxml_sv_iv_atomic_integer_max_exclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_4_nistxml_sv_iv_atomic_integer_min_inclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15399,11 +16388,12 @@ def test_atomic_integer_min_inclusive_4_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15415,11 +16405,12 @@ def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15431,11 +16422,12 @@ def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15447,11 +16439,12 @@ def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15463,11 +16456,12 @@ def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15479,11 +16473,12 @@ def test_atomic_integer_min_inclusive_3_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15495,11 +16490,12 @@ def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15511,11 +16507,12 @@ def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15527,11 +16524,12 @@ def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15543,11 +16541,12 @@ def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15559,11 +16558,12 @@ def test_atomic_integer_min_inclusive_2_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15575,11 +16575,12 @@ def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15591,11 +16592,12 @@ def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -15607,6 +16609,6 @@ def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_19217.py
+++ b/tests/test_nist_meta_19217.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -12,11 +15,12 @@ def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -28,11 +32,12 @@ def test_atomic_integer_min_inclusive_1_nistxml_sv_iv_atomic_integer_min_inclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -44,11 +49,12 @@ def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -60,11 +66,12 @@ def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -76,11 +83,12 @@ def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -92,11 +100,12 @@ def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet minInclusive with value
@@ -108,11 +117,12 @@ def test_atomic_integer_min_inclusive_nistxml_sv_iv_atomic_integer_min_inclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_4_nistxml_sv_iv_atomic_integer_min_exclusive_5_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -124,11 +134,12 @@ def test_atomic_integer_min_exclusive_4_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusive_4_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -140,11 +151,12 @@ def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusive_4_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -156,11 +168,12 @@ def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusive_4_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -172,11 +185,12 @@ def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusive_4_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -188,11 +202,12 @@ def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusive_4_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -204,11 +219,12 @@ def test_atomic_integer_min_exclusive_3_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusive_3_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -220,11 +236,12 @@ def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusive_3_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -236,11 +253,12 @@ def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusive_3_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -252,11 +270,12 @@ def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusive_3_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -268,11 +287,12 @@ def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusive_3_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -284,11 +304,12 @@ def test_atomic_integer_min_exclusive_2_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusive_2_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -300,11 +321,12 @@ def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusive_2_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -316,11 +338,12 @@ def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusive_2_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -332,11 +355,12 @@ def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusive_2_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -348,11 +372,12 @@ def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusive_2_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -364,11 +389,12 @@ def test_atomic_integer_min_exclusive_1_nistxml_sv_iv_atomic_integer_min_exclusi
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive_1_1(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -380,11 +406,12 @@ def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive_1_2(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -396,11 +423,12 @@ def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive_1_3(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -412,11 +440,12 @@ def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive_1_4(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -428,11 +457,12 @@ def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive_1_5(save_xml):
     """
     Type atomic/integer is restricted by facet minExclusive with value
@@ -444,11 +474,12 @@ def test_atomic_integer_min_exclusive_nistxml_sv_iv_atomic_integer_min_exclusive
         instance="nistData/atomic/integer/Schema+Instance/NISTXML-SV-IV-atomic-integer-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicIntegerMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet whiteSpace with value
@@ -460,11 +491,12 @@ def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet whiteSpace with value
@@ -476,11 +508,12 @@ def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet whiteSpace with value
@@ -492,11 +525,12 @@ def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet whiteSpace with value
@@ -508,11 +542,12 @@ def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet whiteSpace with value
@@ -524,11 +559,12 @@ def test_atomic_decimal_white_space_nistxml_sv_iv_atomic_decimal_white_space_1_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -539,11 +575,12 @@ def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -554,11 +591,12 @@ def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -569,11 +607,12 @@ def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -584,11 +623,12 @@ def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -599,11 +639,12 @@ def test_atomic_decimal_enumeration_4_nistxml_sv_iv_atomic_decimal_enumeration_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -614,11 +655,12 @@ def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -629,11 +671,12 @@ def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -644,11 +687,12 @@ def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -659,11 +703,12 @@ def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -674,11 +719,12 @@ def test_atomic_decimal_enumeration_3_nistxml_sv_iv_atomic_decimal_enumeration_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -689,11 +735,12 @@ def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -704,11 +751,12 @@ def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -719,11 +767,12 @@ def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -734,11 +783,12 @@ def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -749,11 +799,12 @@ def test_atomic_decimal_enumeration_2_nistxml_sv_iv_atomic_decimal_enumeration_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -764,11 +815,12 @@ def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -779,11 +831,12 @@ def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -794,11 +847,12 @@ def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -809,11 +863,12 @@ def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -824,11 +879,12 @@ def test_atomic_decimal_enumeration_1_nistxml_sv_iv_atomic_decimal_enumeration_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -839,11 +895,12 @@ def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -854,11 +911,12 @@ def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_2
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -869,11 +927,12 @@ def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_3
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -884,11 +943,12 @@ def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_4
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet enumeration.
@@ -899,11 +959,12 @@ def test_atomic_decimal_enumeration_nistxml_sv_iv_atomic_decimal_enumeration_1_5
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -915,11 +976,12 @@ def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -931,11 +993,12 @@ def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -947,11 +1010,12 @@ def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -963,11 +1027,12 @@ def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -979,11 +1044,12 @@ def test_atomic_decimal_pattern_4_nistxml_sv_iv_atomic_decimal_pattern_5_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -995,11 +1061,12 @@ def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1011,11 +1078,12 @@ def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1027,11 +1095,12 @@ def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1043,11 +1112,12 @@ def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1059,11 +1129,12 @@ def test_atomic_decimal_pattern_3_nistxml_sv_iv_atomic_decimal_pattern_4_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1075,11 +1146,12 @@ def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1091,11 +1163,12 @@ def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1107,11 +1180,12 @@ def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1123,11 +1197,12 @@ def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1139,11 +1214,12 @@ def test_atomic_decimal_pattern_2_nistxml_sv_iv_atomic_decimal_pattern_3_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1155,11 +1231,12 @@ def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_1(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1171,11 +1248,12 @@ def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_2(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1187,11 +1265,12 @@ def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_3(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1203,11 +1282,12 @@ def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_4(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value
@@ -1219,11 +1299,12 @@ def test_atomic_decimal_pattern_1_nistxml_sv_iv_atomic_decimal_pattern_2_5(save_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_1(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -1234,11 +1315,12 @@ def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_1(save_xm
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_2(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -1249,11 +1331,12 @@ def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_2(save_xm
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_3(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -1264,11 +1347,12 @@ def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_3(save_xm
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_4(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -1279,11 +1363,12 @@ def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_4(save_xm
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_5(save_xml):
     r"""
     Type atomic/decimal is restricted by facet pattern with value \d{1}.
@@ -1294,11 +1379,12 @@ def test_atomic_decimal_pattern_nistxml_sv_iv_atomic_decimal_pattern_1_5(save_xm
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 18.
@@ -1309,11 +1395,12 @@ def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 18.
@@ -1324,11 +1411,12 @@ def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 18.
@@ -1339,11 +1427,12 @@ def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 18.
@@ -1354,11 +1443,12 @@ def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 18.
@@ -1369,11 +1459,12 @@ def test_atomic_decimal_total_digits_4_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -1384,11 +1475,12 @@ def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -1399,11 +1491,12 @@ def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -1414,11 +1507,12 @@ def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -1429,11 +1523,12 @@ def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 13.
@@ -1444,11 +1539,12 @@ def test_atomic_decimal_total_digits_3_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 9.
@@ -1459,11 +1555,12 @@ def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 9.
@@ -1474,11 +1571,12 @@ def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 9.
@@ -1489,11 +1587,12 @@ def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 9.
@@ -1504,11 +1603,12 @@ def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 9.
@@ -1519,11 +1619,12 @@ def test_atomic_decimal_total_digits_2_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 5.
@@ -1534,11 +1635,12 @@ def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 5.
@@ -1549,11 +1651,12 @@ def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 5.
@@ -1564,11 +1667,12 @@ def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 5.
@@ -1579,11 +1683,12 @@ def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 5.
@@ -1594,11 +1699,12 @@ def test_atomic_decimal_total_digits_1_nistxml_sv_iv_atomic_decimal_total_digits
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -1609,11 +1715,12 @@ def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -1624,11 +1731,12 @@ def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -1639,11 +1747,12 @@ def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -1654,11 +1763,12 @@ def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet totalDigits with value 1.
@@ -1669,11 +1779,12 @@ def test_atomic_decimal_total_digits_nistxml_sv_iv_atomic_decimal_total_digits_1
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-totalDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalTotalDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_digits_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1685,11 +1796,12 @@ def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_digits_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1701,11 +1813,12 @@ def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_digits_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1717,11 +1830,12 @@ def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_digits_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1733,11 +1847,12 @@ def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_digits_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1749,11 +1864,12 @@ def test_atomic_decimal_fraction_digits_4_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_digits_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1765,11 +1881,12 @@ def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_digits_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1781,11 +1898,12 @@ def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_digits_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1797,11 +1915,12 @@ def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_digits_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1813,11 +1932,12 @@ def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_digits_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1829,11 +1949,12 @@ def test_atomic_decimal_fraction_digits_3_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_digits_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1845,11 +1966,12 @@ def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_digits_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1861,11 +1983,12 @@ def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_digits_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1877,11 +2000,12 @@ def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_digits_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1893,11 +2017,12 @@ def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_digits_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1909,11 +2034,12 @@ def test_atomic_decimal_fraction_digits_2_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_digits_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1925,11 +2051,12 @@ def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_digits_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1941,11 +2068,12 @@ def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_digits_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1957,11 +2085,12 @@ def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_digits_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1973,11 +2102,12 @@ def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_digits_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -1989,11 +2119,12 @@ def test_atomic_decimal_fraction_digits_1_nistxml_sv_iv_atomic_decimal_fraction_
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_digits_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -2005,11 +2136,12 @@ def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_di
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_digits_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -2021,11 +2153,12 @@ def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_di
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_digits_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -2037,11 +2170,12 @@ def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_di
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_digits_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -2053,11 +2187,12 @@ def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_di
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_digits_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet fractionDigits with value
@@ -2069,11 +2204,12 @@ def test_atomic_decimal_fraction_digits_nistxml_sv_iv_atomic_decimal_fraction_di
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-fractionDigits-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalFractionDigits1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2085,11 +2221,12 @@ def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusive_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2101,11 +2238,12 @@ def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusive_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2117,11 +2255,12 @@ def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusive_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2133,11 +2272,12 @@ def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusive_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2149,11 +2289,12 @@ def test_atomic_decimal_max_inclusive_4_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2165,11 +2306,12 @@ def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2181,11 +2323,12 @@ def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2197,11 +2340,12 @@ def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2213,11 +2357,12 @@ def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2229,11 +2374,12 @@ def test_atomic_decimal_max_inclusive_3_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2245,11 +2391,12 @@ def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2261,11 +2408,12 @@ def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2277,11 +2425,12 @@ def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2293,11 +2442,12 @@ def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2309,11 +2459,12 @@ def test_atomic_decimal_max_inclusive_2_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2325,11 +2476,12 @@ def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2341,11 +2493,12 @@ def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2357,11 +2510,12 @@ def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2373,11 +2527,12 @@ def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2389,11 +2544,12 @@ def test_atomic_decimal_max_inclusive_1_nistxml_sv_iv_atomic_decimal_max_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_inclusive_nistxml_sv_iv_atomic_decimal_max_inclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxInclusive with value
@@ -2405,11 +2561,12 @@ def test_atomic_decimal_max_inclusive_nistxml_sv_iv_atomic_decimal_max_inclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2421,11 +2578,12 @@ def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusive_5_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2437,11 +2595,12 @@ def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusive_5_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2453,11 +2612,12 @@ def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusive_5_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2469,11 +2629,12 @@ def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusive_5_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2485,11 +2646,12 @@ def test_atomic_decimal_max_exclusive_4_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2501,11 +2663,12 @@ def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2517,11 +2680,12 @@ def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2533,11 +2697,12 @@ def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2549,11 +2714,12 @@ def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2565,11 +2731,12 @@ def test_atomic_decimal_max_exclusive_3_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2581,11 +2748,12 @@ def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2597,11 +2765,12 @@ def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2613,11 +2782,12 @@ def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2629,11 +2799,12 @@ def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2645,11 +2816,12 @@ def test_atomic_decimal_max_exclusive_2_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2661,11 +2833,12 @@ def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2677,11 +2850,12 @@ def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2693,11 +2867,12 @@ def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2709,11 +2884,12 @@ def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2725,11 +2901,12 @@ def test_atomic_decimal_max_exclusive_1_nistxml_sv_iv_atomic_decimal_max_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_max_exclusive_nistxml_sv_iv_atomic_decimal_max_exclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet maxExclusive with value
@@ -2741,11 +2918,12 @@ def test_atomic_decimal_max_exclusive_nistxml_sv_iv_atomic_decimal_max_exclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-maxExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMaxExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_4_nistxml_sv_iv_atomic_decimal_min_inclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2757,11 +2935,12 @@ def test_atomic_decimal_min_inclusive_4_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2773,11 +2952,12 @@ def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2789,11 +2969,12 @@ def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2805,11 +2986,12 @@ def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2821,11 +3003,12 @@ def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2837,11 +3020,12 @@ def test_atomic_decimal_min_inclusive_3_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2853,11 +3037,12 @@ def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2869,11 +3054,12 @@ def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2885,11 +3071,12 @@ def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2901,11 +3088,12 @@ def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2917,11 +3105,12 @@ def test_atomic_decimal_min_inclusive_2_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2933,11 +3122,12 @@ def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2949,11 +3139,12 @@ def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2965,11 +3156,12 @@ def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2981,11 +3173,12 @@ def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -2997,11 +3190,12 @@ def test_atomic_decimal_min_inclusive_1_nistxml_sv_iv_atomic_decimal_min_inclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -3013,11 +3207,12 @@ def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -3029,11 +3224,12 @@ def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -3045,11 +3241,12 @@ def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -3061,11 +3258,12 @@ def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minInclusive with value
@@ -3077,11 +3275,12 @@ def test_atomic_decimal_min_inclusive_nistxml_sv_iv_atomic_decimal_min_inclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minInclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinInclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_4_nistxml_sv_iv_atomic_decimal_min_exclusive_5_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3093,11 +3292,12 @@ def test_atomic_decimal_min_exclusive_4_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusive_4_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3109,11 +3309,12 @@ def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusive_4_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3125,11 +3326,12 @@ def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusive_4_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3141,11 +3343,12 @@ def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusive_4_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3157,11 +3360,12 @@ def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusive_4_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3173,11 +3377,12 @@ def test_atomic_decimal_min_exclusive_3_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusive_3_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3189,11 +3394,12 @@ def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusive_3_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3205,11 +3411,12 @@ def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusive_3_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3221,11 +3428,12 @@ def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusive_3_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3237,11 +3445,12 @@ def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusive_3_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3253,11 +3462,12 @@ def test_atomic_decimal_min_exclusive_2_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusive_2_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3269,11 +3479,12 @@ def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusive_2_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3285,11 +3496,12 @@ def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusive_2_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3301,11 +3513,12 @@ def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusive_2_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3317,11 +3530,12 @@ def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusive_2_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3333,11 +3547,12 @@ def test_atomic_decimal_min_exclusive_1_nistxml_sv_iv_atomic_decimal_min_exclusi
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive_1_1(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3349,11 +3564,12 @@ def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive_1_2(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3365,11 +3581,12 @@ def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive_1_3(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3381,11 +3598,12 @@ def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive_1_4(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3397,11 +3615,12 @@ def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive_1_5(save_xml):
     """
     Type atomic/decimal is restricted by facet minExclusive with value
@@ -3413,6 +3632,6 @@ def test_atomic_decimal_min_exclusive_nistxml_sv_iv_atomic_decimal_min_exclusive
         instance="nistData/atomic/decimal/Schema+Instance/NISTXML-SV-IV-atomic-decimal-minExclusive-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvAtomicDecimalMinExclusive1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_2000.py
+++ b/tests/test_nist_meta_2000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_length_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -12,11 +15,12 @@ def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_length_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -28,11 +32,12 @@ def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_length_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -44,11 +49,12 @@ def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_length_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -60,11 +66,12 @@ def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_length_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -76,11 +83,12 @@ def test_list_normalized_string_length_9_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_length_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -91,11 +99,12 @@ def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_length_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -106,11 +115,12 @@ def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_length_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -121,11 +131,12 @@ def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_length_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -136,11 +147,12 @@ def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_length_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -151,11 +163,12 @@ def test_list_normalized_string_length_8_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_length_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -166,11 +179,12 @@ def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_length_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -181,11 +195,12 @@ def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_length_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -196,11 +211,12 @@ def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_length_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -211,11 +227,12 @@ def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_length_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -226,11 +243,12 @@ def test_list_normalized_string_length_7_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_length_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -241,11 +259,12 @@ def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_length_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -256,11 +275,12 @@ def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_length_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -271,11 +291,12 @@ def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_length_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -286,11 +307,12 @@ def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_length_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -301,11 +323,12 @@ def test_list_normalized_string_length_6_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_length_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -316,11 +339,12 @@ def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_length_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -331,11 +355,12 @@ def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_length_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -346,11 +371,12 @@ def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_length_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -361,11 +387,12 @@ def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_length_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -376,11 +403,12 @@ def test_list_normalized_string_length_5_nistxml_sv_ii_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_string_min_length_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -392,11 +420,12 @@ def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_string_min_length_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -408,11 +437,12 @@ def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_string_min_length_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -424,11 +454,12 @@ def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_string_min_length_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -440,11 +471,12 @@ def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_string_min_length_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -456,11 +488,12 @@ def test_list_normalized_string_min_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_string_min_length_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -472,11 +505,12 @@ def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_string_min_length_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -488,11 +522,12 @@ def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_string_min_length_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -504,11 +539,12 @@ def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_string_min_length_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -520,11 +556,12 @@ def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_string_min_length_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -536,11 +573,12 @@ def test_list_normalized_string_min_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_string_min_length_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -552,11 +590,12 @@ def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_string_min_length_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -568,11 +607,12 @@ def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_string_min_length_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -584,11 +624,12 @@ def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_string_min_length_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -600,11 +641,12 @@ def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_string_min_length_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -616,11 +658,12 @@ def test_list_normalized_string_min_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_string_min_length_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -632,11 +675,12 @@ def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_string_min_length_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -648,11 +692,12 @@ def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_string_min_length_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -664,11 +709,12 @@ def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_string_min_length_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -680,11 +726,12 @@ def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_string_min_length_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -696,11 +743,12 @@ def test_list_normalized_string_min_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_string_min_length_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -712,11 +760,12 @@ def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_string_min_length_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -728,11 +777,12 @@ def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_string_min_length_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -744,11 +794,12 @@ def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_string_min_length_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -760,11 +811,12 @@ def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_string_min_length_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -776,11 +828,12 @@ def test_list_normalized_string_min_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_string_max_length_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -792,11 +845,12 @@ def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_string_max_length_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -808,11 +862,12 @@ def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_string_max_length_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -824,11 +879,12 @@ def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_string_max_length_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -840,11 +896,12 @@ def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_string_max_length_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -856,11 +913,12 @@ def test_list_normalized_string_max_length_9_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_string_max_length_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -872,11 +930,12 @@ def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_string_max_length_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -888,11 +947,12 @@ def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_string_max_length_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -904,11 +964,12 @@ def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_string_max_length_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -920,11 +981,12 @@ def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_string_max_length_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -936,11 +998,12 @@ def test_list_normalized_string_max_length_8_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_string_max_length_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -952,11 +1015,12 @@ def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_string_max_length_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -968,11 +1032,12 @@ def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_string_max_length_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -984,11 +1049,12 @@ def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_string_max_length_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1000,11 +1066,12 @@ def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_string_max_length_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1016,11 +1083,12 @@ def test_list_normalized_string_max_length_7_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_string_max_length_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1032,11 +1100,12 @@ def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_string_max_length_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1048,11 +1117,12 @@ def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_string_max_length_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1064,11 +1134,12 @@ def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_string_max_length_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1080,11 +1151,12 @@ def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_string_max_length_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1096,11 +1168,12 @@ def test_list_normalized_string_max_length_6_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_string_max_length_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1112,11 +1185,12 @@ def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_string_max_length_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1128,11 +1202,12 @@ def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_string_max_length_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1144,11 +1219,12 @@ def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_string_max_length_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1160,11 +1236,12 @@ def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_string_max_length_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1176,11 +1253,12 @@ def test_list_normalized_string_max_length_5_nistxml_sv_ii_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-II-list-normalizedString-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_1(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -1191,11 +1269,12 @@ def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_2(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -1206,11 +1285,12 @@ def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_3(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -1221,11 +1301,12 @@ def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_4(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -1236,11 +1317,12 @@ def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_5(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -1251,11 +1333,12 @@ def test_list_string_length_9_nistxml_sv_ii_list_string_length_5_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_1(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -1266,11 +1349,12 @@ def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_2(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -1281,11 +1365,12 @@ def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_3(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -1296,11 +1381,12 @@ def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_4(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -1311,11 +1397,12 @@ def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_5(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -1326,11 +1413,12 @@ def test_list_string_length_8_nistxml_sv_ii_list_string_length_4_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_1(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -1341,11 +1429,12 @@ def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_2(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -1356,11 +1445,12 @@ def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_3(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -1371,11 +1461,12 @@ def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_4(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -1386,11 +1477,12 @@ def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_5(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -1401,11 +1493,12 @@ def test_list_string_length_7_nistxml_sv_ii_list_string_length_3_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_1(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -1416,11 +1509,12 @@ def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_2(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -1431,11 +1525,12 @@ def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_3(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -1446,11 +1541,12 @@ def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_4(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -1461,11 +1557,12 @@ def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_5(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -1476,11 +1573,12 @@ def test_list_string_length_6_nistxml_sv_ii_list_string_length_2_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_1(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -1491,11 +1589,12 @@ def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_2(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -1506,11 +1605,12 @@ def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_3(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -1521,11 +1621,12 @@ def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_4(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -1536,11 +1637,12 @@ def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_5(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -1551,11 +1653,12 @@ def test_list_string_length_5_nistxml_sv_ii_list_string_length_1_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -1566,11 +1669,12 @@ def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -1581,11 +1685,12 @@ def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -1596,11 +1701,12 @@ def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -1611,11 +1717,12 @@ def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -1626,11 +1733,12 @@ def test_list_string_min_length_9_nistxml_sv_ii_list_string_min_length_5_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -1641,11 +1749,12 @@ def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -1656,11 +1765,12 @@ def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -1671,11 +1781,12 @@ def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -1686,11 +1797,12 @@ def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -1701,11 +1813,12 @@ def test_list_string_min_length_8_nistxml_sv_ii_list_string_min_length_4_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -1716,11 +1829,12 @@ def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -1731,11 +1845,12 @@ def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -1746,11 +1861,12 @@ def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -1761,11 +1877,12 @@ def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -1776,11 +1893,12 @@ def test_list_string_min_length_7_nistxml_sv_ii_list_string_min_length_3_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -1791,11 +1909,12 @@ def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -1806,11 +1925,12 @@ def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -1821,11 +1941,12 @@ def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -1836,11 +1957,12 @@ def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -1851,11 +1973,12 @@ def test_list_string_min_length_6_nistxml_sv_ii_list_string_min_length_2_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -1866,11 +1989,12 @@ def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -1881,11 +2005,12 @@ def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -1896,11 +2021,12 @@ def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -1911,11 +2037,12 @@ def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -1926,11 +2053,12 @@ def test_list_string_min_length_5_nistxml_sv_ii_list_string_min_length_1_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -1941,11 +2069,12 @@ def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -1956,11 +2085,12 @@ def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -1971,11 +2101,12 @@ def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -1986,11 +2117,12 @@ def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -2001,11 +2133,12 @@ def test_list_string_max_length_9_nistxml_sv_ii_list_string_max_length_5_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2016,11 +2149,12 @@ def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2031,11 +2165,12 @@ def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2046,11 +2181,12 @@ def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2061,11 +2197,12 @@ def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2076,11 +2213,12 @@ def test_list_string_max_length_8_nistxml_sv_ii_list_string_max_length_4_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2091,11 +2229,12 @@ def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2106,11 +2245,12 @@ def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2121,11 +2261,12 @@ def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2136,11 +2277,12 @@ def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2151,11 +2293,12 @@ def test_list_string_max_length_7_nistxml_sv_ii_list_string_max_length_3_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -2166,11 +2309,12 @@ def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -2181,11 +2325,12 @@ def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -2196,11 +2341,12 @@ def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -2211,11 +2357,12 @@ def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -2226,11 +2373,12 @@ def test_list_string_max_length_6_nistxml_sv_ii_list_string_max_length_2_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -2241,11 +2389,12 @@ def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -2256,11 +2405,12 @@ def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -2271,11 +2421,12 @@ def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -2286,11 +2437,12 @@ def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -2301,11 +2453,12 @@ def test_list_string_max_length_5_nistxml_sv_ii_list_string_max_length_1_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-II-list-string-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2316,11 +2469,12 @@ def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2331,11 +2485,12 @@ def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2346,11 +2501,12 @@ def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2361,11 +2517,12 @@ def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2376,11 +2533,12 @@ def test_list_any_uri_enumeration_9_nistxml_sv_ii_list_any_uri_enumeration_5_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2391,11 +2549,12 @@ def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2406,11 +2565,12 @@ def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2421,11 +2581,12 @@ def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2436,11 +2597,12 @@ def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2451,11 +2613,12 @@ def test_list_any_uri_enumeration_8_nistxml_sv_ii_list_any_uri_enumeration_4_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2466,11 +2629,12 @@ def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2481,11 +2645,12 @@ def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2496,11 +2661,12 @@ def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2511,11 +2677,12 @@ def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2526,11 +2693,12 @@ def test_list_any_uri_enumeration_7_nistxml_sv_ii_list_any_uri_enumeration_3_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2541,11 +2709,12 @@ def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2556,11 +2725,12 @@ def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2571,11 +2741,12 @@ def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2586,11 +2757,12 @@ def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2601,11 +2773,12 @@ def test_list_any_uri_enumeration_6_nistxml_sv_ii_list_any_uri_enumeration_2_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2616,11 +2789,12 @@ def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2631,11 +2805,12 @@ def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2646,11 +2821,12 @@ def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2661,11 +2837,12 @@ def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -2676,11 +2853,12 @@ def test_list_any_uri_enumeration_5_nistxml_sv_ii_list_any_uri_enumeration_1_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2695,11 +2873,12 @@ def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2714,11 +2893,12 @@ def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2733,11 +2913,12 @@ def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2752,11 +2933,12 @@ def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2771,11 +2953,12 @@ def test_list_any_uri_pattern_9_nistxml_sv_ii_list_any_uri_pattern_5_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2789,11 +2972,12 @@ def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2807,11 +2991,12 @@ def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2825,11 +3010,12 @@ def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2843,11 +3029,12 @@ def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2861,11 +3048,12 @@ def test_list_any_uri_pattern_8_nistxml_sv_ii_list_any_uri_pattern_4_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2879,11 +3067,12 @@ def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2897,11 +3086,12 @@ def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2915,11 +3105,12 @@ def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2933,11 +3124,12 @@ def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2951,11 +3143,12 @@ def test_list_any_uri_pattern_7_nistxml_sv_ii_list_any_uri_pattern_3_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2971,11 +3164,12 @@ def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -2991,11 +3185,12 @@ def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3011,11 +3206,12 @@ def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3031,11 +3227,12 @@ def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3051,11 +3248,12 @@ def test_list_any_uri_pattern_6_nistxml_sv_ii_list_any_uri_pattern_2_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3071,11 +3269,12 @@ def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3091,11 +3290,12 @@ def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3111,11 +3311,12 @@ def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3131,11 +3332,12 @@ def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -3151,11 +3353,12 @@ def test_list_any_uri_pattern_5_nistxml_sv_ii_list_any_uri_pattern_1_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -3166,11 +3369,12 @@ def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -3181,11 +3385,12 @@ def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -3196,11 +3401,12 @@ def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -3211,11 +3417,12 @@ def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -3226,11 +3433,12 @@ def test_list_any_uri_length_9_nistxml_sv_ii_list_any_uri_length_5_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -3241,11 +3449,12 @@ def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -3256,11 +3465,12 @@ def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -3271,11 +3481,12 @@ def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -3286,11 +3497,12 @@ def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -3301,11 +3513,12 @@ def test_list_any_uri_length_8_nistxml_sv_ii_list_any_uri_length_4_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -3316,11 +3529,12 @@ def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -3331,11 +3545,12 @@ def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -3346,11 +3561,12 @@ def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -3361,11 +3577,12 @@ def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -3376,11 +3593,12 @@ def test_list_any_uri_length_7_nistxml_sv_ii_list_any_uri_length_3_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -3391,11 +3609,12 @@ def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -3406,11 +3625,12 @@ def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -3421,11 +3641,12 @@ def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -3436,11 +3657,12 @@ def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -3451,11 +3673,12 @@ def test_list_any_uri_length_6_nistxml_sv_ii_list_any_uri_length_2_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -3466,11 +3689,12 @@ def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -3481,11 +3705,12 @@ def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -3496,11 +3721,12 @@ def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -3511,11 +3737,12 @@ def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -3526,11 +3753,12 @@ def test_list_any_uri_length_5_nistxml_sv_ii_list_any_uri_length_1_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -3541,11 +3769,12 @@ def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -3556,11 +3785,12 @@ def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -3571,11 +3801,12 @@ def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -3586,11 +3817,12 @@ def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -3601,11 +3833,12 @@ def test_list_any_uri_min_length_9_nistxml_sv_ii_list_any_uri_min_length_5_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -3616,11 +3849,12 @@ def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -3631,11 +3865,12 @@ def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -3646,11 +3881,12 @@ def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -3661,11 +3897,12 @@ def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -3676,11 +3913,12 @@ def test_list_any_uri_min_length_8_nistxml_sv_ii_list_any_uri_min_length_4_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -3691,11 +3929,12 @@ def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -3706,11 +3945,12 @@ def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -3721,11 +3961,12 @@ def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -3736,11 +3977,12 @@ def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -3751,11 +3993,12 @@ def test_list_any_uri_min_length_7_nistxml_sv_ii_list_any_uri_min_length_3_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -3766,11 +4009,12 @@ def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -3781,11 +4025,12 @@ def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -3796,11 +4041,12 @@ def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -3811,11 +4057,12 @@ def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -3826,11 +4073,12 @@ def test_list_any_uri_min_length_6_nistxml_sv_ii_list_any_uri_min_length_2_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -3841,11 +4089,12 @@ def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -3856,11 +4105,12 @@ def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -3871,11 +4121,12 @@ def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -3886,11 +4137,12 @@ def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -3901,11 +4153,12 @@ def test_list_any_uri_min_length_5_nistxml_sv_ii_list_any_uri_min_length_1_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -3916,11 +4169,12 @@ def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -3931,11 +4185,12 @@ def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -3946,11 +4201,12 @@ def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -3961,11 +4217,12 @@ def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -3976,11 +4233,12 @@ def test_list_any_uri_max_length_9_nistxml_sv_ii_list_any_uri_max_length_5_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -3991,11 +4249,12 @@ def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -4006,11 +4265,12 @@ def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -4021,11 +4281,12 @@ def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -4036,11 +4297,12 @@ def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -4051,11 +4313,12 @@ def test_list_any_uri_max_length_8_nistxml_sv_ii_list_any_uri_max_length_4_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -4066,11 +4329,12 @@ def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -4081,11 +4345,12 @@ def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -4096,11 +4361,12 @@ def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -4111,11 +4377,12 @@ def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -4126,11 +4393,12 @@ def test_list_any_uri_max_length_7_nistxml_sv_ii_list_any_uri_max_length_3_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -4141,11 +4409,12 @@ def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -4156,11 +4425,12 @@ def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -4171,11 +4441,12 @@ def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -4186,11 +4457,12 @@ def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -4201,11 +4473,12 @@ def test_list_any_uri_max_length_6_nistxml_sv_ii_list_any_uri_max_length_2_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -4216,11 +4489,12 @@ def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -4231,11 +4505,12 @@ def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -4246,11 +4521,12 @@ def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -4261,11 +4537,12 @@ def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -4276,11 +4553,12 @@ def test_list_any_uri_max_length_5_nistxml_sv_ii_list_any_uri_max_length_1_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-II-list-anyURI-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4291,11 +4569,12 @@ def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4306,11 +4585,12 @@ def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4321,11 +4601,12 @@ def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4336,11 +4617,12 @@ def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4351,11 +4633,12 @@ def test_list_g_month_enumeration_9_nistxml_sv_ii_list_g_month_enumeration_5_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4366,11 +4649,12 @@ def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4381,11 +4665,12 @@ def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4396,11 +4681,12 @@ def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4411,11 +4697,12 @@ def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4426,11 +4713,12 @@ def test_list_g_month_enumeration_8_nistxml_sv_ii_list_g_month_enumeration_4_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4441,11 +4729,12 @@ def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4456,11 +4745,12 @@ def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4471,11 +4761,12 @@ def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4486,11 +4777,12 @@ def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4501,11 +4793,12 @@ def test_list_g_month_enumeration_7_nistxml_sv_ii_list_g_month_enumeration_3_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4516,11 +4809,12 @@ def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4531,11 +4825,12 @@ def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4546,11 +4841,12 @@ def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4561,11 +4857,12 @@ def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4576,11 +4873,12 @@ def test_list_g_month_enumeration_6_nistxml_sv_ii_list_g_month_enumeration_2_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4591,11 +4889,12 @@ def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4606,11 +4905,12 @@ def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4621,11 +4921,12 @@ def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4636,11 +4937,12 @@ def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -4651,11 +4953,12 @@ def test_list_g_month_enumeration_5_nistxml_sv_ii_list_g_month_enumeration_1_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --0\d
@@ -4667,11 +4970,12 @@ def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --0\d
@@ -4683,11 +4987,12 @@ def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --0\d
@@ -4699,11 +5004,12 @@ def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --0\d
@@ -4715,11 +5021,12 @@ def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --0\d
@@ -4731,11 +5038,12 @@ def test_list_g_month_pattern_9_nistxml_sv_ii_list_g_month_pattern_5_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4747,11 +5055,12 @@ def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4763,11 +5072,12 @@ def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4779,11 +5089,12 @@ def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4795,11 +5106,12 @@ def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4811,11 +5123,12 @@ def test_list_g_month_pattern_8_nistxml_sv_ii_list_g_month_pattern_4_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4827,11 +5140,12 @@ def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4843,11 +5157,12 @@ def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4859,11 +5174,12 @@ def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4875,11 +5191,12 @@ def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --0\d --0\d
@@ -4891,11 +5208,12 @@ def test_list_g_month_pattern_7_nistxml_sv_ii_list_g_month_pattern_3_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d8
@@ -4907,11 +5225,12 @@ def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d8
@@ -4923,11 +5242,12 @@ def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d8
@@ -4939,11 +5259,12 @@ def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d8
@@ -4955,11 +5276,12 @@ def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d8
@@ -4971,11 +5293,12 @@ def test_list_g_month_pattern_6_nistxml_sv_ii_list_g_month_pattern_2_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d0 --1\d
@@ -4987,11 +5310,12 @@ def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d0 --1\d
@@ -5003,11 +5327,12 @@ def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d0 --1\d
@@ -5019,11 +5344,12 @@ def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d0 --1\d
@@ -5035,11 +5361,12 @@ def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d0 --1\d
@@ -5051,11 +5378,12 @@ def test_list_g_month_pattern_5_nistxml_sv_ii_list_g_month_pattern_1_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -5066,11 +5394,12 @@ def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -5081,11 +5410,12 @@ def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -5096,11 +5426,12 @@ def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -5111,11 +5442,12 @@ def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -5126,11 +5458,12 @@ def test_list_g_month_length_9_nistxml_sv_ii_list_g_month_length_5_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -5141,11 +5474,12 @@ def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -5156,11 +5490,12 @@ def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -5171,11 +5506,12 @@ def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -5186,11 +5522,12 @@ def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -5201,11 +5538,12 @@ def test_list_g_month_length_8_nistxml_sv_ii_list_g_month_length_4_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -5216,11 +5554,12 @@ def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -5231,11 +5570,12 @@ def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -5246,11 +5586,12 @@ def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -5261,11 +5602,12 @@ def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -5276,11 +5618,12 @@ def test_list_g_month_length_7_nistxml_sv_ii_list_g_month_length_3_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -5291,11 +5634,12 @@ def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -5306,11 +5650,12 @@ def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -5321,11 +5666,12 @@ def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -5336,11 +5682,12 @@ def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -5351,11 +5698,12 @@ def test_list_g_month_length_6_nistxml_sv_ii_list_g_month_length_2_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -5366,11 +5714,12 @@ def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -5381,11 +5730,12 @@ def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -5396,11 +5746,12 @@ def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -5411,11 +5762,12 @@ def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -5426,11 +5778,12 @@ def test_list_g_month_length_5_nistxml_sv_ii_list_g_month_length_1_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -5441,11 +5794,12 @@ def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -5456,11 +5810,12 @@ def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -5471,11 +5826,12 @@ def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -5486,11 +5842,12 @@ def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -5501,11 +5858,12 @@ def test_list_g_month_min_length_9_nistxml_sv_ii_list_g_month_min_length_5_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -5516,11 +5874,12 @@ def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -5531,11 +5890,12 @@ def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -5546,11 +5906,12 @@ def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -5561,11 +5922,12 @@ def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -5576,11 +5938,12 @@ def test_list_g_month_min_length_8_nistxml_sv_ii_list_g_month_min_length_4_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -5591,11 +5954,12 @@ def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -5606,11 +5970,12 @@ def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -5621,11 +5986,12 @@ def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -5636,11 +6002,12 @@ def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -5651,11 +6018,12 @@ def test_list_g_month_min_length_7_nistxml_sv_ii_list_g_month_min_length_3_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -5666,11 +6034,12 @@ def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -5681,11 +6050,12 @@ def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -5696,11 +6066,12 @@ def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -5711,11 +6082,12 @@ def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -5726,11 +6098,12 @@ def test_list_g_month_min_length_6_nistxml_sv_ii_list_g_month_min_length_2_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -5741,11 +6114,12 @@ def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -5756,11 +6130,12 @@ def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -5771,11 +6146,12 @@ def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -5786,11 +6162,12 @@ def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -5801,11 +6178,12 @@ def test_list_g_month_min_length_5_nistxml_sv_ii_list_g_month_min_length_1_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -5816,11 +6194,12 @@ def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -5831,11 +6210,12 @@ def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -5846,11 +6226,12 @@ def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -5861,11 +6242,12 @@ def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -5876,11 +6258,12 @@ def test_list_g_month_max_length_9_nistxml_sv_ii_list_g_month_max_length_5_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -5891,11 +6274,12 @@ def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -5906,11 +6290,12 @@ def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -5921,11 +6306,12 @@ def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -5936,11 +6322,12 @@ def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -5951,11 +6338,12 @@ def test_list_g_month_max_length_8_nistxml_sv_ii_list_g_month_max_length_4_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -5966,11 +6354,12 @@ def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -5981,11 +6370,12 @@ def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -5996,11 +6386,12 @@ def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -6011,11 +6402,12 @@ def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -6026,11 +6418,12 @@ def test_list_g_month_max_length_7_nistxml_sv_ii_list_g_month_max_length_3_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -6041,11 +6434,12 @@ def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -6056,11 +6450,12 @@ def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -6071,11 +6466,12 @@ def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -6086,11 +6482,12 @@ def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -6101,11 +6498,12 @@ def test_list_g_month_max_length_6_nistxml_sv_ii_list_g_month_max_length_2_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -6116,11 +6514,12 @@ def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -6131,11 +6530,12 @@ def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -6146,11 +6546,12 @@ def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -6161,11 +6562,12 @@ def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -6176,11 +6578,12 @@ def test_list_g_month_max_length_5_nistxml_sv_ii_list_g_month_max_length_1_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-II-list-gMonth-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6191,11 +6594,12 @@ def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6206,11 +6610,12 @@ def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6221,11 +6626,12 @@ def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6236,11 +6642,12 @@ def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6251,11 +6658,12 @@ def test_list_g_day_enumeration_9_nistxml_sv_ii_list_g_day_enumeration_5_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6266,11 +6674,12 @@ def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6281,11 +6690,12 @@ def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6296,11 +6706,12 @@ def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6311,11 +6722,12 @@ def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6326,11 +6738,12 @@ def test_list_g_day_enumeration_8_nistxml_sv_ii_list_g_day_enumeration_4_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6341,11 +6754,12 @@ def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6356,11 +6770,12 @@ def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6371,11 +6786,12 @@ def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6386,11 +6802,12 @@ def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6401,11 +6818,12 @@ def test_list_g_day_enumeration_7_nistxml_sv_ii_list_g_day_enumeration_3_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6416,11 +6834,12 @@ def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6431,11 +6850,12 @@ def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6446,11 +6866,12 @@ def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6461,11 +6882,12 @@ def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6476,11 +6898,12 @@ def test_list_g_day_enumeration_6_nistxml_sv_ii_list_g_day_enumeration_2_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6491,11 +6914,12 @@ def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6506,11 +6930,12 @@ def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6521,11 +6946,12 @@ def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6536,11 +6962,12 @@ def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -6551,11 +6978,12 @@ def test_list_g_day_enumeration_5_nistxml_sv_ii_list_g_day_enumeration_1_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d2 ---\d1
@@ -6567,11 +6995,12 @@ def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d2 ---\d1
@@ -6583,11 +7012,12 @@ def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d2 ---\d1
@@ -6599,11 +7029,12 @@ def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d2 ---\d1
@@ -6615,11 +7046,12 @@ def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d2 ---\d1
@@ -6631,11 +7063,12 @@ def test_list_g_day_pattern_9_nistxml_sv_ii_list_g_day_pattern_5_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---2\d ---1\d
@@ -6647,11 +7080,12 @@ def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---2\d ---1\d
@@ -6663,11 +7097,12 @@ def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---2\d ---1\d
@@ -6679,11 +7114,12 @@ def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---2\d ---1\d
@@ -6695,11 +7131,12 @@ def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---2\d ---1\d
@@ -6711,11 +7148,12 @@ def test_list_g_day_pattern_8_nistxml_sv_ii_list_g_day_pattern_4_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d6 ---\d4
@@ -6727,11 +7165,12 @@ def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d6 ---\d4
@@ -6743,11 +7182,12 @@ def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d6 ---\d4
@@ -6759,11 +7199,12 @@ def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d6 ---\d4
@@ -6775,11 +7216,12 @@ def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d6 ---\d4
@@ -6791,11 +7233,12 @@ def test_list_g_day_pattern_7_nistxml_sv_ii_list_g_day_pattern_3_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d0 ---1\d
@@ -6807,11 +7250,12 @@ def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d0 ---1\d
@@ -6823,11 +7267,12 @@ def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d0 ---1\d
@@ -6839,11 +7284,12 @@ def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d0 ---1\d
@@ -6855,11 +7301,12 @@ def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d0 ---1\d
@@ -6871,11 +7318,12 @@ def test_list_g_day_pattern_6_nistxml_sv_ii_list_g_day_pattern_2_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---0\d
@@ -6887,11 +7335,12 @@ def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---0\d
@@ -6903,11 +7352,12 @@ def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---0\d
@@ -6919,11 +7369,12 @@ def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---0\d
@@ -6935,11 +7386,12 @@ def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---0\d
@@ -6951,11 +7403,12 @@ def test_list_g_day_pattern_5_nistxml_sv_ii_list_g_day_pattern_1_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6966,11 +7419,12 @@ def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6981,11 +7435,12 @@ def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6996,11 +7451,12 @@ def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -7011,11 +7467,12 @@ def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -7026,11 +7483,12 @@ def test_list_g_day_length_9_nistxml_sv_ii_list_g_day_length_5_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -7041,11 +7499,12 @@ def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -7056,11 +7515,12 @@ def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -7071,11 +7531,12 @@ def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -7086,11 +7547,12 @@ def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -7101,11 +7563,12 @@ def test_list_g_day_length_8_nistxml_sv_ii_list_g_day_length_4_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -7116,11 +7579,12 @@ def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -7131,11 +7595,12 @@ def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -7146,11 +7611,12 @@ def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -7161,11 +7627,12 @@ def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -7176,11 +7643,12 @@ def test_list_g_day_length_7_nistxml_sv_ii_list_g_day_length_3_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -7191,11 +7659,12 @@ def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -7206,11 +7675,12 @@ def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -7221,11 +7691,12 @@ def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -7236,11 +7707,12 @@ def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -7251,11 +7723,12 @@ def test_list_g_day_length_6_nistxml_sv_ii_list_g_day_length_2_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -7266,11 +7739,12 @@ def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -7281,11 +7755,12 @@ def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -7296,11 +7771,12 @@ def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -7311,11 +7787,12 @@ def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -7326,11 +7803,12 @@ def test_list_g_day_length_5_nistxml_sv_ii_list_g_day_length_1_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -7341,11 +7819,12 @@ def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -7356,11 +7835,12 @@ def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -7371,11 +7851,12 @@ def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -7386,11 +7867,12 @@ def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -7401,11 +7883,12 @@ def test_list_g_day_min_length_9_nistxml_sv_ii_list_g_day_min_length_5_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -7416,11 +7899,12 @@ def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -7431,11 +7915,12 @@ def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -7446,11 +7931,12 @@ def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -7461,11 +7947,12 @@ def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -7476,11 +7963,12 @@ def test_list_g_day_min_length_8_nistxml_sv_ii_list_g_day_min_length_4_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -7491,11 +7979,12 @@ def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -7506,11 +7995,12 @@ def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -7521,11 +8011,12 @@ def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -7536,11 +8027,12 @@ def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -7551,11 +8043,12 @@ def test_list_g_day_min_length_7_nistxml_sv_ii_list_g_day_min_length_3_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -7566,11 +8059,12 @@ def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -7581,11 +8075,12 @@ def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -7596,11 +8091,12 @@ def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -7611,11 +8107,12 @@ def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -7626,11 +8123,12 @@ def test_list_g_day_min_length_6_nistxml_sv_ii_list_g_day_min_length_2_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -7641,11 +8139,12 @@ def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -7656,11 +8155,12 @@ def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -7671,11 +8171,12 @@ def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -7686,11 +8187,12 @@ def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -7701,11 +8203,12 @@ def test_list_g_day_min_length_5_nistxml_sv_ii_list_g_day_min_length_1_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -7716,11 +8219,12 @@ def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -7731,11 +8235,12 @@ def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -7746,11 +8251,12 @@ def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -7761,11 +8267,12 @@ def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -7776,11 +8283,12 @@ def test_list_g_day_max_length_9_nistxml_sv_ii_list_g_day_max_length_5_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -7791,11 +8299,12 @@ def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -7806,11 +8315,12 @@ def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -7821,11 +8331,12 @@ def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -7836,11 +8347,12 @@ def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -7851,11 +8363,12 @@ def test_list_g_day_max_length_8_nistxml_sv_ii_list_g_day_max_length_4_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -7866,11 +8379,12 @@ def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -7881,11 +8395,12 @@ def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -7896,11 +8411,12 @@ def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -7911,11 +8427,12 @@ def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -7926,11 +8443,12 @@ def test_list_g_day_max_length_7_nistxml_sv_ii_list_g_day_max_length_3_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7941,11 +8459,12 @@ def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7956,11 +8475,12 @@ def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7971,11 +8491,12 @@ def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7986,11 +8507,12 @@ def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -8001,11 +8523,12 @@ def test_list_g_day_max_length_6_nistxml_sv_ii_list_g_day_max_length_2_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -8016,11 +8539,12 @@ def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -8031,11 +8555,12 @@ def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -8046,11 +8571,12 @@ def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -8061,11 +8587,12 @@ def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -8076,11 +8603,12 @@ def test_list_g_day_max_length_5_nistxml_sv_ii_list_g_day_max_length_1_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-II-list-gDay-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumeration_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8091,11 +8619,12 @@ def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumeration_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8106,11 +8635,12 @@ def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumeration_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8121,11 +8651,12 @@ def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumeration_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8136,11 +8667,12 @@ def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumeration_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8151,11 +8683,12 @@ def test_list_g_month_day_enumeration_9_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumeration_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8166,11 +8699,12 @@ def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumeration_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8181,11 +8715,12 @@ def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumeration_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8196,11 +8731,12 @@ def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumeration_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8211,11 +8747,12 @@ def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumeration_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8226,11 +8763,12 @@ def test_list_g_month_day_enumeration_8_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumeration_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8241,11 +8779,12 @@ def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumeration_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8256,11 +8795,12 @@ def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumeration_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8271,11 +8811,12 @@ def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumeration_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8286,11 +8827,12 @@ def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumeration_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8301,11 +8843,12 @@ def test_list_g_month_day_enumeration_7_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumeration_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8316,11 +8859,12 @@ def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumeration_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8331,11 +8875,12 @@ def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumeration_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8346,11 +8891,12 @@ def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumeration_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8361,11 +8907,12 @@ def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumeration_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8376,11 +8923,12 @@ def test_list_g_month_day_enumeration_6_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumeration_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8391,11 +8939,12 @@ def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumeration_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8406,11 +8955,12 @@ def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumeration_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8421,11 +8971,12 @@ def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumeration_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8436,11 +8987,12 @@ def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumeration_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -8451,11 +9003,12 @@ def test_list_g_month_day_enumeration_5_nistxml_sv_ii_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8467,11 +9020,12 @@ def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8483,11 +9037,12 @@ def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8499,11 +9054,12 @@ def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8515,11 +9071,12 @@ def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8531,11 +9088,12 @@ def test_list_g_month_day_pattern_9_nistxml_sv_ii_list_g_month_day_pattern_5_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8547,11 +9105,12 @@ def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8563,11 +9122,12 @@ def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8579,11 +9139,12 @@ def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8595,11 +9156,12 @@ def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8611,11 +9173,12 @@ def test_list_g_month_day_pattern_8_nistxml_sv_ii_list_g_month_day_pattern_4_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8628,11 +9191,12 @@ def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8645,11 +9209,12 @@ def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8662,11 +9227,12 @@ def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8679,11 +9245,12 @@ def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8696,11 +9263,12 @@ def test_list_g_month_day_pattern_7_nistxml_sv_ii_list_g_month_day_pattern_3_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8713,11 +9281,12 @@ def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8730,11 +9299,12 @@ def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8747,11 +9317,12 @@ def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8764,11 +9335,12 @@ def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8781,11 +9353,12 @@ def test_list_g_month_day_pattern_6_nistxml_sv_ii_list_g_month_day_pattern_2_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8797,11 +9370,12 @@ def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8813,11 +9387,12 @@ def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8829,11 +9404,12 @@ def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8845,11 +9421,12 @@ def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8861,11 +9438,12 @@ def test_list_g_month_day_pattern_5_nistxml_sv_ii_list_g_month_day_pattern_1_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8876,11 +9454,12 @@ def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8891,11 +9470,12 @@ def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8906,11 +9486,12 @@ def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8921,11 +9502,12 @@ def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8936,11 +9518,12 @@ def test_list_g_month_day_length_9_nistxml_sv_ii_list_g_month_day_length_5_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8951,11 +9534,12 @@ def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8966,11 +9550,12 @@ def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8981,11 +9566,12 @@ def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8996,11 +9582,12 @@ def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -9011,11 +9598,12 @@ def test_list_g_month_day_length_8_nistxml_sv_ii_list_g_month_day_length_4_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -9026,11 +9614,12 @@ def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -9041,11 +9630,12 @@ def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -9056,11 +9646,12 @@ def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -9071,11 +9662,12 @@ def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -9086,11 +9678,12 @@ def test_list_g_month_day_length_7_nistxml_sv_ii_list_g_month_day_length_3_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -9101,11 +9694,12 @@ def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -9116,11 +9710,12 @@ def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -9131,11 +9726,12 @@ def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -9146,11 +9742,12 @@ def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -9161,11 +9758,12 @@ def test_list_g_month_day_length_6_nistxml_sv_ii_list_g_month_day_length_2_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -9176,11 +9774,12 @@ def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -9191,11 +9790,12 @@ def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -9206,11 +9806,12 @@ def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -9221,11 +9822,12 @@ def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -9236,11 +9838,12 @@ def test_list_g_month_day_length_5_nistxml_sv_ii_list_g_month_day_length_1_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -9251,11 +9854,12 @@ def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -9266,11 +9870,12 @@ def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -9281,11 +9886,12 @@ def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -9296,11 +9902,12 @@ def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -9311,11 +9918,12 @@ def test_list_g_month_day_min_length_9_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -9326,11 +9934,12 @@ def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -9341,11 +9950,12 @@ def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -9356,11 +9966,12 @@ def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -9371,11 +9982,12 @@ def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -9386,11 +9998,12 @@ def test_list_g_month_day_min_length_8_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -9401,11 +10014,12 @@ def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -9416,11 +10030,12 @@ def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -9431,11 +10046,12 @@ def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -9446,11 +10062,12 @@ def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -9461,11 +10078,12 @@ def test_list_g_month_day_min_length_7_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -9476,11 +10094,12 @@ def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -9491,11 +10110,12 @@ def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -9506,11 +10126,12 @@ def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -9521,11 +10142,12 @@ def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -9536,11 +10158,12 @@ def test_list_g_month_day_min_length_6_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -9551,11 +10174,12 @@ def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -9566,11 +10190,12 @@ def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -9581,11 +10206,12 @@ def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -9596,11 +10222,12 @@ def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -9611,11 +10238,12 @@ def test_list_g_month_day_min_length_5_nistxml_sv_ii_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -9626,11 +10254,12 @@ def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -9641,11 +10270,12 @@ def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -9656,11 +10286,12 @@ def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -9671,11 +10302,12 @@ def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -9686,11 +10318,12 @@ def test_list_g_month_day_max_length_9_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -9701,11 +10334,12 @@ def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -9716,11 +10350,12 @@ def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -9731,11 +10366,12 @@ def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -9746,11 +10382,12 @@ def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -9761,11 +10398,12 @@ def test_list_g_month_day_max_length_8_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -9776,11 +10414,12 @@ def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -9791,11 +10430,12 @@ def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -9806,11 +10446,12 @@ def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -9821,11 +10462,12 @@ def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -9836,11 +10478,12 @@ def test_list_g_month_day_max_length_7_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9851,11 +10494,12 @@ def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9866,11 +10510,12 @@ def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9881,11 +10526,12 @@ def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9896,11 +10542,12 @@ def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9911,11 +10558,12 @@ def test_list_g_month_day_max_length_6_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9926,11 +10574,12 @@ def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9941,11 +10590,12 @@ def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9956,11 +10606,12 @@ def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9971,11 +10622,12 @@ def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9986,11 +10638,12 @@ def test_list_g_month_day_max_length_5_nistxml_sv_ii_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-II-list-gMonthDay-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10001,11 +10654,12 @@ def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10016,11 +10670,12 @@ def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10031,11 +10686,12 @@ def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10046,11 +10702,12 @@ def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10061,11 +10718,12 @@ def test_list_g_year_enumeration_9_nistxml_sv_ii_list_g_year_enumeration_5_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10076,11 +10734,12 @@ def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10091,11 +10750,12 @@ def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10106,11 +10766,12 @@ def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10121,11 +10782,12 @@ def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10136,11 +10798,12 @@ def test_list_g_year_enumeration_8_nistxml_sv_ii_list_g_year_enumeration_4_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10151,11 +10814,12 @@ def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10166,11 +10830,12 @@ def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10181,11 +10846,12 @@ def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10196,11 +10862,12 @@ def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10211,11 +10878,12 @@ def test_list_g_year_enumeration_7_nistxml_sv_ii_list_g_year_enumeration_3_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10226,11 +10894,12 @@ def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10241,11 +10910,12 @@ def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10256,11 +10926,12 @@ def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10271,11 +10942,12 @@ def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10286,11 +10958,12 @@ def test_list_g_year_enumeration_6_nistxml_sv_ii_list_g_year_enumeration_2_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10301,11 +10974,12 @@ def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10316,11 +10990,12 @@ def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10331,11 +11006,12 @@ def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10346,11 +11022,12 @@ def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -10361,11 +11038,12 @@ def test_list_g_year_enumeration_5_nistxml_sv_ii_list_g_year_enumeration_1_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -10377,11 +11055,12 @@ def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -10393,11 +11072,12 @@ def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -10409,11 +11089,12 @@ def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -10425,11 +11106,12 @@ def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -10441,11 +11123,12 @@ def test_list_g_year_pattern_9_nistxml_sv_ii_list_g_year_pattern_5_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d92
@@ -10457,11 +11140,12 @@ def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d92
@@ -10473,11 +11157,12 @@ def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d92
@@ -10489,11 +11174,12 @@ def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d92
@@ -10505,11 +11191,12 @@ def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d92
@@ -10521,11 +11208,12 @@ def test_list_g_year_pattern_8_nistxml_sv_ii_list_g_year_pattern_4_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d26
@@ -10537,11 +11225,12 @@ def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d26
@@ -10553,11 +11242,12 @@ def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d26
@@ -10569,11 +11259,12 @@ def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d26
@@ -10585,11 +11276,12 @@ def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d26
@@ -10601,11 +11293,12 @@ def test_list_g_year_pattern_7_nistxml_sv_ii_list_g_year_pattern_3_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -10617,11 +11310,12 @@ def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -10633,11 +11327,12 @@ def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -10649,11 +11344,12 @@ def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -10665,11 +11361,12 @@ def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -10681,11 +11378,12 @@ def test_list_g_year_pattern_6_nistxml_sv_ii_list_g_year_pattern_2_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d73
@@ -10697,11 +11395,12 @@ def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d73
@@ -10713,11 +11412,12 @@ def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d73
@@ -10729,11 +11429,12 @@ def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d73
@@ -10745,11 +11446,12 @@ def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d73
@@ -10761,11 +11463,12 @@ def test_list_g_year_pattern_5_nistxml_sv_ii_list_g_year_pattern_1_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10776,11 +11479,12 @@ def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10791,11 +11495,12 @@ def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10806,11 +11511,12 @@ def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10821,11 +11527,12 @@ def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10836,11 +11543,12 @@ def test_list_g_year_length_9_nistxml_sv_ii_list_g_year_length_5_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10851,11 +11559,12 @@ def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10866,11 +11575,12 @@ def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10881,11 +11591,12 @@ def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10896,11 +11607,12 @@ def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10911,11 +11623,12 @@ def test_list_g_year_length_8_nistxml_sv_ii_list_g_year_length_4_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10926,11 +11639,12 @@ def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10941,11 +11655,12 @@ def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10956,11 +11671,12 @@ def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10971,11 +11687,12 @@ def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10986,11 +11703,12 @@ def test_list_g_year_length_7_nistxml_sv_ii_list_g_year_length_3_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -11001,11 +11719,12 @@ def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -11016,11 +11735,12 @@ def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -11031,11 +11751,12 @@ def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -11046,11 +11767,12 @@ def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -11061,11 +11783,12 @@ def test_list_g_year_length_6_nistxml_sv_ii_list_g_year_length_2_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -11076,11 +11799,12 @@ def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -11091,11 +11815,12 @@ def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -11106,11 +11831,12 @@ def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -11121,11 +11847,12 @@ def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -11136,11 +11863,12 @@ def test_list_g_year_length_5_nistxml_sv_ii_list_g_year_length_1_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -11151,11 +11879,12 @@ def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -11166,11 +11895,12 @@ def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -11181,11 +11911,12 @@ def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -11196,11 +11927,12 @@ def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -11211,11 +11943,12 @@ def test_list_g_year_min_length_9_nistxml_sv_ii_list_g_year_min_length_5_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -11226,11 +11959,12 @@ def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -11241,11 +11975,12 @@ def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -11256,11 +11991,12 @@ def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -11271,11 +12007,12 @@ def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -11286,11 +12023,12 @@ def test_list_g_year_min_length_8_nistxml_sv_ii_list_g_year_min_length_4_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -11301,11 +12039,12 @@ def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -11316,11 +12055,12 @@ def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -11331,11 +12071,12 @@ def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -11346,11 +12087,12 @@ def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -11361,11 +12103,12 @@ def test_list_g_year_min_length_7_nistxml_sv_ii_list_g_year_min_length_3_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -11376,11 +12119,12 @@ def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -11391,11 +12135,12 @@ def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -11406,11 +12151,12 @@ def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -11421,11 +12167,12 @@ def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -11436,11 +12183,12 @@ def test_list_g_year_min_length_6_nistxml_sv_ii_list_g_year_min_length_2_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -11451,11 +12199,12 @@ def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -11466,11 +12215,12 @@ def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -11481,11 +12231,12 @@ def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -11496,11 +12247,12 @@ def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -11511,11 +12263,12 @@ def test_list_g_year_min_length_5_nistxml_sv_ii_list_g_year_min_length_1_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -11526,11 +12279,12 @@ def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -11541,11 +12295,12 @@ def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -11556,11 +12311,12 @@ def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -11571,11 +12327,12 @@ def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -11586,11 +12343,12 @@ def test_list_g_year_max_length_9_nistxml_sv_ii_list_g_year_max_length_5_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -11601,11 +12359,12 @@ def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -11616,11 +12375,12 @@ def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -11631,11 +12391,12 @@ def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -11646,11 +12407,12 @@ def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -11661,11 +12423,12 @@ def test_list_g_year_max_length_8_nistxml_sv_ii_list_g_year_max_length_4_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -11676,11 +12439,12 @@ def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -11691,11 +12455,12 @@ def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -11706,11 +12471,12 @@ def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -11721,11 +12487,12 @@ def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -11736,11 +12503,12 @@ def test_list_g_year_max_length_7_nistxml_sv_ii_list_g_year_max_length_3_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11751,11 +12519,12 @@ def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11766,11 +12535,12 @@ def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11781,11 +12551,12 @@ def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11796,11 +12567,12 @@ def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11811,11 +12583,12 @@ def test_list_g_year_max_length_6_nistxml_sv_ii_list_g_year_max_length_2_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11826,11 +12599,12 @@ def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11841,11 +12615,12 @@ def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11856,11 +12631,12 @@ def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11871,11 +12647,12 @@ def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11886,11 +12663,12 @@ def test_list_g_year_max_length_5_nistxml_sv_ii_list_g_year_max_length_1_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-II-list-gYear-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumeration_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11901,11 +12679,12 @@ def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumeration_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11916,11 +12695,12 @@ def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumeration_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11931,11 +12711,12 @@ def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumeration_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11946,11 +12727,12 @@ def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumeration_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11961,11 +12743,12 @@ def test_list_g_year_month_enumeration_9_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumeration_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11976,11 +12759,12 @@ def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumeration_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11991,11 +12775,12 @@ def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumeration_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12006,11 +12791,12 @@ def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumeration_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12021,11 +12807,12 @@ def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumeration_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12036,11 +12823,12 @@ def test_list_g_year_month_enumeration_8_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumeration_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12051,11 +12839,12 @@ def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumeration_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12066,11 +12855,12 @@ def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumeration_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12081,11 +12871,12 @@ def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumeration_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12096,11 +12887,12 @@ def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumeration_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12111,11 +12903,12 @@ def test_list_g_year_month_enumeration_7_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumeration_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12126,11 +12919,12 @@ def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumeration_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12141,11 +12935,12 @@ def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumeration_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12156,11 +12951,12 @@ def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumeration_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12171,11 +12967,12 @@ def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumeration_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12186,11 +12983,12 @@ def test_list_g_year_month_enumeration_6_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumeration_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12201,11 +12999,12 @@ def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumeration_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12216,11 +13015,12 @@ def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumeration_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12231,11 +13031,12 @@ def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumeration_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12246,11 +13047,12 @@ def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumeration_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -12261,11 +13063,12 @@ def test_list_g_year_month_enumeration_5_nistxml_sv_ii_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12278,11 +13081,12 @@ def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12295,11 +13099,12 @@ def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12312,11 +13117,12 @@ def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12329,11 +13135,12 @@ def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12346,11 +13153,12 @@ def test_list_g_year_month_pattern_9_nistxml_sv_ii_list_g_year_month_pattern_5_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12362,11 +13170,12 @@ def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12378,11 +13187,12 @@ def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12394,11 +13204,12 @@ def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12410,11 +13221,12 @@ def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12426,11 +13238,12 @@ def test_list_g_year_month_pattern_8_nistxml_sv_ii_list_g_year_month_pattern_4_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12443,11 +13256,12 @@ def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12460,11 +13274,12 @@ def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12477,11 +13292,12 @@ def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12494,11 +13310,12 @@ def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12511,11 +13328,12 @@ def test_list_g_year_month_pattern_7_nistxml_sv_ii_list_g_year_month_pattern_3_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12528,11 +13346,12 @@ def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12545,11 +13364,12 @@ def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12562,11 +13382,12 @@ def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12579,11 +13400,12 @@ def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12596,11 +13418,12 @@ def test_list_g_year_month_pattern_6_nistxml_sv_ii_list_g_year_month_pattern_2_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12613,11 +13436,12 @@ def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12630,11 +13454,12 @@ def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12647,11 +13472,12 @@ def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12664,11 +13490,12 @@ def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -12681,11 +13508,12 @@ def test_list_g_year_month_pattern_5_nistxml_sv_ii_list_g_year_month_pattern_1_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12696,11 +13524,12 @@ def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12711,11 +13540,12 @@ def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12726,11 +13556,12 @@ def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12741,11 +13572,12 @@ def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12756,11 +13588,12 @@ def test_list_g_year_month_length_9_nistxml_sv_ii_list_g_year_month_length_5_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12771,11 +13604,12 @@ def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12786,11 +13620,12 @@ def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12801,11 +13636,12 @@ def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12816,11 +13652,12 @@ def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12831,11 +13668,12 @@ def test_list_g_year_month_length_8_nistxml_sv_ii_list_g_year_month_length_4_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12846,11 +13684,12 @@ def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12861,11 +13700,12 @@ def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12876,11 +13716,12 @@ def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12891,11 +13732,12 @@ def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12906,11 +13748,12 @@ def test_list_g_year_month_length_7_nistxml_sv_ii_list_g_year_month_length_3_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12921,11 +13764,12 @@ def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12936,11 +13780,12 @@ def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12951,11 +13796,12 @@ def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12966,11 +13812,12 @@ def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12981,11 +13828,12 @@ def test_list_g_year_month_length_6_nistxml_sv_ii_list_g_year_month_length_2_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -12996,11 +13844,12 @@ def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -13011,11 +13860,12 @@ def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -13026,11 +13876,12 @@ def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -13041,11 +13892,12 @@ def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -13056,11 +13908,12 @@ def test_list_g_year_month_length_5_nistxml_sv_ii_list_g_year_month_length_1_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_length_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -13071,11 +13924,12 @@ def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_length_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -13086,11 +13940,12 @@ def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_length_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -13101,11 +13956,12 @@ def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_length_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -13116,11 +13972,12 @@ def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_length_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -13131,11 +13988,12 @@ def test_list_g_year_month_min_length_9_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_length_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -13146,11 +14004,12 @@ def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_length_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -13161,11 +14020,12 @@ def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_length_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -13176,11 +14036,12 @@ def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_length_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -13191,11 +14052,12 @@ def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_length_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -13206,11 +14068,12 @@ def test_list_g_year_month_min_length_8_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_length_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -13221,11 +14084,12 @@ def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_length_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -13236,11 +14100,12 @@ def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_length_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -13251,11 +14116,12 @@ def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_length_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -13266,11 +14132,12 @@ def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_length_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -13281,11 +14148,12 @@ def test_list_g_year_month_min_length_7_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_length_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -13296,11 +14164,12 @@ def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_length_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -13311,11 +14180,12 @@ def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_length_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -13326,11 +14196,12 @@ def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_length_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -13341,11 +14212,12 @@ def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_length_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -13356,11 +14228,12 @@ def test_list_g_year_month_min_length_6_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_length_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -13371,11 +14244,12 @@ def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_length_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -13386,11 +14260,12 @@ def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_length_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -13401,11 +14276,12 @@ def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_length_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -13416,11 +14292,12 @@ def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_length_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -13431,11 +14308,12 @@ def test_list_g_year_month_min_length_5_nistxml_sv_ii_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_length_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -13446,11 +14324,12 @@ def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_length_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -13461,11 +14340,12 @@ def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_length_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -13476,11 +14356,12 @@ def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_length_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -13491,11 +14372,12 @@ def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_length_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -13506,11 +14388,12 @@ def test_list_g_year_month_max_length_9_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_length_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -13521,11 +14404,12 @@ def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_length_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -13536,11 +14420,12 @@ def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_length_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -13551,11 +14436,12 @@ def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_length_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -13566,11 +14452,12 @@ def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_length_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -13581,11 +14468,12 @@ def test_list_g_year_month_max_length_8_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_length_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -13596,11 +14484,12 @@ def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_length_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -13611,11 +14500,12 @@ def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_length_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -13626,11 +14516,12 @@ def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_length_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -13641,11 +14532,12 @@ def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_length_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -13656,11 +14548,12 @@ def test_list_g_year_month_max_length_7_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_length_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13671,11 +14564,12 @@ def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_length_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13686,11 +14580,12 @@ def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_length_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13701,11 +14596,12 @@ def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_length_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13716,11 +14612,12 @@ def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_length_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13731,11 +14628,12 @@ def test_list_g_year_month_max_length_6_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_length_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13746,11 +14644,12 @@ def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_length_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13761,11 +14660,12 @@ def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_length_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13776,11 +14676,12 @@ def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_length_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13791,11 +14692,12 @@ def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_length_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13806,11 +14708,12 @@ def test_list_g_year_month_max_length_5_nistxml_sv_ii_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-II-list-gYearMonth-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13821,11 +14724,12 @@ def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13836,11 +14740,12 @@ def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13851,11 +14756,12 @@ def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13866,11 +14772,12 @@ def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13881,11 +14788,12 @@ def test_list_date_enumeration_9_nistxml_sv_ii_list_date_enumeration_5_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13896,11 +14804,12 @@ def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13911,11 +14820,12 @@ def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13926,11 +14836,12 @@ def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13941,11 +14852,12 @@ def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13956,11 +14868,12 @@ def test_list_date_enumeration_8_nistxml_sv_ii_list_date_enumeration_4_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13971,11 +14884,12 @@ def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13986,11 +14900,12 @@ def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14001,11 +14916,12 @@ def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14016,11 +14932,12 @@ def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14031,11 +14948,12 @@ def test_list_date_enumeration_7_nistxml_sv_ii_list_date_enumeration_3_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14046,11 +14964,12 @@ def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14061,11 +14980,12 @@ def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14076,11 +14996,12 @@ def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14091,11 +15012,12 @@ def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14106,11 +15028,12 @@ def test_list_date_enumeration_6_nistxml_sv_ii_list_date_enumeration_2_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14121,11 +15044,12 @@ def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14136,11 +15060,12 @@ def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14151,11 +15076,12 @@ def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14166,11 +15092,12 @@ def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -14181,11 +15108,12 @@ def test_list_date_enumeration_5_nistxml_sv_ii_list_date_enumeration_1_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14198,11 +15126,12 @@ def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14215,11 +15144,12 @@ def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14232,11 +15162,12 @@ def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14249,11 +15180,12 @@ def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14266,11 +15198,12 @@ def test_list_date_pattern_9_nistxml_sv_ii_list_date_pattern_5_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14283,11 +15216,12 @@ def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14300,11 +15234,12 @@ def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14317,11 +15252,12 @@ def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14334,11 +15270,12 @@ def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14351,11 +15288,12 @@ def test_list_date_pattern_8_nistxml_sv_ii_list_date_pattern_4_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14368,11 +15306,12 @@ def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14385,11 +15324,12 @@ def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14402,11 +15342,12 @@ def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14419,11 +15360,12 @@ def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14436,11 +15378,12 @@ def test_list_date_pattern_7_nistxml_sv_ii_list_date_pattern_3_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14453,11 +15396,12 @@ def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14470,11 +15414,12 @@ def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14487,11 +15432,12 @@ def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14504,11 +15450,12 @@ def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14521,11 +15468,12 @@ def test_list_date_pattern_6_nistxml_sv_ii_list_date_pattern_2_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14538,11 +15486,12 @@ def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14555,11 +15504,12 @@ def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14572,11 +15522,12 @@ def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14589,11 +15540,12 @@ def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -14606,11 +15558,12 @@ def test_list_date_pattern_5_nistxml_sv_ii_list_date_pattern_1_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_1(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14621,11 +15574,12 @@ def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_2(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14636,11 +15590,12 @@ def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_3(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14651,11 +15606,12 @@ def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_4(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14666,11 +15622,12 @@ def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_5(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14681,11 +15638,12 @@ def test_list_date_length_9_nistxml_sv_ii_list_date_length_5_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_1(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14696,11 +15654,12 @@ def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_2(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14711,11 +15670,12 @@ def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_3(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14726,11 +15686,12 @@ def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_4(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14741,11 +15702,12 @@ def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_5(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14756,11 +15718,12 @@ def test_list_date_length_8_nistxml_sv_ii_list_date_length_4_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_1(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14771,11 +15734,12 @@ def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_2(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14786,11 +15750,12 @@ def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_3(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14801,11 +15766,12 @@ def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_4(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14816,11 +15782,12 @@ def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_5(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14831,11 +15798,12 @@ def test_list_date_length_7_nistxml_sv_ii_list_date_length_3_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_1(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14846,11 +15814,12 @@ def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_2(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14861,11 +15830,12 @@ def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_3(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14876,11 +15846,12 @@ def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_4(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14891,11 +15862,12 @@ def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_5(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14906,11 +15878,12 @@ def test_list_date_length_6_nistxml_sv_ii_list_date_length_2_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_1(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14921,11 +15894,12 @@ def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_2(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14936,11 +15910,12 @@ def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_3(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14951,11 +15926,12 @@ def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_4(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14966,11 +15942,12 @@ def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_5(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14981,11 +15958,12 @@ def test_list_date_length_5_nistxml_sv_ii_list_date_length_1_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -14996,11 +15974,12 @@ def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -15011,11 +15990,12 @@ def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -15026,11 +16006,12 @@ def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -15041,11 +16022,12 @@ def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -15056,11 +16038,12 @@ def test_list_date_min_length_9_nistxml_sv_ii_list_date_min_length_5_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -15071,11 +16054,12 @@ def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -15086,11 +16070,12 @@ def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -15101,11 +16086,12 @@ def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -15116,11 +16102,12 @@ def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -15131,11 +16118,12 @@ def test_list_date_min_length_8_nistxml_sv_ii_list_date_min_length_4_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -15146,11 +16134,12 @@ def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -15161,11 +16150,12 @@ def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -15176,11 +16166,12 @@ def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -15191,11 +16182,12 @@ def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -15206,11 +16198,12 @@ def test_list_date_min_length_7_nistxml_sv_ii_list_date_min_length_3_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -15221,11 +16214,12 @@ def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -15236,11 +16230,12 @@ def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -15251,11 +16246,12 @@ def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -15266,11 +16262,12 @@ def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -15281,11 +16278,12 @@ def test_list_date_min_length_6_nistxml_sv_ii_list_date_min_length_2_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -15296,11 +16294,12 @@ def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -15311,11 +16310,12 @@ def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -15326,11 +16326,12 @@ def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -15341,11 +16342,12 @@ def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -15356,6 +16358,6 @@ def test_list_date_min_length_5_nistxml_sv_ii_list_date_min_length_1_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_3000.py
+++ b/tests/test_nist_meta_3000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -11,11 +14,12 @@ def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -26,11 +30,12 @@ def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -41,11 +46,12 @@ def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -56,11 +62,12 @@ def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -71,11 +78,12 @@ def test_list_date_max_length_9_nistxml_sv_ii_list_date_max_length_5_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -86,11 +94,12 @@ def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -101,11 +110,12 @@ def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -116,11 +126,12 @@ def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -131,11 +142,12 @@ def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -146,11 +158,12 @@ def test_list_date_max_length_8_nistxml_sv_ii_list_date_max_length_4_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -161,11 +174,12 @@ def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -176,11 +190,12 @@ def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -191,11 +206,12 @@ def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -206,11 +222,12 @@ def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -221,11 +238,12 @@ def test_list_date_max_length_7_nistxml_sv_ii_list_date_max_length_3_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -236,11 +254,12 @@ def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -251,11 +270,12 @@ def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -266,11 +286,12 @@ def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -281,11 +302,12 @@ def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -296,11 +318,12 @@ def test_list_date_max_length_6_nistxml_sv_ii_list_date_max_length_2_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -311,11 +334,12 @@ def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -326,11 +350,12 @@ def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -341,11 +366,12 @@ def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -356,11 +382,12 @@ def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -371,11 +398,12 @@ def test_list_date_max_length_5_nistxml_sv_ii_list_date_max_length_1_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-II-list-date-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -386,11 +414,12 @@ def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -401,11 +430,12 @@ def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -416,11 +446,12 @@ def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -431,11 +462,12 @@ def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -446,11 +478,12 @@ def test_list_time_enumeration_9_nistxml_sv_ii_list_time_enumeration_5_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -461,11 +494,12 @@ def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -476,11 +510,12 @@ def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -491,11 +526,12 @@ def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -506,11 +542,12 @@ def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -521,11 +558,12 @@ def test_list_time_enumeration_8_nistxml_sv_ii_list_time_enumeration_4_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -536,11 +574,12 @@ def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -551,11 +590,12 @@ def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -566,11 +606,12 @@ def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -581,11 +622,12 @@ def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -596,11 +638,12 @@ def test_list_time_enumeration_7_nistxml_sv_ii_list_time_enumeration_3_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -611,11 +654,12 @@ def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -626,11 +670,12 @@ def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -641,11 +686,12 @@ def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -656,11 +702,12 @@ def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -671,11 +718,12 @@ def test_list_time_enumeration_6_nistxml_sv_ii_list_time_enumeration_2_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -686,11 +734,12 @@ def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -701,11 +750,12 @@ def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -716,11 +766,12 @@ def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -731,11 +782,12 @@ def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -746,11 +798,12 @@ def test_list_time_enumeration_5_nistxml_sv_ii_list_time_enumeration_1_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d5:\d5
@@ -763,11 +816,12 @@ def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d5:\d5
@@ -780,11 +834,12 @@ def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d5:\d5
@@ -797,11 +852,12 @@ def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d5:\d5
@@ -814,11 +870,12 @@ def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d5:\d5
@@ -831,11 +888,12 @@ def test_list_time_pattern_9_nistxml_sv_ii_list_time_pattern_5_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d1:\d9
@@ -847,11 +905,12 @@ def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d1:\d9
@@ -863,11 +922,12 @@ def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d1:\d9
@@ -879,11 +939,12 @@ def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d1:\d9
@@ -895,11 +956,12 @@ def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d1:\d9
@@ -911,11 +973,12 @@ def test_list_time_pattern_8_nistxml_sv_ii_list_time_pattern_4_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -928,11 +991,12 @@ def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -945,11 +1009,12 @@ def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -962,11 +1027,12 @@ def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -979,11 +1045,12 @@ def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -996,11 +1063,12 @@ def test_list_time_pattern_7_nistxml_sv_ii_list_time_pattern_3_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d9:\d7
@@ -1013,11 +1081,12 @@ def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d9:\d7
@@ -1030,11 +1099,12 @@ def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d9:\d7
@@ -1047,11 +1117,12 @@ def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d9:\d7
@@ -1064,11 +1135,12 @@ def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:\d9:\d7
@@ -1081,11 +1153,12 @@ def test_list_time_pattern_6_nistxml_sv_ii_list_time_pattern_2_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d1:\d5:2\d
@@ -1097,11 +1170,12 @@ def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d1:\d5:2\d
@@ -1113,11 +1187,12 @@ def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d1:\d5:2\d
@@ -1129,11 +1204,12 @@ def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d1:\d5:2\d
@@ -1145,11 +1221,12 @@ def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d1:\d5:2\d
@@ -1161,11 +1238,12 @@ def test_list_time_pattern_5_nistxml_sv_ii_list_time_pattern_1_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_1(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -1176,11 +1254,12 @@ def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_2(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -1191,11 +1270,12 @@ def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_3(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -1206,11 +1286,12 @@ def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_4(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -1221,11 +1302,12 @@ def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_5(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -1236,11 +1318,12 @@ def test_list_time_length_9_nistxml_sv_ii_list_time_length_5_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_1(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -1251,11 +1334,12 @@ def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_2(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -1266,11 +1350,12 @@ def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_3(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -1281,11 +1366,12 @@ def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_4(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -1296,11 +1382,12 @@ def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_5(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -1311,11 +1398,12 @@ def test_list_time_length_8_nistxml_sv_ii_list_time_length_4_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_1(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -1326,11 +1414,12 @@ def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_2(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -1341,11 +1430,12 @@ def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_3(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -1356,11 +1446,12 @@ def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_4(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -1371,11 +1462,12 @@ def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_5(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -1386,11 +1478,12 @@ def test_list_time_length_7_nistxml_sv_ii_list_time_length_3_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_1(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -1401,11 +1494,12 @@ def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_2(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -1416,11 +1510,12 @@ def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_3(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -1431,11 +1526,12 @@ def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_4(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -1446,11 +1542,12 @@ def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_5(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -1461,11 +1558,12 @@ def test_list_time_length_6_nistxml_sv_ii_list_time_length_2_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_1(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -1476,11 +1574,12 @@ def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_2(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -1491,11 +1590,12 @@ def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_3(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -1506,11 +1606,12 @@ def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_4(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -1521,11 +1622,12 @@ def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_5(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -1536,11 +1638,12 @@ def test_list_time_length_5_nistxml_sv_ii_list_time_length_1_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -1551,11 +1654,12 @@ def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -1566,11 +1670,12 @@ def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -1581,11 +1686,12 @@ def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -1596,11 +1702,12 @@ def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -1611,11 +1718,12 @@ def test_list_time_min_length_9_nistxml_sv_ii_list_time_min_length_5_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -1626,11 +1734,12 @@ def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -1641,11 +1750,12 @@ def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -1656,11 +1766,12 @@ def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -1671,11 +1782,12 @@ def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -1686,11 +1798,12 @@ def test_list_time_min_length_8_nistxml_sv_ii_list_time_min_length_4_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1701,11 +1814,12 @@ def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1716,11 +1830,12 @@ def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1731,11 +1846,12 @@ def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1746,11 +1862,12 @@ def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1761,11 +1878,12 @@ def test_list_time_min_length_7_nistxml_sv_ii_list_time_min_length_3_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1776,11 +1894,12 @@ def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1791,11 +1910,12 @@ def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1806,11 +1926,12 @@ def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1821,11 +1942,12 @@ def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1836,11 +1958,12 @@ def test_list_time_min_length_6_nistxml_sv_ii_list_time_min_length_2_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1851,11 +1974,12 @@ def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1866,11 +1990,12 @@ def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1881,11 +2006,12 @@ def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1896,11 +2022,12 @@ def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1911,11 +2038,12 @@ def test_list_time_min_length_5_nistxml_sv_ii_list_time_min_length_1_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1926,11 +2054,12 @@ def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1941,11 +2070,12 @@ def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1956,11 +2086,12 @@ def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1971,11 +2102,12 @@ def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1986,11 +2118,12 @@ def test_list_time_max_length_9_nistxml_sv_ii_list_time_max_length_5_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -2001,11 +2134,12 @@ def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -2016,11 +2150,12 @@ def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -2031,11 +2166,12 @@ def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -2046,11 +2182,12 @@ def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -2061,11 +2198,12 @@ def test_list_time_max_length_8_nistxml_sv_ii_list_time_max_length_4_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -2076,11 +2214,12 @@ def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -2091,11 +2230,12 @@ def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -2106,11 +2246,12 @@ def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -2121,11 +2262,12 @@ def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -2136,11 +2278,12 @@ def test_list_time_max_length_7_nistxml_sv_ii_list_time_max_length_3_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -2151,11 +2294,12 @@ def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -2166,11 +2310,12 @@ def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -2181,11 +2326,12 @@ def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -2196,11 +2342,12 @@ def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -2211,11 +2358,12 @@ def test_list_time_max_length_6_nistxml_sv_ii_list_time_max_length_2_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -2226,11 +2374,12 @@ def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -2241,11 +2390,12 @@ def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -2256,11 +2406,12 @@ def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -2271,11 +2422,12 @@ def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -2286,11 +2438,12 @@ def test_list_time_max_length_5_nistxml_sv_ii_list_time_max_length_1_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-II-list-time-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2301,11 +2454,12 @@ def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2316,11 +2470,12 @@ def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2331,11 +2486,12 @@ def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2346,11 +2502,12 @@ def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2361,11 +2518,12 @@ def test_list_date_time_enumeration_9_nistxml_sv_ii_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2376,11 +2534,12 @@ def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2391,11 +2550,12 @@ def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2406,11 +2566,12 @@ def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2421,11 +2582,12 @@ def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2436,11 +2598,12 @@ def test_list_date_time_enumeration_8_nistxml_sv_ii_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2451,11 +2614,12 @@ def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2466,11 +2630,12 @@ def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2481,11 +2646,12 @@ def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2496,11 +2662,12 @@ def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2511,11 +2678,12 @@ def test_list_date_time_enumeration_7_nistxml_sv_ii_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2526,11 +2694,12 @@ def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2541,11 +2710,12 @@ def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2556,11 +2726,12 @@ def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2571,11 +2742,12 @@ def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2586,11 +2758,12 @@ def test_list_date_time_enumeration_6_nistxml_sv_ii_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2601,11 +2774,12 @@ def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2616,11 +2790,12 @@ def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2631,11 +2806,12 @@ def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2646,11 +2822,12 @@ def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2661,11 +2838,12 @@ def test_list_date_time_enumeration_5_nistxml_sv_ii_list_date_time_enumeration_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2681,11 +2859,12 @@ def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2701,11 +2880,12 @@ def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2721,11 +2901,12 @@ def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2741,11 +2922,12 @@ def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2761,11 +2943,12 @@ def test_list_date_time_pattern_9_nistxml_sv_ii_list_date_time_pattern_5_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2779,11 +2962,12 @@ def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2797,11 +2981,12 @@ def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2815,11 +3000,12 @@ def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2833,11 +3019,12 @@ def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2851,11 +3038,12 @@ def test_list_date_time_pattern_8_nistxml_sv_ii_list_date_time_pattern_4_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2869,11 +3057,12 @@ def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2887,11 +3076,12 @@ def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2905,11 +3095,12 @@ def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2923,11 +3114,12 @@ def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2941,11 +3133,12 @@ def test_list_date_time_pattern_7_nistxml_sv_ii_list_date_time_pattern_3_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2960,11 +3153,12 @@ def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2979,11 +3173,12 @@ def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2998,11 +3193,12 @@ def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3017,11 +3213,12 @@ def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3036,11 +3233,12 @@ def test_list_date_time_pattern_6_nistxml_sv_ii_list_date_time_pattern_2_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3054,11 +3252,12 @@ def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3072,11 +3271,12 @@ def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3090,11 +3290,12 @@ def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3108,11 +3309,12 @@ def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -3126,11 +3328,12 @@ def test_list_date_time_pattern_5_nistxml_sv_ii_list_date_time_pattern_1_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -3141,11 +3344,12 @@ def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -3156,11 +3360,12 @@ def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -3171,11 +3376,12 @@ def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -3186,11 +3392,12 @@ def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -3201,11 +3408,12 @@ def test_list_date_time_length_9_nistxml_sv_ii_list_date_time_length_5_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -3216,11 +3424,12 @@ def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -3231,11 +3440,12 @@ def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -3246,11 +3456,12 @@ def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -3261,11 +3472,12 @@ def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -3276,11 +3488,12 @@ def test_list_date_time_length_8_nistxml_sv_ii_list_date_time_length_4_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -3291,11 +3504,12 @@ def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -3306,11 +3520,12 @@ def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -3321,11 +3536,12 @@ def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -3336,11 +3552,12 @@ def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -3351,11 +3568,12 @@ def test_list_date_time_length_7_nistxml_sv_ii_list_date_time_length_3_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -3366,11 +3584,12 @@ def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -3381,11 +3600,12 @@ def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -3396,11 +3616,12 @@ def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -3411,11 +3632,12 @@ def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -3426,11 +3648,12 @@ def test_list_date_time_length_6_nistxml_sv_ii_list_date_time_length_2_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -3441,11 +3664,12 @@ def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -3456,11 +3680,12 @@ def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -3471,11 +3696,12 @@ def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -3486,11 +3712,12 @@ def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -3501,11 +3728,12 @@ def test_list_date_time_length_5_nistxml_sv_ii_list_date_time_length_1_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -3516,11 +3744,12 @@ def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -3531,11 +3760,12 @@ def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -3546,11 +3776,12 @@ def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -3561,11 +3792,12 @@ def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -3576,11 +3808,12 @@ def test_list_date_time_min_length_9_nistxml_sv_ii_list_date_time_min_length_5_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3591,11 +3824,12 @@ def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3606,11 +3840,12 @@ def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3621,11 +3856,12 @@ def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3636,11 +3872,12 @@ def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3651,11 +3888,12 @@ def test_list_date_time_min_length_8_nistxml_sv_ii_list_date_time_min_length_4_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3666,11 +3904,12 @@ def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3681,11 +3920,12 @@ def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3696,11 +3936,12 @@ def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3711,11 +3952,12 @@ def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3726,11 +3968,12 @@ def test_list_date_time_min_length_7_nistxml_sv_ii_list_date_time_min_length_3_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3741,11 +3984,12 @@ def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3756,11 +4000,12 @@ def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3771,11 +4016,12 @@ def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3786,11 +4032,12 @@ def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3801,11 +4048,12 @@ def test_list_date_time_min_length_6_nistxml_sv_ii_list_date_time_min_length_2_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3816,11 +4064,12 @@ def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3831,11 +4080,12 @@ def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3846,11 +4096,12 @@ def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3861,11 +4112,12 @@ def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3876,11 +4128,12 @@ def test_list_date_time_min_length_5_nistxml_sv_ii_list_date_time_min_length_1_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3891,11 +4144,12 @@ def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3906,11 +4160,12 @@ def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3921,11 +4176,12 @@ def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3936,11 +4192,12 @@ def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3951,11 +4208,12 @@ def test_list_date_time_max_length_9_nistxml_sv_ii_list_date_time_max_length_5_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3966,11 +4224,12 @@ def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3981,11 +4240,12 @@ def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3996,11 +4256,12 @@ def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -4011,11 +4272,12 @@ def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -4026,11 +4288,12 @@ def test_list_date_time_max_length_8_nistxml_sv_ii_list_date_time_max_length_4_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -4041,11 +4304,12 @@ def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -4056,11 +4320,12 @@ def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -4071,11 +4336,12 @@ def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -4086,11 +4352,12 @@ def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -4101,11 +4368,12 @@ def test_list_date_time_max_length_7_nistxml_sv_ii_list_date_time_max_length_3_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -4116,11 +4384,12 @@ def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -4131,11 +4400,12 @@ def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -4146,11 +4416,12 @@ def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -4161,11 +4432,12 @@ def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -4176,11 +4448,12 @@ def test_list_date_time_max_length_6_nistxml_sv_ii_list_date_time_max_length_2_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -4191,11 +4464,12 @@ def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -4206,11 +4480,12 @@ def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -4221,11 +4496,12 @@ def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -4236,11 +4512,12 @@ def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -4251,11 +4528,12 @@ def test_list_date_time_max_length_5_nistxml_sv_ii_list_date_time_max_length_1_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-II-list-dateTime-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4266,11 +4544,12 @@ def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4281,11 +4560,12 @@ def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4296,11 +4576,12 @@ def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4311,11 +4592,12 @@ def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4326,11 +4608,12 @@ def test_list_duration_enumeration_9_nistxml_sv_ii_list_duration_enumeration_5_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4341,11 +4624,12 @@ def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4356,11 +4640,12 @@ def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4371,11 +4656,12 @@ def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4386,11 +4672,12 @@ def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4401,11 +4688,12 @@ def test_list_duration_enumeration_8_nistxml_sv_ii_list_duration_enumeration_4_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4416,11 +4704,12 @@ def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4431,11 +4720,12 @@ def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4446,11 +4736,12 @@ def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4461,11 +4752,12 @@ def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4476,11 +4768,12 @@ def test_list_duration_enumeration_7_nistxml_sv_ii_list_duration_enumeration_3_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4491,11 +4784,12 @@ def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4506,11 +4800,12 @@ def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4521,11 +4816,12 @@ def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4536,11 +4832,12 @@ def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4551,11 +4848,12 @@ def test_list_duration_enumeration_6_nistxml_sv_ii_list_duration_enumeration_2_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4566,11 +4864,12 @@ def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4581,11 +4880,12 @@ def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4596,11 +4896,12 @@ def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4611,11 +4912,12 @@ def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4626,11 +4928,12 @@ def test_list_duration_enumeration_5_nistxml_sv_ii_list_duration_enumeration_1_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4644,11 +4947,12 @@ def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4662,11 +4966,12 @@ def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4680,11 +4985,12 @@ def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4698,11 +5004,12 @@ def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4716,11 +5023,12 @@ def test_list_duration_pattern_9_nistxml_sv_ii_list_duration_pattern_5_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4736,11 +5044,12 @@ def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4756,11 +5065,12 @@ def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4776,11 +5086,12 @@ def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4796,11 +5107,12 @@ def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4816,11 +5128,12 @@ def test_list_duration_pattern_8_nistxml_sv_ii_list_duration_pattern_4_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4835,11 +5148,12 @@ def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4854,11 +5168,12 @@ def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4873,11 +5188,12 @@ def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4892,11 +5208,12 @@ def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4911,11 +5228,12 @@ def test_list_duration_pattern_7_nistxml_sv_ii_list_duration_pattern_3_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4930,11 +5248,12 @@ def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4949,11 +5268,12 @@ def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4968,11 +5288,12 @@ def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4987,11 +5308,12 @@ def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -5006,11 +5328,12 @@ def test_list_duration_pattern_6_nistxml_sv_ii_list_duration_pattern_2_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -5026,11 +5349,12 @@ def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -5046,11 +5370,12 @@ def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -5066,11 +5391,12 @@ def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -5086,11 +5412,12 @@ def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -5106,11 +5433,12 @@ def test_list_duration_pattern_5_nistxml_sv_ii_list_duration_pattern_1_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -5121,11 +5449,12 @@ def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -5136,11 +5465,12 @@ def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -5151,11 +5481,12 @@ def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -5166,11 +5497,12 @@ def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -5181,11 +5513,12 @@ def test_list_duration_length_9_nistxml_sv_ii_list_duration_length_5_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -5196,11 +5529,12 @@ def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -5211,11 +5545,12 @@ def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -5226,11 +5561,12 @@ def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -5241,11 +5577,12 @@ def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -5256,11 +5593,12 @@ def test_list_duration_length_8_nistxml_sv_ii_list_duration_length_4_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -5271,11 +5609,12 @@ def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -5286,11 +5625,12 @@ def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -5301,11 +5641,12 @@ def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -5316,11 +5657,12 @@ def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -5331,11 +5673,12 @@ def test_list_duration_length_7_nistxml_sv_ii_list_duration_length_3_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -5346,11 +5689,12 @@ def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -5361,11 +5705,12 @@ def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -5376,11 +5721,12 @@ def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -5391,11 +5737,12 @@ def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -5406,11 +5753,12 @@ def test_list_duration_length_6_nistxml_sv_ii_list_duration_length_2_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -5421,11 +5769,12 @@ def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -5436,11 +5785,12 @@ def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -5451,11 +5801,12 @@ def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -5466,11 +5817,12 @@ def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -5481,11 +5833,12 @@ def test_list_duration_length_5_nistxml_sv_ii_list_duration_length_1_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5496,11 +5849,12 @@ def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5511,11 +5865,12 @@ def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5526,11 +5881,12 @@ def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5541,11 +5897,12 @@ def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5556,11 +5913,12 @@ def test_list_duration_min_length_9_nistxml_sv_ii_list_duration_min_length_5_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5571,11 +5929,12 @@ def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5586,11 +5945,12 @@ def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5601,11 +5961,12 @@ def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5616,11 +5977,12 @@ def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5631,11 +5993,12 @@ def test_list_duration_min_length_8_nistxml_sv_ii_list_duration_min_length_4_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5646,11 +6009,12 @@ def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5661,11 +6025,12 @@ def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5676,11 +6041,12 @@ def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5691,11 +6057,12 @@ def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5706,11 +6073,12 @@ def test_list_duration_min_length_7_nistxml_sv_ii_list_duration_min_length_3_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5721,11 +6089,12 @@ def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5736,11 +6105,12 @@ def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5751,11 +6121,12 @@ def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5766,11 +6137,12 @@ def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5781,11 +6153,12 @@ def test_list_duration_min_length_6_nistxml_sv_ii_list_duration_min_length_2_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5796,11 +6169,12 @@ def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5811,11 +6185,12 @@ def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5826,11 +6201,12 @@ def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5841,11 +6217,12 @@ def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5856,11 +6233,12 @@ def test_list_duration_min_length_5_nistxml_sv_ii_list_duration_min_length_1_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5871,11 +6249,12 @@ def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5886,11 +6265,12 @@ def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5901,11 +6281,12 @@ def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5916,11 +6297,12 @@ def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5931,11 +6313,12 @@ def test_list_duration_max_length_9_nistxml_sv_ii_list_duration_max_length_5_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5946,11 +6329,12 @@ def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5961,11 +6345,12 @@ def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5976,11 +6361,12 @@ def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5991,11 +6377,12 @@ def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -6006,11 +6393,12 @@ def test_list_duration_max_length_8_nistxml_sv_ii_list_duration_max_length_4_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -6021,11 +6409,12 @@ def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -6036,11 +6425,12 @@ def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -6051,11 +6441,12 @@ def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -6066,11 +6457,12 @@ def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -6081,11 +6473,12 @@ def test_list_duration_max_length_7_nistxml_sv_ii_list_duration_max_length_3_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -6096,11 +6489,12 @@ def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -6111,11 +6505,12 @@ def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -6126,11 +6521,12 @@ def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -6141,11 +6537,12 @@ def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -6156,11 +6553,12 @@ def test_list_duration_max_length_6_nistxml_sv_ii_list_duration_max_length_2_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -6171,11 +6569,12 @@ def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -6186,11 +6585,12 @@ def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -6201,11 +6601,12 @@ def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -6216,11 +6617,12 @@ def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -6231,11 +6633,12 @@ def test_list_duration_max_length_5_nistxml_sv_ii_list_duration_max_length_1_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-II-list-duration-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6246,11 +6649,12 @@ def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6261,11 +6665,12 @@ def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6276,11 +6681,12 @@ def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6291,11 +6697,12 @@ def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6306,11 +6713,12 @@ def test_list_float_enumeration_9_nistxml_sv_ii_list_float_enumeration_5_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6321,11 +6729,12 @@ def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6336,11 +6745,12 @@ def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6351,11 +6761,12 @@ def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6366,11 +6777,12 @@ def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6381,11 +6793,12 @@ def test_list_float_enumeration_8_nistxml_sv_ii_list_float_enumeration_4_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6396,11 +6809,12 @@ def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6411,11 +6825,12 @@ def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6426,11 +6841,12 @@ def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6441,11 +6857,12 @@ def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6456,11 +6873,12 @@ def test_list_float_enumeration_7_nistxml_sv_ii_list_float_enumeration_3_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6471,11 +6889,12 @@ def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6486,11 +6905,12 @@ def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6501,11 +6921,12 @@ def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6516,11 +6937,12 @@ def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6531,11 +6953,12 @@ def test_list_float_enumeration_6_nistxml_sv_ii_list_float_enumeration_2_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6546,11 +6969,12 @@ def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6561,11 +6985,12 @@ def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6576,11 +7001,12 @@ def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6591,11 +7017,12 @@ def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6606,11 +7033,12 @@ def test_list_float_enumeration_5_nistxml_sv_ii_list_float_enumeration_1_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6623,11 +7051,12 @@ def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6640,11 +7069,12 @@ def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6657,11 +7087,12 @@ def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6674,11 +7105,12 @@ def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6691,11 +7123,12 @@ def test_list_float_pattern_9_nistxml_sv_ii_list_float_pattern_5_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6709,11 +7142,12 @@ def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6727,11 +7161,12 @@ def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6745,11 +7180,12 @@ def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6763,11 +7199,12 @@ def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6781,11 +7218,12 @@ def test_list_float_pattern_8_nistxml_sv_ii_list_float_pattern_4_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6799,11 +7237,12 @@ def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6817,11 +7256,12 @@ def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6835,11 +7275,12 @@ def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6853,11 +7294,12 @@ def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6871,11 +7313,12 @@ def test_list_float_pattern_7_nistxml_sv_ii_list_float_pattern_3_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6888,11 +7331,12 @@ def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6905,11 +7349,12 @@ def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6922,11 +7367,12 @@ def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6939,11 +7385,12 @@ def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6956,11 +7403,12 @@ def test_list_float_pattern_6_nistxml_sv_ii_list_float_pattern_2_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6974,11 +7422,12 @@ def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6992,11 +7441,12 @@ def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -7010,11 +7460,12 @@ def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -7028,11 +7479,12 @@ def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -7046,11 +7498,12 @@ def test_list_float_pattern_5_nistxml_sv_ii_list_float_pattern_1_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_1(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -7061,11 +7514,12 @@ def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_2(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -7076,11 +7530,12 @@ def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_3(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -7091,11 +7546,12 @@ def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_4(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -7106,11 +7562,12 @@ def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_5(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -7121,11 +7578,12 @@ def test_list_float_length_9_nistxml_sv_ii_list_float_length_5_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_1(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -7136,11 +7594,12 @@ def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_2(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -7151,11 +7610,12 @@ def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_3(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -7166,11 +7626,12 @@ def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_4(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -7181,11 +7642,12 @@ def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_5(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -7196,11 +7658,12 @@ def test_list_float_length_8_nistxml_sv_ii_list_float_length_4_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_1(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -7211,11 +7674,12 @@ def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_2(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -7226,11 +7690,12 @@ def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_3(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -7241,11 +7706,12 @@ def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_4(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -7256,11 +7722,12 @@ def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_5(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -7271,11 +7738,12 @@ def test_list_float_length_7_nistxml_sv_ii_list_float_length_3_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_1(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -7286,11 +7754,12 @@ def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_2(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -7301,11 +7770,12 @@ def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_3(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -7316,11 +7786,12 @@ def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_4(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -7331,11 +7802,12 @@ def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_5(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -7346,11 +7818,12 @@ def test_list_float_length_6_nistxml_sv_ii_list_float_length_2_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_1(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -7361,11 +7834,12 @@ def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_2(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -7376,11 +7850,12 @@ def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_3(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -7391,11 +7866,12 @@ def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_4(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -7406,11 +7882,12 @@ def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_5(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -7421,11 +7898,12 @@ def test_list_float_length_5_nistxml_sv_ii_list_float_length_1_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7436,11 +7914,12 @@ def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7451,11 +7930,12 @@ def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7466,11 +7946,12 @@ def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7481,11 +7962,12 @@ def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7496,11 +7978,12 @@ def test_list_float_min_length_9_nistxml_sv_ii_list_float_min_length_5_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7511,11 +7994,12 @@ def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7526,11 +8010,12 @@ def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7541,11 +8026,12 @@ def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7556,11 +8042,12 @@ def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7571,11 +8058,12 @@ def test_list_float_min_length_8_nistxml_sv_ii_list_float_min_length_4_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7586,11 +8074,12 @@ def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7601,11 +8090,12 @@ def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7616,11 +8106,12 @@ def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7631,11 +8122,12 @@ def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7646,11 +8138,12 @@ def test_list_float_min_length_7_nistxml_sv_ii_list_float_min_length_3_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7661,11 +8154,12 @@ def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7676,11 +8170,12 @@ def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7691,11 +8186,12 @@ def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7706,11 +8202,12 @@ def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7721,11 +8218,12 @@ def test_list_float_min_length_6_nistxml_sv_ii_list_float_min_length_2_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7736,11 +8234,12 @@ def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7751,11 +8250,12 @@ def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7766,11 +8266,12 @@ def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7781,11 +8282,12 @@ def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7796,11 +8298,12 @@ def test_list_float_min_length_5_nistxml_sv_ii_list_float_min_length_1_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7811,11 +8314,12 @@ def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7826,11 +8330,12 @@ def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7841,11 +8346,12 @@ def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7856,11 +8362,12 @@ def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7871,11 +8378,12 @@ def test_list_float_max_length_9_nistxml_sv_ii_list_float_max_length_5_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7886,11 +8394,12 @@ def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7901,11 +8410,12 @@ def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7916,11 +8426,12 @@ def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7931,11 +8442,12 @@ def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7946,11 +8458,12 @@ def test_list_float_max_length_8_nistxml_sv_ii_list_float_max_length_4_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7961,11 +8474,12 @@ def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7976,11 +8490,12 @@ def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7991,11 +8506,12 @@ def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -8006,11 +8522,12 @@ def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -8021,11 +8538,12 @@ def test_list_float_max_length_7_nistxml_sv_ii_list_float_max_length_3_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -8036,11 +8554,12 @@ def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -8051,11 +8570,12 @@ def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -8066,11 +8586,12 @@ def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -8081,11 +8602,12 @@ def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -8096,11 +8618,12 @@ def test_list_float_max_length_6_nistxml_sv_ii_list_float_max_length_2_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -8111,11 +8634,12 @@ def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -8126,11 +8650,12 @@ def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -8141,11 +8666,12 @@ def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -8156,11 +8682,12 @@ def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -8171,11 +8698,12 @@ def test_list_float_max_length_5_nistxml_sv_ii_list_float_max_length_1_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-II-list-float-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8186,11 +8714,12 @@ def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8201,11 +8730,12 @@ def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8216,11 +8746,12 @@ def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8231,11 +8762,12 @@ def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8246,11 +8778,12 @@ def test_list_double_enumeration_9_nistxml_sv_ii_list_double_enumeration_5_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8261,11 +8794,12 @@ def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8276,11 +8810,12 @@ def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8291,11 +8826,12 @@ def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8306,11 +8842,12 @@ def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8321,11 +8858,12 @@ def test_list_double_enumeration_8_nistxml_sv_ii_list_double_enumeration_4_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8336,11 +8874,12 @@ def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8351,11 +8890,12 @@ def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8366,11 +8906,12 @@ def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8381,11 +8922,12 @@ def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8396,11 +8938,12 @@ def test_list_double_enumeration_7_nistxml_sv_ii_list_double_enumeration_3_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8411,11 +8954,12 @@ def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8426,11 +8970,12 @@ def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8441,11 +8986,12 @@ def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8456,11 +9002,12 @@ def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8471,11 +9018,12 @@ def test_list_double_enumeration_6_nistxml_sv_ii_list_double_enumeration_2_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8486,11 +9034,12 @@ def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8501,11 +9050,12 @@ def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8516,11 +9066,12 @@ def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8531,11 +9082,12 @@ def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8546,11 +9098,12 @@ def test_list_double_enumeration_5_nistxml_sv_ii_list_double_enumeration_1_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8564,11 +9117,12 @@ def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8582,11 +9136,12 @@ def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8600,11 +9155,12 @@ def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8618,11 +9174,12 @@ def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8636,11 +9193,12 @@ def test_list_double_pattern_9_nistxml_sv_ii_list_double_pattern_5_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8654,11 +9212,12 @@ def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8672,11 +9231,12 @@ def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8690,11 +9250,12 @@ def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8708,11 +9269,12 @@ def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8726,11 +9288,12 @@ def test_list_double_pattern_8_nistxml_sv_ii_list_double_pattern_4_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8743,11 +9306,12 @@ def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8760,11 +9324,12 @@ def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8777,11 +9342,12 @@ def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8794,11 +9360,12 @@ def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8811,11 +9378,12 @@ def test_list_double_pattern_7_nistxml_sv_ii_list_double_pattern_3_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8829,11 +9397,12 @@ def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8847,11 +9416,12 @@ def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8865,11 +9435,12 @@ def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8883,11 +9454,12 @@ def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8901,11 +9473,12 @@ def test_list_double_pattern_6_nistxml_sv_ii_list_double_pattern_2_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8918,11 +9491,12 @@ def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8935,11 +9509,12 @@ def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8952,11 +9527,12 @@ def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8969,11 +9545,12 @@ def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8986,11 +9563,12 @@ def test_list_double_pattern_5_nistxml_sv_ii_list_double_pattern_1_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_1(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -9001,11 +9579,12 @@ def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_2(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -9016,11 +9595,12 @@ def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_3(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -9031,11 +9611,12 @@ def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_4(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -9046,11 +9627,12 @@ def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_5(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -9061,11 +9643,12 @@ def test_list_double_length_9_nistxml_sv_ii_list_double_length_5_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_1(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -9076,11 +9659,12 @@ def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_2(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -9091,11 +9675,12 @@ def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_3(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -9106,11 +9691,12 @@ def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_4(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -9121,11 +9707,12 @@ def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_5(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -9136,11 +9723,12 @@ def test_list_double_length_8_nistxml_sv_ii_list_double_length_4_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_1(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -9151,11 +9739,12 @@ def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_2(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -9166,11 +9755,12 @@ def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_3(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -9181,11 +9771,12 @@ def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_4(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -9196,11 +9787,12 @@ def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_5(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -9211,11 +9803,12 @@ def test_list_double_length_7_nistxml_sv_ii_list_double_length_3_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_1(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -9226,11 +9819,12 @@ def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_2(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -9241,11 +9835,12 @@ def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_3(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -9256,11 +9851,12 @@ def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_4(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -9271,11 +9867,12 @@ def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_5(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -9286,11 +9883,12 @@ def test_list_double_length_6_nistxml_sv_ii_list_double_length_2_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_1(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -9301,11 +9899,12 @@ def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_2(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -9316,11 +9915,12 @@ def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_3(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -9331,11 +9931,12 @@ def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_4(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -9346,11 +9947,12 @@ def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_5(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -9361,11 +9963,12 @@ def test_list_double_length_5_nistxml_sv_ii_list_double_length_1_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9376,11 +9979,12 @@ def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9391,11 +9995,12 @@ def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9406,11 +10011,12 @@ def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9421,11 +10027,12 @@ def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9436,11 +10043,12 @@ def test_list_double_min_length_9_nistxml_sv_ii_list_double_min_length_5_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9451,11 +10059,12 @@ def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9466,11 +10075,12 @@ def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9481,11 +10091,12 @@ def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9496,11 +10107,12 @@ def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9511,11 +10123,12 @@ def test_list_double_min_length_8_nistxml_sv_ii_list_double_min_length_4_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9526,11 +10139,12 @@ def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9541,11 +10155,12 @@ def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9556,11 +10171,12 @@ def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9571,11 +10187,12 @@ def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9586,11 +10203,12 @@ def test_list_double_min_length_7_nistxml_sv_ii_list_double_min_length_3_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9601,11 +10219,12 @@ def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9616,11 +10235,12 @@ def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9631,11 +10251,12 @@ def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9646,11 +10267,12 @@ def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9661,11 +10283,12 @@ def test_list_double_min_length_6_nistxml_sv_ii_list_double_min_length_2_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9676,11 +10299,12 @@ def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9691,11 +10315,12 @@ def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9706,11 +10331,12 @@ def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9721,11 +10347,12 @@ def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9736,11 +10363,12 @@ def test_list_double_min_length_5_nistxml_sv_ii_list_double_min_length_1_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9751,11 +10379,12 @@ def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9766,11 +10395,12 @@ def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9781,11 +10411,12 @@ def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9796,11 +10427,12 @@ def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9811,11 +10443,12 @@ def test_list_double_max_length_9_nistxml_sv_ii_list_double_max_length_5_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9826,11 +10459,12 @@ def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9841,11 +10475,12 @@ def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9856,11 +10491,12 @@ def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9871,11 +10507,12 @@ def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9886,11 +10523,12 @@ def test_list_double_max_length_8_nistxml_sv_ii_list_double_max_length_4_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9901,11 +10539,12 @@ def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9916,11 +10555,12 @@ def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9931,11 +10571,12 @@ def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9946,11 +10587,12 @@ def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9961,11 +10603,12 @@ def test_list_double_max_length_7_nistxml_sv_ii_list_double_max_length_3_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9976,11 +10619,12 @@ def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9991,11 +10635,12 @@ def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -10006,11 +10651,12 @@ def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -10021,11 +10667,12 @@ def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -10036,11 +10683,12 @@ def test_list_double_max_length_6_nistxml_sv_ii_list_double_max_length_2_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -10051,11 +10699,12 @@ def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -10066,11 +10715,12 @@ def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -10081,11 +10731,12 @@ def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -10096,11 +10747,12 @@ def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -10111,11 +10763,12 @@ def test_list_double_max_length_5_nistxml_sv_ii_list_double_max_length_1_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-II-list-double-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer_enumeration_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10126,11 +10779,12 @@ def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer_enumeration_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10141,11 +10795,12 @@ def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer_enumeration_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10156,11 +10811,12 @@ def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer_enumeration_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10171,11 +10827,12 @@ def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer_enumeration_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10186,11 +10843,12 @@ def test_list_positive_integer_enumeration_9_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer_enumeration_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10201,11 +10859,12 @@ def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer_enumeration_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10216,11 +10875,12 @@ def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer_enumeration_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10231,11 +10891,12 @@ def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer_enumeration_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10246,11 +10907,12 @@ def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer_enumeration_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10261,11 +10923,12 @@ def test_list_positive_integer_enumeration_8_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer_enumeration_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10276,11 +10939,12 @@ def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer_enumeration_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10291,11 +10955,12 @@ def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer_enumeration_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10306,11 +10971,12 @@ def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer_enumeration_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10321,11 +10987,12 @@ def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer_enumeration_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10336,11 +11003,12 @@ def test_list_positive_integer_enumeration_7_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer_enumeration_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10351,11 +11019,12 @@ def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer_enumeration_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10366,11 +11035,12 @@ def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer_enumeration_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10381,11 +11051,12 @@ def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer_enumeration_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10396,11 +11067,12 @@ def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer_enumeration_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10411,11 +11083,12 @@ def test_list_positive_integer_enumeration_6_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer_enumeration_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10426,11 +11099,12 @@ def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer_enumeration_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10441,11 +11115,12 @@ def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer_enumeration_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10456,11 +11131,12 @@ def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer_enumeration_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10471,11 +11147,12 @@ def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer_enumeration_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10486,11 +11163,12 @@ def test_list_positive_integer_enumeration_5_nistxml_sv_ii_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pattern_5_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10502,11 +11180,12 @@ def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pattern_5_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10518,11 +11197,12 @@ def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pattern_5_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10534,11 +11214,12 @@ def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pattern_5_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10550,11 +11231,12 @@ def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pattern_5_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10566,11 +11248,12 @@ def test_list_positive_integer_pattern_9_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pattern_4_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10582,11 +11265,12 @@ def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pattern_4_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10598,11 +11282,12 @@ def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pattern_4_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10614,11 +11299,12 @@ def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pattern_4_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10630,11 +11316,12 @@ def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pattern_4_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10646,11 +11333,12 @@ def test_list_positive_integer_pattern_8_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pattern_3_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10662,11 +11350,12 @@ def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pattern_3_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10678,11 +11367,12 @@ def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pattern_3_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10694,11 +11384,12 @@ def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pattern_3_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10710,11 +11401,12 @@ def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pattern_3_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10726,11 +11418,12 @@ def test_list_positive_integer_pattern_7_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pattern_2_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10742,11 +11435,12 @@ def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pattern_2_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10758,11 +11452,12 @@ def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pattern_2_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10774,11 +11469,12 @@ def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pattern_2_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10790,11 +11486,12 @@ def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pattern_2_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10806,11 +11503,12 @@ def test_list_positive_integer_pattern_6_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pattern_1_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10822,11 +11520,12 @@ def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pattern_1_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10838,11 +11537,12 @@ def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pattern_1_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10854,11 +11554,12 @@ def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pattern_1_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10870,11 +11571,12 @@ def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pattern_1_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10886,11 +11588,12 @@ def test_list_positive_integer_pattern_5_nistxml_sv_ii_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_length_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10901,11 +11604,12 @@ def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_length_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10916,11 +11620,12 @@ def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_length_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10931,11 +11636,12 @@ def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_length_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10946,11 +11652,12 @@ def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_length_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10961,11 +11668,12 @@ def test_list_positive_integer_length_9_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_length_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10976,11 +11684,12 @@ def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_length_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10991,11 +11700,12 @@ def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_length_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -11006,11 +11716,12 @@ def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_length_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -11021,11 +11732,12 @@ def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_length_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -11036,11 +11748,12 @@ def test_list_positive_integer_length_8_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_length_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -11051,11 +11764,12 @@ def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_length_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -11066,11 +11780,12 @@ def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_length_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -11081,11 +11796,12 @@ def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_length_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -11096,11 +11812,12 @@ def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_length_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -11111,11 +11828,12 @@ def test_list_positive_integer_length_7_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_length_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -11126,11 +11844,12 @@ def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_length_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -11141,11 +11860,12 @@ def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_length_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -11156,11 +11876,12 @@ def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_length_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -11171,11 +11892,12 @@ def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_length_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -11186,11 +11908,12 @@ def test_list_positive_integer_length_6_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_length_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -11201,11 +11924,12 @@ def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_length_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -11216,11 +11940,12 @@ def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_length_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -11231,11 +11956,12 @@ def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_length_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -11246,11 +11972,12 @@ def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_length_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -11261,11 +11988,12 @@ def test_list_positive_integer_length_5_nistxml_sv_ii_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_min_length_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11277,11 +12005,12 @@ def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_min_length_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11293,11 +12022,12 @@ def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_min_length_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11309,11 +12039,12 @@ def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_min_length_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11325,11 +12056,12 @@ def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_min_length_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11341,11 +12073,12 @@ def test_list_positive_integer_min_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_min_length_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11357,11 +12090,12 @@ def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_min_length_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11373,11 +12107,12 @@ def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_min_length_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11389,11 +12124,12 @@ def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_min_length_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11405,11 +12141,12 @@ def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_min_length_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11421,11 +12158,12 @@ def test_list_positive_integer_min_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_min_length_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11437,11 +12175,12 @@ def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_min_length_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11453,11 +12192,12 @@ def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_min_length_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11469,11 +12209,12 @@ def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_min_length_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11485,11 +12226,12 @@ def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_min_length_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11501,11 +12243,12 @@ def test_list_positive_integer_min_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_min_length_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11517,11 +12260,12 @@ def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_min_length_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11533,11 +12277,12 @@ def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_min_length_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11549,11 +12294,12 @@ def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_min_length_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11565,11 +12311,12 @@ def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_min_length_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11581,11 +12328,12 @@ def test_list_positive_integer_min_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_min_length_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11597,11 +12345,12 @@ def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_min_length_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11613,11 +12362,12 @@ def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_min_length_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11629,11 +12379,12 @@ def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_min_length_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11645,11 +12396,12 @@ def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_min_length_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11661,11 +12413,12 @@ def test_list_positive_integer_min_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_max_length_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11677,11 +12430,12 @@ def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_max_length_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11693,11 +12447,12 @@ def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_max_length_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11709,11 +12464,12 @@ def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_max_length_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11725,11 +12481,12 @@ def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_max_length_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11741,11 +12498,12 @@ def test_list_positive_integer_max_length_9_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_max_length_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11757,11 +12515,12 @@ def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_max_length_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11773,11 +12532,12 @@ def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_max_length_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11789,11 +12549,12 @@ def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_max_length_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11805,11 +12566,12 @@ def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_max_length_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11821,11 +12583,12 @@ def test_list_positive_integer_max_length_8_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_max_length_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11837,11 +12600,12 @@ def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_max_length_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11853,11 +12617,12 @@ def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_max_length_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11869,11 +12634,12 @@ def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_max_length_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11885,11 +12651,12 @@ def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_max_length_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11901,11 +12668,12 @@ def test_list_positive_integer_max_length_7_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_max_length_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11917,11 +12685,12 @@ def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_max_length_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11933,11 +12702,12 @@ def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_max_length_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11949,11 +12719,12 @@ def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_max_length_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11965,11 +12736,12 @@ def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_max_length_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11981,11 +12753,12 @@ def test_list_positive_integer_max_length_6_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_max_length_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11997,11 +12770,12 @@ def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_max_length_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -12013,11 +12787,12 @@ def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_max_length_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -12029,11 +12804,12 @@ def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_max_length_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -12045,11 +12821,12 @@ def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_max_length_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -12061,11 +12838,12 @@ def test_list_positive_integer_max_length_5_nistxml_sv_ii_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-II-list-positiveInteger-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enumeration_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12076,11 +12854,12 @@ def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enumeration_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12091,11 +12870,12 @@ def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enumeration_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12106,11 +12886,12 @@ def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enumeration_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12121,11 +12902,12 @@ def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enumeration_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12136,11 +12918,12 @@ def test_list_unsigned_byte_enumeration_9_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enumeration_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12151,11 +12934,12 @@ def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enumeration_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12166,11 +12950,12 @@ def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enumeration_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12181,11 +12966,12 @@ def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enumeration_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12196,11 +12982,12 @@ def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enumeration_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12211,11 +12998,12 @@ def test_list_unsigned_byte_enumeration_8_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enumeration_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12226,11 +13014,12 @@ def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enumeration_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12241,11 +13030,12 @@ def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enumeration_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12256,11 +13046,12 @@ def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enumeration_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12271,11 +13062,12 @@ def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enumeration_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12286,11 +13078,12 @@ def test_list_unsigned_byte_enumeration_7_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enumeration_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12301,11 +13094,12 @@ def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enumeration_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12316,11 +13110,12 @@ def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enumeration_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12331,11 +13126,12 @@ def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enumeration_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12346,11 +13142,12 @@ def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enumeration_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12361,11 +13158,12 @@ def test_list_unsigned_byte_enumeration_6_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enumeration_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12376,11 +13174,12 @@ def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enumeration_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12391,11 +13190,12 @@ def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enumeration_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12406,11 +13206,12 @@ def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enumeration_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12421,11 +13222,12 @@ def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enumeration_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12436,11 +13238,12 @@ def test_list_unsigned_byte_enumeration_5_nistxml_sv_ii_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12452,11 +13255,12 @@ def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12468,11 +13272,12 @@ def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12484,11 +13289,12 @@ def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12500,11 +13306,12 @@ def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12516,11 +13323,12 @@ def test_list_unsigned_byte_pattern_9_nistxml_sv_ii_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12532,11 +13340,12 @@ def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12548,11 +13357,12 @@ def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12564,11 +13374,12 @@ def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12580,11 +13391,12 @@ def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12596,11 +13408,12 @@ def test_list_unsigned_byte_pattern_8_nistxml_sv_ii_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12612,11 +13425,12 @@ def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12628,11 +13442,12 @@ def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12644,11 +13459,12 @@ def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12660,11 +13476,12 @@ def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12676,11 +13493,12 @@ def test_list_unsigned_byte_pattern_7_nistxml_sv_ii_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12692,11 +13510,12 @@ def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12708,11 +13527,12 @@ def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12724,11 +13544,12 @@ def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12740,11 +13561,12 @@ def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12756,11 +13578,12 @@ def test_list_unsigned_byte_pattern_6_nistxml_sv_ii_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12772,11 +13595,12 @@ def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12788,11 +13612,12 @@ def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12804,11 +13629,12 @@ def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12820,11 +13646,12 @@ def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12836,11 +13663,12 @@ def test_list_unsigned_byte_pattern_5_nistxml_sv_ii_list_unsigned_byte_pattern_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12851,11 +13679,12 @@ def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12866,11 +13695,12 @@ def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12881,11 +13711,12 @@ def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12896,11 +13727,12 @@ def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12911,11 +13743,12 @@ def test_list_unsigned_byte_length_9_nistxml_sv_ii_list_unsigned_byte_length_5_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12926,11 +13759,12 @@ def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12941,11 +13775,12 @@ def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12956,11 +13791,12 @@ def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12971,11 +13807,12 @@ def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12986,11 +13823,12 @@ def test_list_unsigned_byte_length_8_nistxml_sv_ii_list_unsigned_byte_length_4_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -13001,11 +13839,12 @@ def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -13016,11 +13855,12 @@ def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -13031,11 +13871,12 @@ def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -13046,11 +13887,12 @@ def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -13061,11 +13903,12 @@ def test_list_unsigned_byte_length_7_nistxml_sv_ii_list_unsigned_byte_length_3_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -13076,11 +13919,12 @@ def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -13091,11 +13935,12 @@ def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -13106,11 +13951,12 @@ def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -13121,11 +13967,12 @@ def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -13136,11 +13983,12 @@ def test_list_unsigned_byte_length_6_nistxml_sv_ii_list_unsigned_byte_length_2_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -13151,11 +13999,12 @@ def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -13166,11 +14015,12 @@ def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -13181,11 +14031,12 @@ def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -13196,11 +14047,12 @@ def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -13211,11 +14063,12 @@ def test_list_unsigned_byte_length_5_nistxml_sv_ii_list_unsigned_byte_length_1_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_length_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13226,11 +14079,12 @@ def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_length_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13241,11 +14095,12 @@ def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_length_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13256,11 +14111,12 @@ def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_length_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13271,11 +14127,12 @@ def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_length_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13286,11 +14143,12 @@ def test_list_unsigned_byte_min_length_9_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_length_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13301,11 +14159,12 @@ def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_length_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13316,11 +14175,12 @@ def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_length_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13331,11 +14191,12 @@ def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_length_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13346,11 +14207,12 @@ def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_length_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13361,11 +14223,12 @@ def test_list_unsigned_byte_min_length_8_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_length_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13376,11 +14239,12 @@ def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_length_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13391,11 +14255,12 @@ def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_length_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13406,11 +14271,12 @@ def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_length_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13421,11 +14287,12 @@ def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_length_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13436,11 +14303,12 @@ def test_list_unsigned_byte_min_length_7_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_length_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13451,11 +14319,12 @@ def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_length_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13466,11 +14335,12 @@ def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_length_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13481,11 +14351,12 @@ def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_length_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13496,11 +14367,12 @@ def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_length_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13511,11 +14383,12 @@ def test_list_unsigned_byte_min_length_6_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_length_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13526,11 +14399,12 @@ def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_length_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13541,11 +14415,12 @@ def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_length_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13556,11 +14431,12 @@ def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_length_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13571,11 +14447,12 @@ def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_length_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13586,11 +14463,12 @@ def test_list_unsigned_byte_min_length_5_nistxml_sv_ii_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_length_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13601,11 +14479,12 @@ def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_length_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13616,11 +14495,12 @@ def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_length_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13631,11 +14511,12 @@ def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_length_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13646,11 +14527,12 @@ def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_length_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13661,11 +14543,12 @@ def test_list_unsigned_byte_max_length_9_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_length_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13676,11 +14559,12 @@ def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_length_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13691,11 +14575,12 @@ def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_length_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13706,11 +14591,12 @@ def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_length_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13721,11 +14607,12 @@ def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_length_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13736,11 +14623,12 @@ def test_list_unsigned_byte_max_length_8_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_length_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13751,11 +14639,12 @@ def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_length_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13766,11 +14655,12 @@ def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_length_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13781,11 +14671,12 @@ def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_length_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13796,11 +14687,12 @@ def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_length_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13811,11 +14703,12 @@ def test_list_unsigned_byte_max_length_7_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_length_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13826,11 +14719,12 @@ def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_length_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13841,11 +14735,12 @@ def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_length_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13856,11 +14751,12 @@ def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_length_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13871,11 +14767,12 @@ def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_length_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13886,11 +14783,12 @@ def test_list_unsigned_byte_max_length_6_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_length_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13901,11 +14799,12 @@ def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_length_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13916,11 +14815,12 @@ def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_length_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13931,11 +14831,12 @@ def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_length_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13946,11 +14847,12 @@ def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_length_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13961,11 +14863,12 @@ def test_list_unsigned_byte_max_length_5_nistxml_sv_ii_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-II-list-unsignedByte-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enumeration_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13976,11 +14879,12 @@ def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enumeration_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13991,11 +14895,12 @@ def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enumeration_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14006,11 +14911,12 @@ def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enumeration_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14021,11 +14927,12 @@ def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enumeration_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14036,11 +14943,12 @@ def test_list_unsigned_short_enumeration_9_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enumeration_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14051,11 +14959,12 @@ def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enumeration_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14066,11 +14975,12 @@ def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enumeration_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14081,11 +14991,12 @@ def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enumeration_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14096,11 +15007,12 @@ def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enumeration_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14111,11 +15023,12 @@ def test_list_unsigned_short_enumeration_8_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enumeration_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14126,11 +15039,12 @@ def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enumeration_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14141,11 +15055,12 @@ def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enumeration_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14156,11 +15071,12 @@ def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enumeration_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14171,11 +15087,12 @@ def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enumeration_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14186,11 +15103,12 @@ def test_list_unsigned_short_enumeration_7_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enumeration_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14201,11 +15119,12 @@ def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enumeration_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14216,11 +15135,12 @@ def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enumeration_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14231,11 +15151,12 @@ def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enumeration_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14246,11 +15167,12 @@ def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enumeration_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14261,11 +15183,12 @@ def test_list_unsigned_short_enumeration_6_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enumeration_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14276,11 +15199,12 @@ def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enumeration_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14291,11 +15215,12 @@ def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enumeration_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14306,11 +15231,12 @@ def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enumeration_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14321,11 +15247,12 @@ def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enumeration_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14336,11 +15263,12 @@ def test_list_unsigned_short_enumeration_5_nistxml_sv_ii_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern_5_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14352,11 +15280,12 @@ def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern_5_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14368,11 +15297,12 @@ def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern_5_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14384,11 +15314,12 @@ def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern_5_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14400,11 +15331,12 @@ def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern_5_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14416,11 +15348,12 @@ def test_list_unsigned_short_pattern_9_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern_4_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14432,11 +15365,12 @@ def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern_4_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14448,11 +15382,12 @@ def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern_4_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14464,11 +15399,12 @@ def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern_4_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14480,11 +15416,12 @@ def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern_4_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14496,11 +15433,12 @@ def test_list_unsigned_short_pattern_8_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern_3_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14512,11 +15450,12 @@ def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern_3_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14528,11 +15467,12 @@ def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern_3_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14544,11 +15484,12 @@ def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern_3_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14560,11 +15501,12 @@ def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern_3_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14576,11 +15518,12 @@ def test_list_unsigned_short_pattern_7_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern_2_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14592,11 +15535,12 @@ def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern_2_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14608,11 +15552,12 @@ def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern_2_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14624,11 +15569,12 @@ def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern_2_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14640,11 +15586,12 @@ def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern_2_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14656,11 +15603,12 @@ def test_list_unsigned_short_pattern_6_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern_1_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14672,11 +15620,12 @@ def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern_1_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14688,11 +15637,12 @@ def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern_1_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14704,11 +15654,12 @@ def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern_1_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14720,11 +15671,12 @@ def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern_1_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14736,11 +15688,12 @@ def test_list_unsigned_short_pattern_5_nistxml_sv_ii_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14751,11 +15704,12 @@ def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14766,11 +15720,12 @@ def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14781,11 +15736,12 @@ def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14796,11 +15752,12 @@ def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14811,11 +15768,12 @@ def test_list_unsigned_short_length_9_nistxml_sv_ii_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14826,11 +15784,12 @@ def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14841,11 +15800,12 @@ def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14856,11 +15816,12 @@ def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14871,11 +15832,12 @@ def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14886,11 +15848,12 @@ def test_list_unsigned_short_length_8_nistxml_sv_ii_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14901,11 +15864,12 @@ def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14916,11 +15880,12 @@ def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14931,11 +15896,12 @@ def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14946,11 +15912,12 @@ def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14961,11 +15928,12 @@ def test_list_unsigned_short_length_7_nistxml_sv_ii_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14976,11 +15944,12 @@ def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14991,11 +15960,12 @@ def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -15006,11 +15976,12 @@ def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -15021,11 +15992,12 @@ def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -15036,11 +16008,12 @@ def test_list_unsigned_short_length_6_nistxml_sv_ii_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -15051,11 +16024,12 @@ def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -15066,11 +16040,12 @@ def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -15081,11 +16056,12 @@ def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -15096,11 +16072,12 @@ def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -15111,11 +16088,12 @@ def test_list_unsigned_short_length_5_nistxml_sv_ii_list_unsigned_short_length_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_length_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15127,11 +16105,12 @@ def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_length_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15143,11 +16122,12 @@ def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_length_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15159,11 +16139,12 @@ def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_length_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15175,11 +16156,12 @@ def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_length_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15191,11 +16173,12 @@ def test_list_unsigned_short_min_length_9_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_length_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15206,11 +16189,12 @@ def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_length_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15221,11 +16205,12 @@ def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_length_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15236,11 +16221,12 @@ def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_length_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15251,11 +16237,12 @@ def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_length_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15266,11 +16253,12 @@ def test_list_unsigned_short_min_length_8_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_length_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15281,11 +16269,12 @@ def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_length_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15296,11 +16285,12 @@ def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_length_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15311,11 +16301,12 @@ def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_length_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15326,11 +16317,12 @@ def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_length_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15341,11 +16333,12 @@ def test_list_unsigned_short_min_length_7_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_length_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15356,11 +16349,12 @@ def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_length_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15371,11 +16365,12 @@ def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_length_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15386,11 +16381,12 @@ def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_length_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15401,11 +16397,12 @@ def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_length_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15416,11 +16413,12 @@ def test_list_unsigned_short_min_length_6_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_length_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15431,11 +16429,12 @@ def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_length_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15446,11 +16445,12 @@ def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_length_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15461,11 +16461,12 @@ def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_length_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15476,11 +16477,12 @@ def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_length_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15491,6 +16493,6 @@ def test_list_unsigned_short_min_length_5_nistxml_sv_ii_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_4000.py
+++ b/tests/test_nist_meta_4000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_length_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -12,11 +15,12 @@ def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_length_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -28,11 +32,12 @@ def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_length_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -44,11 +49,12 @@ def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_length_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -60,11 +66,12 @@ def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_length_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -76,11 +83,12 @@ def test_list_unsigned_short_max_length_9_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_length_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -91,11 +99,12 @@ def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_length_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -106,11 +115,12 @@ def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_length_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -121,11 +131,12 @@ def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_length_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -136,11 +147,12 @@ def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_length_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -151,11 +163,12 @@ def test_list_unsigned_short_max_length_8_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_length_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -166,11 +179,12 @@ def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_length_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -181,11 +195,12 @@ def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_length_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -196,11 +211,12 @@ def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_length_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -211,11 +227,12 @@ def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_length_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -226,11 +243,12 @@ def test_list_unsigned_short_max_length_7_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_length_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -241,11 +259,12 @@ def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_length_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -256,11 +275,12 @@ def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_length_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -271,11 +291,12 @@ def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_length_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -286,11 +307,12 @@ def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_length_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -301,11 +323,12 @@ def test_list_unsigned_short_max_length_6_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_length_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -316,11 +339,12 @@ def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_length_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -331,11 +355,12 @@ def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_length_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -346,11 +371,12 @@ def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_length_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -361,11 +387,12 @@ def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_length_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -376,11 +403,12 @@ def test_list_unsigned_short_max_length_5_nistxml_sv_ii_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-II-list-unsignedShort-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumeration_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -391,11 +419,12 @@ def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumeration_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -406,11 +435,12 @@ def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumeration_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -421,11 +451,12 @@ def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumeration_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -436,11 +467,12 @@ def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumeration_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -451,11 +483,12 @@ def test_list_unsigned_int_enumeration_9_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumeration_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -466,11 +499,12 @@ def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumeration_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -481,11 +515,12 @@ def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumeration_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -496,11 +531,12 @@ def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumeration_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -511,11 +547,12 @@ def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumeration_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -526,11 +563,12 @@ def test_list_unsigned_int_enumeration_8_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumeration_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -541,11 +579,12 @@ def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumeration_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -556,11 +595,12 @@ def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumeration_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -571,11 +611,12 @@ def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumeration_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -586,11 +627,12 @@ def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumeration_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -601,11 +643,12 @@ def test_list_unsigned_int_enumeration_7_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumeration_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -616,11 +659,12 @@ def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumeration_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -631,11 +675,12 @@ def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumeration_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -646,11 +691,12 @@ def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumeration_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -661,11 +707,12 @@ def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumeration_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -676,11 +723,12 @@ def test_list_unsigned_int_enumeration_6_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumeration_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -691,11 +739,12 @@ def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumeration_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -706,11 +755,12 @@ def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumeration_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -721,11 +771,12 @@ def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumeration_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -736,11 +787,12 @@ def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumeration_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -751,11 +803,12 @@ def test_list_unsigned_int_enumeration_5_nistxml_sv_ii_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -767,11 +820,12 @@ def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -783,11 +837,12 @@ def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -799,11 +854,12 @@ def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -815,11 +871,12 @@ def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -831,11 +888,12 @@ def test_list_unsigned_int_pattern_9_nistxml_sv_ii_list_unsigned_int_pattern_5_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -847,11 +905,12 @@ def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -863,11 +922,12 @@ def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -879,11 +939,12 @@ def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -895,11 +956,12 @@ def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -911,11 +973,12 @@ def test_list_unsigned_int_pattern_8_nistxml_sv_ii_list_unsigned_int_pattern_4_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -927,11 +990,12 @@ def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -943,11 +1007,12 @@ def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -959,11 +1024,12 @@ def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -975,11 +1041,12 @@ def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -991,11 +1058,12 @@ def test_list_unsigned_int_pattern_7_nistxml_sv_ii_list_unsigned_int_pattern_3_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1007,11 +1075,12 @@ def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1023,11 +1092,12 @@ def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1039,11 +1109,12 @@ def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1055,11 +1126,12 @@ def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1071,11 +1143,12 @@ def test_list_unsigned_int_pattern_6_nistxml_sv_ii_list_unsigned_int_pattern_2_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1087,11 +1160,12 @@ def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1103,11 +1177,12 @@ def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1119,11 +1194,12 @@ def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1135,11 +1211,12 @@ def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1151,11 +1228,12 @@ def test_list_unsigned_int_pattern_5_nistxml_sv_ii_list_unsigned_int_pattern_1_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1166,11 +1244,12 @@ def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1181,11 +1260,12 @@ def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1196,11 +1276,12 @@ def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1211,11 +1292,12 @@ def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1226,11 +1308,12 @@ def test_list_unsigned_int_length_9_nistxml_sv_ii_list_unsigned_int_length_5_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1241,11 +1324,12 @@ def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1256,11 +1340,12 @@ def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1271,11 +1356,12 @@ def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1286,11 +1372,12 @@ def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1301,11 +1388,12 @@ def test_list_unsigned_int_length_8_nistxml_sv_ii_list_unsigned_int_length_4_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1316,11 +1404,12 @@ def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1331,11 +1420,12 @@ def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1346,11 +1436,12 @@ def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1361,11 +1452,12 @@ def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1376,11 +1468,12 @@ def test_list_unsigned_int_length_7_nistxml_sv_ii_list_unsigned_int_length_3_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1391,11 +1484,12 @@ def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1406,11 +1500,12 @@ def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1421,11 +1516,12 @@ def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1436,11 +1532,12 @@ def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1451,11 +1548,12 @@ def test_list_unsigned_int_length_6_nistxml_sv_ii_list_unsigned_int_length_2_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1466,11 +1564,12 @@ def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1481,11 +1580,12 @@ def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1496,11 +1596,12 @@ def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1511,11 +1612,12 @@ def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1526,11 +1628,12 @@ def test_list_unsigned_int_length_5_nistxml_sv_ii_list_unsigned_int_length_1_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_length_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1541,11 +1644,12 @@ def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_length_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1556,11 +1660,12 @@ def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_length_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1571,11 +1676,12 @@ def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_length_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1586,11 +1692,12 @@ def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_length_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1601,11 +1708,12 @@ def test_list_unsigned_int_min_length_9_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_length_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1616,11 +1724,12 @@ def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_length_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1631,11 +1740,12 @@ def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_length_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1646,11 +1756,12 @@ def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_length_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1661,11 +1772,12 @@ def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_length_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1676,11 +1788,12 @@ def test_list_unsigned_int_min_length_8_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_length_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1691,11 +1804,12 @@ def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_length_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1706,11 +1820,12 @@ def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_length_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1721,11 +1836,12 @@ def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_length_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1736,11 +1852,12 @@ def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_length_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1751,11 +1868,12 @@ def test_list_unsigned_int_min_length_7_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_length_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1766,11 +1884,12 @@ def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_length_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1781,11 +1900,12 @@ def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_length_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1796,11 +1916,12 @@ def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_length_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1811,11 +1932,12 @@ def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_length_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1826,11 +1948,12 @@ def test_list_unsigned_int_min_length_6_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_length_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1841,11 +1964,12 @@ def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_length_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1856,11 +1980,12 @@ def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_length_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1871,11 +1996,12 @@ def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_length_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1886,11 +2012,12 @@ def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_length_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1901,11 +2028,12 @@ def test_list_unsigned_int_min_length_5_nistxml_sv_ii_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_length_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1916,11 +2044,12 @@ def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_length_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1931,11 +2060,12 @@ def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_length_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1946,11 +2076,12 @@ def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_length_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1961,11 +2092,12 @@ def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_length_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1976,11 +2108,12 @@ def test_list_unsigned_int_max_length_9_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_length_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -1991,11 +2124,12 @@ def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_length_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -2006,11 +2140,12 @@ def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_length_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -2021,11 +2156,12 @@ def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_length_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -2036,11 +2172,12 @@ def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_length_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -2051,11 +2188,12 @@ def test_list_unsigned_int_max_length_8_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_length_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2066,11 +2204,12 @@ def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_length_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2081,11 +2220,12 @@ def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_length_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2096,11 +2236,12 @@ def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_length_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2111,11 +2252,12 @@ def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_length_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2126,11 +2268,12 @@ def test_list_unsigned_int_max_length_7_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_length_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2141,11 +2284,12 @@ def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_length_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2156,11 +2300,12 @@ def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_length_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2171,11 +2316,12 @@ def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_length_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2186,11 +2332,12 @@ def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_length_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2201,11 +2348,12 @@ def test_list_unsigned_int_max_length_6_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_length_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2216,11 +2364,12 @@ def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_length_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2231,11 +2380,12 @@ def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_length_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2246,11 +2396,12 @@ def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_length_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2261,11 +2412,12 @@ def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_length_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2276,11 +2428,12 @@ def test_list_unsigned_int_max_length_5_nistxml_sv_ii_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-II-list-unsignedInt-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enumeration_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2291,11 +2444,12 @@ def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enumeration_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2306,11 +2460,12 @@ def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enumeration_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2321,11 +2476,12 @@ def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enumeration_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2336,11 +2492,12 @@ def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enumeration_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2351,11 +2508,12 @@ def test_list_unsigned_long_enumeration_9_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enumeration_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2366,11 +2524,12 @@ def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enumeration_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2381,11 +2540,12 @@ def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enumeration_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2396,11 +2556,12 @@ def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enumeration_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2411,11 +2572,12 @@ def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enumeration_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2426,11 +2588,12 @@ def test_list_unsigned_long_enumeration_8_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enumeration_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2441,11 +2604,12 @@ def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enumeration_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2456,11 +2620,12 @@ def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enumeration_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2471,11 +2636,12 @@ def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enumeration_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2486,11 +2652,12 @@ def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enumeration_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2501,11 +2668,12 @@ def test_list_unsigned_long_enumeration_7_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enumeration_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2516,11 +2684,12 @@ def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enumeration_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2531,11 +2700,12 @@ def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enumeration_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2546,11 +2716,12 @@ def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enumeration_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2561,11 +2732,12 @@ def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enumeration_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2576,11 +2748,12 @@ def test_list_unsigned_long_enumeration_6_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enumeration_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2591,11 +2764,12 @@ def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enumeration_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2606,11 +2780,12 @@ def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enumeration_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2621,11 +2796,12 @@ def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enumeration_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2636,11 +2812,12 @@ def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enumeration_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2651,11 +2828,12 @@ def test_list_unsigned_long_enumeration_5_nistxml_sv_ii_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2667,11 +2845,12 @@ def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2683,11 +2862,12 @@ def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2699,11 +2879,12 @@ def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2715,11 +2896,12 @@ def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2731,11 +2913,12 @@ def test_list_unsigned_long_pattern_9_nistxml_sv_ii_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2747,11 +2930,12 @@ def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2763,11 +2947,12 @@ def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2779,11 +2964,12 @@ def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2795,11 +2981,12 @@ def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2811,11 +2998,12 @@ def test_list_unsigned_long_pattern_8_nistxml_sv_ii_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2827,11 +3015,12 @@ def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2843,11 +3032,12 @@ def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2859,11 +3049,12 @@ def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2875,11 +3066,12 @@ def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2891,11 +3083,12 @@ def test_list_unsigned_long_pattern_7_nistxml_sv_ii_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2907,11 +3100,12 @@ def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2923,11 +3117,12 @@ def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2939,11 +3134,12 @@ def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2955,11 +3151,12 @@ def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2971,11 +3168,12 @@ def test_list_unsigned_long_pattern_6_nistxml_sv_ii_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2987,11 +3185,12 @@ def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3003,11 +3202,12 @@ def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3019,11 +3219,12 @@ def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3035,11 +3236,12 @@ def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3051,11 +3253,12 @@ def test_list_unsigned_long_pattern_5_nistxml_sv_ii_list_unsigned_long_pattern_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3066,11 +3269,12 @@ def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3081,11 +3285,12 @@ def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3096,11 +3301,12 @@ def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3111,11 +3317,12 @@ def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3126,11 +3333,12 @@ def test_list_unsigned_long_length_9_nistxml_sv_ii_list_unsigned_long_length_5_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3141,11 +3349,12 @@ def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3156,11 +3365,12 @@ def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3171,11 +3381,12 @@ def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3186,11 +3397,12 @@ def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3201,11 +3413,12 @@ def test_list_unsigned_long_length_8_nistxml_sv_ii_list_unsigned_long_length_4_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3216,11 +3429,12 @@ def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3231,11 +3445,12 @@ def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3246,11 +3461,12 @@ def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3261,11 +3477,12 @@ def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3276,11 +3493,12 @@ def test_list_unsigned_long_length_7_nistxml_sv_ii_list_unsigned_long_length_3_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3291,11 +3509,12 @@ def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3306,11 +3525,12 @@ def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3321,11 +3541,12 @@ def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3336,11 +3557,12 @@ def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3351,11 +3573,12 @@ def test_list_unsigned_long_length_6_nistxml_sv_ii_list_unsigned_long_length_2_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3366,11 +3589,12 @@ def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3381,11 +3605,12 @@ def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3396,11 +3621,12 @@ def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3411,11 +3637,12 @@ def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3426,11 +3653,12 @@ def test_list_unsigned_long_length_5_nistxml_sv_ii_list_unsigned_long_length_1_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_length_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3441,11 +3669,12 @@ def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_length_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3456,11 +3685,12 @@ def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_length_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3471,11 +3701,12 @@ def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_length_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3486,11 +3717,12 @@ def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_length_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3501,11 +3733,12 @@ def test_list_unsigned_long_min_length_9_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_length_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3516,11 +3749,12 @@ def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_length_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3531,11 +3765,12 @@ def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_length_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3546,11 +3781,12 @@ def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_length_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3561,11 +3797,12 @@ def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_length_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3576,11 +3813,12 @@ def test_list_unsigned_long_min_length_8_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_length_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3591,11 +3829,12 @@ def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_length_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3606,11 +3845,12 @@ def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_length_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3621,11 +3861,12 @@ def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_length_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3636,11 +3877,12 @@ def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_length_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3651,11 +3893,12 @@ def test_list_unsigned_long_min_length_7_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_length_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3666,11 +3909,12 @@ def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_length_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3681,11 +3925,12 @@ def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_length_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3696,11 +3941,12 @@ def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_length_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3711,11 +3957,12 @@ def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_length_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3726,11 +3973,12 @@ def test_list_unsigned_long_min_length_6_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_length_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3741,11 +3989,12 @@ def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_length_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3756,11 +4005,12 @@ def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_length_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3771,11 +4021,12 @@ def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_length_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3786,11 +4037,12 @@ def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_length_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3801,11 +4053,12 @@ def test_list_unsigned_long_min_length_5_nistxml_sv_ii_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_length_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3816,11 +4069,12 @@ def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_length_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3831,11 +4085,12 @@ def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_length_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3846,11 +4101,12 @@ def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_length_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3861,11 +4117,12 @@ def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_length_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3876,11 +4133,12 @@ def test_list_unsigned_long_max_length_9_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_length_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3891,11 +4149,12 @@ def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_length_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3906,11 +4165,12 @@ def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_length_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3921,11 +4181,12 @@ def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_length_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3936,11 +4197,12 @@ def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_length_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3951,11 +4213,12 @@ def test_list_unsigned_long_max_length_8_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_length_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -3966,11 +4229,12 @@ def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_length_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -3981,11 +4245,12 @@ def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_length_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -3996,11 +4261,12 @@ def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_length_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -4011,11 +4277,12 @@ def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_length_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -4026,11 +4293,12 @@ def test_list_unsigned_long_max_length_7_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_length_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4041,11 +4309,12 @@ def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_length_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4056,11 +4325,12 @@ def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_length_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4071,11 +4341,12 @@ def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_length_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4086,11 +4357,12 @@ def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_length_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4101,11 +4373,12 @@ def test_list_unsigned_long_max_length_6_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_length_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4116,11 +4389,12 @@ def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_length_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4131,11 +4405,12 @@ def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_length_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4146,11 +4421,12 @@ def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_length_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4161,11 +4437,12 @@ def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_length_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4176,11 +4453,12 @@ def test_list_unsigned_long_max_length_5_nistxml_sv_ii_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-II-list-unsignedLong-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative_integer_enumeration_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4191,11 +4469,12 @@ def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative_integer_enumeration_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4206,11 +4485,12 @@ def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative_integer_enumeration_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4221,11 +4501,12 @@ def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative_integer_enumeration_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4236,11 +4517,12 @@ def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative_integer_enumeration_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4251,11 +4533,12 @@ def test_list_non_negative_integer_enumeration_9_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative_integer_enumeration_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4266,11 +4549,12 @@ def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative_integer_enumeration_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4281,11 +4565,12 @@ def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative_integer_enumeration_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4296,11 +4581,12 @@ def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative_integer_enumeration_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4311,11 +4597,12 @@ def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative_integer_enumeration_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4326,11 +4613,12 @@ def test_list_non_negative_integer_enumeration_8_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative_integer_enumeration_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4341,11 +4629,12 @@ def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative_integer_enumeration_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4356,11 +4645,12 @@ def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative_integer_enumeration_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4371,11 +4661,12 @@ def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative_integer_enumeration_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4386,11 +4677,12 @@ def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative_integer_enumeration_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4401,11 +4693,12 @@ def test_list_non_negative_integer_enumeration_7_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative_integer_enumeration_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4416,11 +4709,12 @@ def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative_integer_enumeration_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4431,11 +4725,12 @@ def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative_integer_enumeration_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4446,11 +4741,12 @@ def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative_integer_enumeration_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4461,11 +4757,12 @@ def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative_integer_enumeration_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4476,11 +4773,12 @@ def test_list_non_negative_integer_enumeration_6_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative_integer_enumeration_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4491,11 +4789,12 @@ def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative_integer_enumeration_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4506,11 +4805,12 @@ def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative_integer_enumeration_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4521,11 +4821,12 @@ def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative_integer_enumeration_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4536,11 +4837,12 @@ def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative_integer_enumeration_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4551,11 +4853,12 @@ def test_list_non_negative_integer_enumeration_5_nistxml_sv_ii_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_integer_pattern_5_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4567,11 +4870,12 @@ def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_integer_pattern_5_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4583,11 +4887,12 @@ def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_integer_pattern_5_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4599,11 +4904,12 @@ def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_integer_pattern_5_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4615,11 +4921,12 @@ def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_integer_pattern_5_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4631,11 +4938,12 @@ def test_list_non_negative_integer_pattern_9_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_integer_pattern_4_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4647,11 +4955,12 @@ def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_integer_pattern_4_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4663,11 +4972,12 @@ def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_integer_pattern_4_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4679,11 +4989,12 @@ def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_integer_pattern_4_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4695,11 +5006,12 @@ def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_integer_pattern_4_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4711,11 +5023,12 @@ def test_list_non_negative_integer_pattern_8_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_integer_pattern_3_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4727,11 +5040,12 @@ def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_integer_pattern_3_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4743,11 +5057,12 @@ def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_integer_pattern_3_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4759,11 +5074,12 @@ def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_integer_pattern_3_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4775,11 +5091,12 @@ def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_integer_pattern_3_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4791,11 +5108,12 @@ def test_list_non_negative_integer_pattern_7_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_integer_pattern_2_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4807,11 +5125,12 @@ def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_integer_pattern_2_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4823,11 +5142,12 @@ def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_integer_pattern_2_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4839,11 +5159,12 @@ def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_integer_pattern_2_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4855,11 +5176,12 @@ def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_integer_pattern_2_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4871,11 +5193,12 @@ def test_list_non_negative_integer_pattern_6_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_integer_pattern_1_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4887,11 +5210,12 @@ def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_integer_pattern_1_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4903,11 +5227,12 @@ def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_integer_pattern_1_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4919,11 +5244,12 @@ def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_integer_pattern_1_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4935,11 +5261,12 @@ def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_integer_pattern_1_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4951,11 +5278,12 @@ def test_list_non_negative_integer_pattern_5_nistxml_sv_ii_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_integer_length_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -4967,11 +5295,12 @@ def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_integer_length_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -4983,11 +5312,12 @@ def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_integer_length_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -4999,11 +5329,12 @@ def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_integer_length_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5015,11 +5346,12 @@ def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_integer_length_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5031,11 +5363,12 @@ def test_list_non_negative_integer_length_9_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_integer_length_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5047,11 +5380,12 @@ def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_integer_length_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5063,11 +5397,12 @@ def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_integer_length_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5079,11 +5414,12 @@ def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_integer_length_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5095,11 +5431,12 @@ def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_integer_length_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5111,11 +5448,12 @@ def test_list_non_negative_integer_length_8_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_integer_length_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5127,11 +5465,12 @@ def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_integer_length_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5143,11 +5482,12 @@ def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_integer_length_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5159,11 +5499,12 @@ def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_integer_length_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5175,11 +5516,12 @@ def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_integer_length_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5191,11 +5533,12 @@ def test_list_non_negative_integer_length_7_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_integer_length_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5207,11 +5550,12 @@ def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_integer_length_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5223,11 +5567,12 @@ def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_integer_length_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5239,11 +5584,12 @@ def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_integer_length_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5255,11 +5601,12 @@ def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_integer_length_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5271,11 +5618,12 @@ def test_list_non_negative_integer_length_6_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_integer_length_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5287,11 +5635,12 @@ def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_integer_length_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5303,11 +5652,12 @@ def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_integer_length_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5319,11 +5669,12 @@ def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_integer_length_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5335,11 +5686,12 @@ def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_integer_length_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5351,11 +5703,12 @@ def test_list_non_negative_integer_length_5_nistxml_sv_ii_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_integer_min_length_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5367,11 +5720,12 @@ def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_integer_min_length_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5383,11 +5737,12 @@ def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_integer_min_length_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5399,11 +5754,12 @@ def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_integer_min_length_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5415,11 +5771,12 @@ def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_integer_min_length_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5431,11 +5788,12 @@ def test_list_non_negative_integer_min_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_integer_min_length_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5447,11 +5805,12 @@ def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_integer_min_length_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5463,11 +5822,12 @@ def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_integer_min_length_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5479,11 +5839,12 @@ def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_integer_min_length_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5495,11 +5856,12 @@ def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_integer_min_length_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5511,11 +5873,12 @@ def test_list_non_negative_integer_min_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_integer_min_length_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5527,11 +5890,12 @@ def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_integer_min_length_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5543,11 +5907,12 @@ def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_integer_min_length_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5559,11 +5924,12 @@ def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_integer_min_length_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5575,11 +5941,12 @@ def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_integer_min_length_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5591,11 +5958,12 @@ def test_list_non_negative_integer_min_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_integer_min_length_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5607,11 +5975,12 @@ def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_integer_min_length_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5623,11 +5992,12 @@ def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_integer_min_length_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5639,11 +6009,12 @@ def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_integer_min_length_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5655,11 +6026,12 @@ def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_integer_min_length_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5671,11 +6043,12 @@ def test_list_non_negative_integer_min_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_integer_min_length_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5687,11 +6060,12 @@ def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_integer_min_length_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5703,11 +6077,12 @@ def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_integer_min_length_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5719,11 +6094,12 @@ def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_integer_min_length_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5735,11 +6111,12 @@ def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_integer_min_length_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5751,11 +6128,12 @@ def test_list_non_negative_integer_min_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_integer_max_length_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5767,11 +6145,12 @@ def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_integer_max_length_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5783,11 +6162,12 @@ def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_integer_max_length_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5799,11 +6179,12 @@ def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_integer_max_length_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5815,11 +6196,12 @@ def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_integer_max_length_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5831,11 +6213,12 @@ def test_list_non_negative_integer_max_length_9_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_integer_max_length_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5847,11 +6230,12 @@ def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_integer_max_length_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5863,11 +6247,12 @@ def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_integer_max_length_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5879,11 +6264,12 @@ def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_integer_max_length_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5895,11 +6281,12 @@ def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_integer_max_length_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5911,11 +6298,12 @@ def test_list_non_negative_integer_max_length_8_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_integer_max_length_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5927,11 +6315,12 @@ def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_integer_max_length_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5943,11 +6332,12 @@ def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_integer_max_length_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5959,11 +6349,12 @@ def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_integer_max_length_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5975,11 +6366,12 @@ def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_integer_max_length_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5991,11 +6383,12 @@ def test_list_non_negative_integer_max_length_7_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_integer_max_length_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6007,11 +6400,12 @@ def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_integer_max_length_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6023,11 +6417,12 @@ def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_integer_max_length_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6039,11 +6434,12 @@ def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_integer_max_length_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6055,11 +6451,12 @@ def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_integer_max_length_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6071,11 +6468,12 @@ def test_list_non_negative_integer_max_length_6_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_integer_max_length_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6087,11 +6485,12 @@ def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_integer_max_length_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6103,11 +6502,12 @@ def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_integer_max_length_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6119,11 +6519,12 @@ def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_integer_max_length_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6135,11 +6536,12 @@ def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_integer_max_length_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6151,11 +6553,12 @@ def test_list_non_negative_integer_max_length_5_nistxml_sv_ii_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-II-list-nonNegativeInteger-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6166,11 +6569,12 @@ def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6181,11 +6585,12 @@ def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6196,11 +6601,12 @@ def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6211,11 +6617,12 @@ def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6226,11 +6633,12 @@ def test_list_byte_enumeration_9_nistxml_sv_ii_list_byte_enumeration_5_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6241,11 +6649,12 @@ def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6256,11 +6665,12 @@ def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6271,11 +6681,12 @@ def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6286,11 +6697,12 @@ def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6301,11 +6713,12 @@ def test_list_byte_enumeration_8_nistxml_sv_ii_list_byte_enumeration_4_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6316,11 +6729,12 @@ def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6331,11 +6745,12 @@ def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6346,11 +6761,12 @@ def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6361,11 +6777,12 @@ def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6376,11 +6793,12 @@ def test_list_byte_enumeration_7_nistxml_sv_ii_list_byte_enumeration_3_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6391,11 +6809,12 @@ def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6406,11 +6825,12 @@ def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6421,11 +6841,12 @@ def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6436,11 +6857,12 @@ def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6451,11 +6873,12 @@ def test_list_byte_enumeration_6_nistxml_sv_ii_list_byte_enumeration_2_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6466,11 +6889,12 @@ def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6481,11 +6905,12 @@ def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6496,11 +6921,12 @@ def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6511,11 +6937,12 @@ def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6526,11 +6953,12 @@ def test_list_byte_enumeration_5_nistxml_sv_ii_list_byte_enumeration_1_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6542,11 +6970,12 @@ def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6558,11 +6987,12 @@ def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6574,11 +7004,12 @@ def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6590,11 +7021,12 @@ def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6606,11 +7038,12 @@ def test_list_byte_pattern_9_nistxml_sv_ii_list_byte_pattern_5_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6622,11 +7055,12 @@ def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6638,11 +7072,12 @@ def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6654,11 +7089,12 @@ def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6670,11 +7106,12 @@ def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6686,11 +7123,12 @@ def test_list_byte_pattern_8_nistxml_sv_ii_list_byte_pattern_4_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6702,11 +7140,12 @@ def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6718,11 +7157,12 @@ def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6734,11 +7174,12 @@ def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6750,11 +7191,12 @@ def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6766,11 +7208,12 @@ def test_list_byte_pattern_7_nistxml_sv_ii_list_byte_pattern_3_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6782,11 +7225,12 @@ def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6798,11 +7242,12 @@ def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6814,11 +7259,12 @@ def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6830,11 +7276,12 @@ def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6846,11 +7293,12 @@ def test_list_byte_pattern_6_nistxml_sv_ii_list_byte_pattern_2_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6862,11 +7310,12 @@ def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6878,11 +7327,12 @@ def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6894,11 +7344,12 @@ def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6910,11 +7361,12 @@ def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6926,11 +7378,12 @@ def test_list_byte_pattern_5_nistxml_sv_ii_list_byte_pattern_1_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -6941,11 +7394,12 @@ def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -6956,11 +7410,12 @@ def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -6971,11 +7426,12 @@ def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -6986,11 +7442,12 @@ def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -7001,11 +7458,12 @@ def test_list_byte_length_9_nistxml_sv_ii_list_byte_length_5_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7016,11 +7474,12 @@ def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7031,11 +7490,12 @@ def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7046,11 +7506,12 @@ def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7061,11 +7522,12 @@ def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7076,11 +7538,12 @@ def test_list_byte_length_8_nistxml_sv_ii_list_byte_length_4_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7091,11 +7554,12 @@ def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7106,11 +7570,12 @@ def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7121,11 +7586,12 @@ def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7136,11 +7602,12 @@ def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7151,11 +7618,12 @@ def test_list_byte_length_7_nistxml_sv_ii_list_byte_length_3_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7166,11 +7634,12 @@ def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7181,11 +7650,12 @@ def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7196,11 +7666,12 @@ def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7211,11 +7682,12 @@ def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7226,11 +7698,12 @@ def test_list_byte_length_6_nistxml_sv_ii_list_byte_length_2_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7241,11 +7714,12 @@ def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7256,11 +7730,12 @@ def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7271,11 +7746,12 @@ def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7286,11 +7762,12 @@ def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7301,11 +7778,12 @@ def test_list_byte_length_5_nistxml_sv_ii_list_byte_length_1_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7316,11 +7794,12 @@ def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7331,11 +7810,12 @@ def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7346,11 +7826,12 @@ def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7361,11 +7842,12 @@ def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7376,11 +7858,12 @@ def test_list_byte_min_length_9_nistxml_sv_ii_list_byte_min_length_5_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7391,11 +7874,12 @@ def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7406,11 +7890,12 @@ def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7421,11 +7906,12 @@ def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7436,11 +7922,12 @@ def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7451,11 +7938,12 @@ def test_list_byte_min_length_8_nistxml_sv_ii_list_byte_min_length_4_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7466,11 +7954,12 @@ def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7481,11 +7970,12 @@ def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7496,11 +7986,12 @@ def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7511,11 +8002,12 @@ def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7526,11 +8018,12 @@ def test_list_byte_min_length_7_nistxml_sv_ii_list_byte_min_length_3_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7541,11 +8034,12 @@ def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7556,11 +8050,12 @@ def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7571,11 +8066,12 @@ def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7586,11 +8082,12 @@ def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7601,11 +8098,12 @@ def test_list_byte_min_length_6_nistxml_sv_ii_list_byte_min_length_2_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7616,11 +8114,12 @@ def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7631,11 +8130,12 @@ def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7646,11 +8146,12 @@ def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7661,11 +8162,12 @@ def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7676,11 +8178,12 @@ def test_list_byte_min_length_5_nistxml_sv_ii_list_byte_min_length_1_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7691,11 +8194,12 @@ def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7706,11 +8210,12 @@ def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7721,11 +8226,12 @@ def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7736,11 +8242,12 @@ def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7751,11 +8258,12 @@ def test_list_byte_max_length_9_nistxml_sv_ii_list_byte_max_length_5_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7766,11 +8274,12 @@ def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7781,11 +8290,12 @@ def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7796,11 +8306,12 @@ def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7811,11 +8322,12 @@ def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7826,11 +8338,12 @@ def test_list_byte_max_length_8_nistxml_sv_ii_list_byte_max_length_4_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -7841,11 +8354,12 @@ def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -7856,11 +8370,12 @@ def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -7871,11 +8386,12 @@ def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -7886,11 +8402,12 @@ def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -7901,11 +8418,12 @@ def test_list_byte_max_length_7_nistxml_sv_ii_list_byte_max_length_3_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -7916,11 +8434,12 @@ def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -7931,11 +8450,12 @@ def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -7946,11 +8466,12 @@ def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -7961,11 +8482,12 @@ def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -7976,11 +8498,12 @@ def test_list_byte_max_length_6_nistxml_sv_ii_list_byte_max_length_2_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -7991,11 +8514,12 @@ def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8006,11 +8530,12 @@ def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8021,11 +8546,12 @@ def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8036,11 +8562,12 @@ def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8051,11 +8578,12 @@ def test_list_byte_max_length_5_nistxml_sv_ii_list_byte_max_length_1_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-II-list-byte-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8066,11 +8594,12 @@ def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8081,11 +8610,12 @@ def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8096,11 +8626,12 @@ def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8111,11 +8642,12 @@ def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8126,11 +8658,12 @@ def test_list_short_enumeration_9_nistxml_sv_ii_list_short_enumeration_5_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8141,11 +8674,12 @@ def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8156,11 +8690,12 @@ def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8171,11 +8706,12 @@ def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8186,11 +8722,12 @@ def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8201,11 +8738,12 @@ def test_list_short_enumeration_8_nistxml_sv_ii_list_short_enumeration_4_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8216,11 +8754,12 @@ def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8231,11 +8770,12 @@ def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8246,11 +8786,12 @@ def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8261,11 +8802,12 @@ def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8276,11 +8818,12 @@ def test_list_short_enumeration_7_nistxml_sv_ii_list_short_enumeration_3_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8291,11 +8834,12 @@ def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8306,11 +8850,12 @@ def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8321,11 +8866,12 @@ def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8336,11 +8882,12 @@ def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8351,11 +8898,12 @@ def test_list_short_enumeration_6_nistxml_sv_ii_list_short_enumeration_2_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8366,11 +8914,12 @@ def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8381,11 +8930,12 @@ def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8396,11 +8946,12 @@ def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8411,11 +8962,12 @@ def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8426,11 +8978,12 @@ def test_list_short_enumeration_5_nistxml_sv_ii_list_short_enumeration_1_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8442,11 +8995,12 @@ def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8458,11 +9012,12 @@ def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8474,11 +9029,12 @@ def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8490,11 +9046,12 @@ def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8506,11 +9063,12 @@ def test_list_short_pattern_9_nistxml_sv_ii_list_short_pattern_5_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8522,11 +9080,12 @@ def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8538,11 +9097,12 @@ def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8554,11 +9114,12 @@ def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8570,11 +9131,12 @@ def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8586,11 +9148,12 @@ def test_list_short_pattern_8_nistxml_sv_ii_list_short_pattern_4_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8602,11 +9165,12 @@ def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8618,11 +9182,12 @@ def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8634,11 +9199,12 @@ def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8650,11 +9216,12 @@ def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8666,11 +9233,12 @@ def test_list_short_pattern_7_nistxml_sv_ii_list_short_pattern_3_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8682,11 +9250,12 @@ def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8698,11 +9267,12 @@ def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8714,11 +9284,12 @@ def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8730,11 +9301,12 @@ def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8746,11 +9318,12 @@ def test_list_short_pattern_6_nistxml_sv_ii_list_short_pattern_2_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8762,11 +9335,12 @@ def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8778,11 +9352,12 @@ def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8794,11 +9369,12 @@ def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8810,11 +9386,12 @@ def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8826,11 +9403,12 @@ def test_list_short_pattern_5_nistxml_sv_ii_list_short_pattern_1_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_1(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -8841,11 +9419,12 @@ def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_2(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -8856,11 +9435,12 @@ def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_3(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -8871,11 +9451,12 @@ def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_4(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -8886,11 +9467,12 @@ def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_5(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -8901,11 +9483,12 @@ def test_list_short_length_9_nistxml_sv_ii_list_short_length_5_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_1(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -8916,11 +9499,12 @@ def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_2(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -8931,11 +9515,12 @@ def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_3(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -8946,11 +9531,12 @@ def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_4(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -8961,11 +9547,12 @@ def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_5(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -8976,11 +9563,12 @@ def test_list_short_length_8_nistxml_sv_ii_list_short_length_4_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_1(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -8991,11 +9579,12 @@ def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_2(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9006,11 +9595,12 @@ def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_3(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9021,11 +9611,12 @@ def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_4(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9036,11 +9627,12 @@ def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_5(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9051,11 +9643,12 @@ def test_list_short_length_7_nistxml_sv_ii_list_short_length_3_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_1(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9066,11 +9659,12 @@ def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_2(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9081,11 +9675,12 @@ def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_3(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9096,11 +9691,12 @@ def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_4(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9111,11 +9707,12 @@ def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_5(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9126,11 +9723,12 @@ def test_list_short_length_6_nistxml_sv_ii_list_short_length_2_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_1(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9141,11 +9739,12 @@ def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_2(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9156,11 +9755,12 @@ def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_3(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9171,11 +9771,12 @@ def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_4(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9186,11 +9787,12 @@ def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_5(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9201,11 +9803,12 @@ def test_list_short_length_5_nistxml_sv_ii_list_short_length_1_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9216,11 +9819,12 @@ def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9231,11 +9835,12 @@ def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9246,11 +9851,12 @@ def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9261,11 +9867,12 @@ def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9276,11 +9883,12 @@ def test_list_short_min_length_9_nistxml_sv_ii_list_short_min_length_5_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9291,11 +9899,12 @@ def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9306,11 +9915,12 @@ def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9321,11 +9931,12 @@ def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9336,11 +9947,12 @@ def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9351,11 +9963,12 @@ def test_list_short_min_length_8_nistxml_sv_ii_list_short_min_length_4_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9366,11 +9979,12 @@ def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9381,11 +9995,12 @@ def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9396,11 +10011,12 @@ def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9411,11 +10027,12 @@ def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9426,11 +10043,12 @@ def test_list_short_min_length_7_nistxml_sv_ii_list_short_min_length_3_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9441,11 +10059,12 @@ def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9456,11 +10075,12 @@ def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9471,11 +10091,12 @@ def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9486,11 +10107,12 @@ def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9501,11 +10123,12 @@ def test_list_short_min_length_6_nistxml_sv_ii_list_short_min_length_2_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9516,11 +10139,12 @@ def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9531,11 +10155,12 @@ def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9546,11 +10171,12 @@ def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9561,11 +10187,12 @@ def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9576,11 +10203,12 @@ def test_list_short_min_length_5_nistxml_sv_ii_list_short_min_length_1_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9591,11 +10219,12 @@ def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9606,11 +10235,12 @@ def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9621,11 +10251,12 @@ def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9636,11 +10267,12 @@ def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9651,11 +10283,12 @@ def test_list_short_max_length_9_nistxml_sv_ii_list_short_max_length_5_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9666,11 +10299,12 @@ def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9681,11 +10315,12 @@ def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9696,11 +10331,12 @@ def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9711,11 +10347,12 @@ def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9726,11 +10363,12 @@ def test_list_short_max_length_8_nistxml_sv_ii_list_short_max_length_4_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9741,11 +10379,12 @@ def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9756,11 +10395,12 @@ def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9771,11 +10411,12 @@ def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9786,11 +10427,12 @@ def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9801,11 +10443,12 @@ def test_list_short_max_length_7_nistxml_sv_ii_list_short_max_length_3_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -9816,11 +10459,12 @@ def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -9831,11 +10475,12 @@ def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -9846,11 +10491,12 @@ def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -9861,11 +10507,12 @@ def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -9876,11 +10523,12 @@ def test_list_short_max_length_6_nistxml_sv_ii_list_short_max_length_2_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -9891,11 +10539,12 @@ def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -9906,11 +10555,12 @@ def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -9921,11 +10571,12 @@ def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -9936,11 +10587,12 @@ def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -9951,11 +10603,12 @@ def test_list_short_max_length_5_nistxml_sv_ii_list_short_max_length_1_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-II-list-short-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -9966,11 +10619,12 @@ def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -9981,11 +10635,12 @@ def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -9996,11 +10651,12 @@ def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10011,11 +10667,12 @@ def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10026,11 +10683,12 @@ def test_list_int_enumeration_9_nistxml_sv_ii_list_int_enumeration_5_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10041,11 +10699,12 @@ def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10056,11 +10715,12 @@ def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10071,11 +10731,12 @@ def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10086,11 +10747,12 @@ def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10101,11 +10763,12 @@ def test_list_int_enumeration_8_nistxml_sv_ii_list_int_enumeration_4_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10116,11 +10779,12 @@ def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10131,11 +10795,12 @@ def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10146,11 +10811,12 @@ def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10161,11 +10827,12 @@ def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10176,11 +10843,12 @@ def test_list_int_enumeration_7_nistxml_sv_ii_list_int_enumeration_3_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10191,11 +10859,12 @@ def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10206,11 +10875,12 @@ def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10221,11 +10891,12 @@ def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10236,11 +10907,12 @@ def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10251,11 +10923,12 @@ def test_list_int_enumeration_6_nistxml_sv_ii_list_int_enumeration_2_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10266,11 +10939,12 @@ def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10281,11 +10955,12 @@ def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10296,11 +10971,12 @@ def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10311,11 +10987,12 @@ def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10326,11 +11003,12 @@ def test_list_int_enumeration_5_nistxml_sv_ii_list_int_enumeration_1_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10342,11 +11020,12 @@ def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10358,11 +11037,12 @@ def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10374,11 +11054,12 @@ def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10390,11 +11071,12 @@ def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10406,11 +11088,12 @@ def test_list_int_pattern_9_nistxml_sv_ii_list_int_pattern_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10422,11 +11105,12 @@ def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10438,11 +11122,12 @@ def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10454,11 +11139,12 @@ def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10470,11 +11156,12 @@ def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10486,11 +11173,12 @@ def test_list_int_pattern_8_nistxml_sv_ii_list_int_pattern_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10502,11 +11190,12 @@ def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10518,11 +11207,12 @@ def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10534,11 +11224,12 @@ def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10550,11 +11241,12 @@ def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10566,11 +11258,12 @@ def test_list_int_pattern_7_nistxml_sv_ii_list_int_pattern_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10582,11 +11275,12 @@ def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10598,11 +11292,12 @@ def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10614,11 +11309,12 @@ def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10630,11 +11326,12 @@ def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10646,11 +11343,12 @@ def test_list_int_pattern_6_nistxml_sv_ii_list_int_pattern_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10662,11 +11360,12 @@ def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10678,11 +11377,12 @@ def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10694,11 +11394,12 @@ def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10710,11 +11411,12 @@ def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10726,11 +11428,12 @@ def test_list_int_pattern_5_nistxml_sv_ii_list_int_pattern_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_1(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -10741,11 +11444,12 @@ def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_2(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -10756,11 +11460,12 @@ def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_3(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -10771,11 +11476,12 @@ def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_4(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -10786,11 +11492,12 @@ def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_5(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -10801,11 +11508,12 @@ def test_list_int_length_9_nistxml_sv_ii_list_int_length_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_1(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -10816,11 +11524,12 @@ def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_2(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -10831,11 +11540,12 @@ def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_3(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -10846,11 +11556,12 @@ def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_4(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -10861,11 +11572,12 @@ def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_5(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -10876,11 +11588,12 @@ def test_list_int_length_8_nistxml_sv_ii_list_int_length_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_1(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -10891,11 +11604,12 @@ def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_2(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -10906,11 +11620,12 @@ def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_3(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -10921,11 +11636,12 @@ def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_4(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -10936,11 +11652,12 @@ def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_5(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -10951,11 +11668,12 @@ def test_list_int_length_7_nistxml_sv_ii_list_int_length_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_1(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -10966,11 +11684,12 @@ def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_2(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -10981,11 +11700,12 @@ def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_3(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -10996,11 +11716,12 @@ def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_4(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11011,11 +11732,12 @@ def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_5(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11026,11 +11748,12 @@ def test_list_int_length_6_nistxml_sv_ii_list_int_length_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_1(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11041,11 +11764,12 @@ def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_2(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11056,11 +11780,12 @@ def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_3(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11071,11 +11796,12 @@ def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_4(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11086,11 +11812,12 @@ def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_5(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11101,11 +11828,12 @@ def test_list_int_length_5_nistxml_sv_ii_list_int_length_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11116,11 +11844,12 @@ def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11131,11 +11860,12 @@ def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11146,11 +11876,12 @@ def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11161,11 +11892,12 @@ def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11176,11 +11908,12 @@ def test_list_int_min_length_9_nistxml_sv_ii_list_int_min_length_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11191,11 +11924,12 @@ def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11206,11 +11940,12 @@ def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11221,11 +11956,12 @@ def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11236,11 +11972,12 @@ def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11251,11 +11988,12 @@ def test_list_int_min_length_8_nistxml_sv_ii_list_int_min_length_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11266,11 +12004,12 @@ def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11281,11 +12020,12 @@ def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11296,11 +12036,12 @@ def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11311,11 +12052,12 @@ def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11326,11 +12068,12 @@ def test_list_int_min_length_7_nistxml_sv_ii_list_int_min_length_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11341,11 +12084,12 @@ def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11356,11 +12100,12 @@ def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11371,11 +12116,12 @@ def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11386,11 +12132,12 @@ def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11401,11 +12148,12 @@ def test_list_int_min_length_6_nistxml_sv_ii_list_int_min_length_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11416,11 +12164,12 @@ def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11431,11 +12180,12 @@ def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11446,11 +12196,12 @@ def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11461,11 +12212,12 @@ def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11476,11 +12228,12 @@ def test_list_int_min_length_5_nistxml_sv_ii_list_int_min_length_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11491,11 +12244,12 @@ def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11506,11 +12260,12 @@ def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11521,11 +12276,12 @@ def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11536,11 +12292,12 @@ def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11551,11 +12308,12 @@ def test_list_int_max_length_9_nistxml_sv_ii_list_int_max_length_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11566,11 +12324,12 @@ def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11581,11 +12340,12 @@ def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11596,11 +12356,12 @@ def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11611,11 +12372,12 @@ def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11626,11 +12388,12 @@ def test_list_int_max_length_8_nistxml_sv_ii_list_int_max_length_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11641,11 +12404,12 @@ def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11656,11 +12420,12 @@ def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11671,11 +12436,12 @@ def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11686,11 +12452,12 @@ def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11701,11 +12468,12 @@ def test_list_int_max_length_7_nistxml_sv_ii_list_int_max_length_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -11716,11 +12484,12 @@ def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -11731,11 +12500,12 @@ def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -11746,11 +12516,12 @@ def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -11761,11 +12532,12 @@ def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -11776,11 +12548,12 @@ def test_list_int_max_length_6_nistxml_sv_ii_list_int_max_length_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -11791,11 +12564,12 @@ def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -11806,11 +12580,12 @@ def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -11821,11 +12596,12 @@ def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -11836,11 +12612,12 @@ def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -11851,11 +12628,12 @@ def test_list_int_max_length_5_nistxml_sv_ii_list_int_max_length_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-II-list-int-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11866,11 +12644,12 @@ def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11881,11 +12660,12 @@ def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11896,11 +12676,12 @@ def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11911,11 +12692,12 @@ def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11926,11 +12708,12 @@ def test_list_long_enumeration_9_nistxml_sv_ii_list_long_enumeration_5_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11941,11 +12724,12 @@ def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11956,11 +12740,12 @@ def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11971,11 +12756,12 @@ def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -11986,11 +12772,12 @@ def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12001,11 +12788,12 @@ def test_list_long_enumeration_8_nistxml_sv_ii_list_long_enumeration_4_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12016,11 +12804,12 @@ def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12031,11 +12820,12 @@ def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12046,11 +12836,12 @@ def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12061,11 +12852,12 @@ def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12076,11 +12868,12 @@ def test_list_long_enumeration_7_nistxml_sv_ii_list_long_enumeration_3_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12091,11 +12884,12 @@ def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12106,11 +12900,12 @@ def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12121,11 +12916,12 @@ def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12136,11 +12932,12 @@ def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12151,11 +12948,12 @@ def test_list_long_enumeration_6_nistxml_sv_ii_list_long_enumeration_2_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12166,11 +12964,12 @@ def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12181,11 +12980,12 @@ def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12196,11 +12996,12 @@ def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12211,11 +13012,12 @@ def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12226,11 +13028,12 @@ def test_list_long_enumeration_5_nistxml_sv_ii_list_long_enumeration_1_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12242,11 +13045,12 @@ def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12258,11 +13062,12 @@ def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12274,11 +13079,12 @@ def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12290,11 +13096,12 @@ def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12306,11 +13113,12 @@ def test_list_long_pattern_9_nistxml_sv_ii_list_long_pattern_5_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12322,11 +13130,12 @@ def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12338,11 +13147,12 @@ def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12354,11 +13164,12 @@ def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12370,11 +13181,12 @@ def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12386,11 +13198,12 @@ def test_list_long_pattern_8_nistxml_sv_ii_list_long_pattern_4_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12402,11 +13215,12 @@ def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12418,11 +13232,12 @@ def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12434,11 +13249,12 @@ def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12450,11 +13266,12 @@ def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12466,11 +13283,12 @@ def test_list_long_pattern_7_nistxml_sv_ii_list_long_pattern_3_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12482,11 +13300,12 @@ def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12498,11 +13317,12 @@ def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12514,11 +13334,12 @@ def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12530,11 +13351,12 @@ def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12546,11 +13368,12 @@ def test_list_long_pattern_6_nistxml_sv_ii_list_long_pattern_2_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12562,11 +13385,12 @@ def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12578,11 +13402,12 @@ def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12594,11 +13419,12 @@ def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12610,11 +13436,12 @@ def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12626,11 +13453,12 @@ def test_list_long_pattern_5_nistxml_sv_ii_list_long_pattern_1_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_1(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -12641,11 +13469,12 @@ def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_2(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -12656,11 +13485,12 @@ def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_3(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -12671,11 +13501,12 @@ def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_4(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -12686,11 +13517,12 @@ def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_5(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -12701,11 +13533,12 @@ def test_list_long_length_9_nistxml_sv_ii_list_long_length_5_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_1(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -12716,11 +13549,12 @@ def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_2(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -12731,11 +13565,12 @@ def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_3(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -12746,11 +13581,12 @@ def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_4(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -12761,11 +13597,12 @@ def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_5(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -12776,11 +13613,12 @@ def test_list_long_length_8_nistxml_sv_ii_list_long_length_4_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_1(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -12791,11 +13629,12 @@ def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_2(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -12806,11 +13645,12 @@ def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_3(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -12821,11 +13661,12 @@ def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_4(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -12836,11 +13677,12 @@ def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_5(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -12851,11 +13693,12 @@ def test_list_long_length_7_nistxml_sv_ii_list_long_length_3_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_1(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -12866,11 +13709,12 @@ def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_2(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -12881,11 +13725,12 @@ def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_3(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -12896,11 +13741,12 @@ def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_4(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -12911,11 +13757,12 @@ def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_5(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -12926,11 +13773,12 @@ def test_list_long_length_6_nistxml_sv_ii_list_long_length_2_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_1(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -12941,11 +13789,12 @@ def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_2(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -12956,11 +13805,12 @@ def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_3(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -12971,11 +13821,12 @@ def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_4(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -12986,11 +13837,12 @@ def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_5(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -13001,11 +13853,12 @@ def test_list_long_length_5_nistxml_sv_ii_list_long_length_1_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13016,11 +13869,12 @@ def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13031,11 +13885,12 @@ def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13046,11 +13901,12 @@ def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13061,11 +13917,12 @@ def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13076,11 +13933,12 @@ def test_list_long_min_length_9_nistxml_sv_ii_list_long_min_length_5_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13091,11 +13949,12 @@ def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13106,11 +13965,12 @@ def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13121,11 +13981,12 @@ def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13136,11 +13997,12 @@ def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13151,11 +14013,12 @@ def test_list_long_min_length_8_nistxml_sv_ii_list_long_min_length_4_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13166,11 +14029,12 @@ def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13181,11 +14045,12 @@ def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13196,11 +14061,12 @@ def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13211,11 +14077,12 @@ def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13226,11 +14093,12 @@ def test_list_long_min_length_7_nistxml_sv_ii_list_long_min_length_3_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13241,11 +14109,12 @@ def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13256,11 +14125,12 @@ def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13271,11 +14141,12 @@ def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13286,11 +14157,12 @@ def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13301,11 +14173,12 @@ def test_list_long_min_length_6_nistxml_sv_ii_list_long_min_length_2_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13316,11 +14189,12 @@ def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13331,11 +14205,12 @@ def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13346,11 +14221,12 @@ def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13361,11 +14237,12 @@ def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13376,11 +14253,12 @@ def test_list_long_min_length_5_nistxml_sv_ii_list_long_min_length_1_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13391,11 +14269,12 @@ def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13406,11 +14285,12 @@ def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13421,11 +14301,12 @@ def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13436,11 +14317,12 @@ def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13451,11 +14333,12 @@ def test_list_long_max_length_9_nistxml_sv_ii_list_long_max_length_5_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13466,11 +14349,12 @@ def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13481,11 +14365,12 @@ def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13496,11 +14381,12 @@ def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13511,11 +14397,12 @@ def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13526,11 +14413,12 @@ def test_list_long_max_length_8_nistxml_sv_ii_list_long_max_length_4_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13541,11 +14429,12 @@ def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13556,11 +14445,12 @@ def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13571,11 +14461,12 @@ def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13586,11 +14477,12 @@ def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13601,11 +14493,12 @@ def test_list_long_max_length_7_nistxml_sv_ii_list_long_max_length_3_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -13616,11 +14509,12 @@ def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -13631,11 +14525,12 @@ def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -13646,11 +14541,12 @@ def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -13661,11 +14557,12 @@ def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -13676,11 +14573,12 @@ def test_list_long_max_length_6_nistxml_sv_ii_list_long_max_length_2_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -13691,11 +14589,12 @@ def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -13706,11 +14605,12 @@ def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -13721,11 +14621,12 @@ def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -13736,11 +14637,12 @@ def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -13751,11 +14653,12 @@ def test_list_long_max_length_5_nistxml_sv_ii_list_long_max_length_1_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-II-list-long-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer_enumeration_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13766,11 +14669,12 @@ def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer_enumeration_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13781,11 +14685,12 @@ def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer_enumeration_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13796,11 +14701,12 @@ def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer_enumeration_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13811,11 +14717,12 @@ def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer_enumeration_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13826,11 +14733,12 @@ def test_list_negative_integer_enumeration_9_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer_enumeration_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13841,11 +14749,12 @@ def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer_enumeration_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13856,11 +14765,12 @@ def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer_enumeration_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13871,11 +14781,12 @@ def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer_enumeration_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13886,11 +14797,12 @@ def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer_enumeration_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13901,11 +14813,12 @@ def test_list_negative_integer_enumeration_8_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer_enumeration_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13916,11 +14829,12 @@ def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer_enumeration_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13931,11 +14845,12 @@ def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer_enumeration_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13946,11 +14861,12 @@ def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer_enumeration_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13961,11 +14877,12 @@ def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer_enumeration_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13976,11 +14893,12 @@ def test_list_negative_integer_enumeration_7_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer_enumeration_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -13991,11 +14909,12 @@ def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer_enumeration_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14006,11 +14925,12 @@ def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer_enumeration_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14021,11 +14941,12 @@ def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer_enumeration_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14036,11 +14957,12 @@ def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer_enumeration_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14051,11 +14973,12 @@ def test_list_negative_integer_enumeration_6_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer_enumeration_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14066,11 +14989,12 @@ def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer_enumeration_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14081,11 +15005,12 @@ def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer_enumeration_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14096,11 +15021,12 @@ def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer_enumeration_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14111,11 +15037,12 @@ def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer_enumeration_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14126,11 +15053,12 @@ def test_list_negative_integer_enumeration_5_nistxml_sv_ii_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pattern_5_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14143,11 +15071,12 @@ def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pattern_5_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14160,11 +15089,12 @@ def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pattern_5_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14177,11 +15107,12 @@ def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pattern_5_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14194,11 +15125,12 @@ def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pattern_5_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14211,11 +15143,12 @@ def test_list_negative_integer_pattern_9_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pattern_4_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14227,11 +15160,12 @@ def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pattern_4_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14243,11 +15177,12 @@ def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pattern_4_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14259,11 +15194,12 @@ def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pattern_4_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14275,11 +15211,12 @@ def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pattern_4_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14291,11 +15228,12 @@ def test_list_negative_integer_pattern_8_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pattern_3_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14307,11 +15245,12 @@ def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pattern_3_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14323,11 +15262,12 @@ def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pattern_3_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14339,11 +15279,12 @@ def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pattern_3_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14355,11 +15296,12 @@ def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pattern_3_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14371,11 +15313,12 @@ def test_list_negative_integer_pattern_7_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pattern_2_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14387,11 +15330,12 @@ def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pattern_2_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14403,11 +15347,12 @@ def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pattern_2_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14419,11 +15364,12 @@ def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pattern_2_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14435,11 +15381,12 @@ def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pattern_2_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14451,11 +15398,12 @@ def test_list_negative_integer_pattern_6_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pattern_1_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14468,11 +15416,12 @@ def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pattern_1_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14485,11 +15434,12 @@ def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pattern_1_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14502,11 +15452,12 @@ def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pattern_1_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14519,11 +15470,12 @@ def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pattern_1_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14536,11 +15488,12 @@ def test_list_negative_integer_pattern_5_nistxml_sv_ii_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_length_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -14551,11 +15504,12 @@ def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_length_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -14566,11 +15520,12 @@ def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_length_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -14581,11 +15536,12 @@ def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_length_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -14596,11 +15552,12 @@ def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_length_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -14611,11 +15568,12 @@ def test_list_negative_integer_length_9_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_length_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -14626,11 +15584,12 @@ def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_length_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -14641,11 +15600,12 @@ def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_length_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -14656,11 +15616,12 @@ def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_length_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -14671,11 +15632,12 @@ def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_length_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -14686,11 +15648,12 @@ def test_list_negative_integer_length_8_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_length_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -14701,11 +15664,12 @@ def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_length_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -14716,11 +15680,12 @@ def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_length_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -14731,11 +15696,12 @@ def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_length_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -14746,11 +15712,12 @@ def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_length_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -14761,11 +15728,12 @@ def test_list_negative_integer_length_7_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_length_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -14776,11 +15744,12 @@ def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_length_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -14791,11 +15760,12 @@ def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_length_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -14806,11 +15776,12 @@ def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_length_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -14821,11 +15792,12 @@ def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_length_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -14836,11 +15808,12 @@ def test_list_negative_integer_length_6_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_length_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -14851,11 +15824,12 @@ def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_length_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -14866,11 +15840,12 @@ def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_length_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -14881,11 +15856,12 @@ def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_length_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -14896,11 +15872,12 @@ def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_length_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 5.
@@ -14911,11 +15888,12 @@ def test_list_negative_integer_length_5_nistxml_sv_ii_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_min_length_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -14927,11 +15905,12 @@ def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_min_length_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -14943,11 +15922,12 @@ def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_min_length_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -14959,11 +15939,12 @@ def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_min_length_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -14975,11 +15956,12 @@ def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_min_length_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -14991,11 +15973,12 @@ def test_list_negative_integer_min_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_min_length_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15007,11 +15990,12 @@ def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_min_length_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15023,11 +16007,12 @@ def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_min_length_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15039,11 +16024,12 @@ def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_min_length_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15055,11 +16041,12 @@ def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_min_length_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15071,11 +16058,12 @@ def test_list_negative_integer_min_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_min_length_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15087,11 +16075,12 @@ def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_min_length_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15103,11 +16092,12 @@ def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_min_length_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15119,11 +16109,12 @@ def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_min_length_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15135,11 +16126,12 @@ def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_min_length_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15151,11 +16143,12 @@ def test_list_negative_integer_min_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_min_length_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15167,11 +16160,12 @@ def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_min_length_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15183,11 +16177,12 @@ def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_min_length_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15199,11 +16194,12 @@ def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_min_length_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15215,11 +16211,12 @@ def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_min_length_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15231,11 +16228,12 @@ def test_list_negative_integer_min_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_min_length_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15247,11 +16245,12 @@ def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_min_length_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15263,11 +16262,12 @@ def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_min_length_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15279,11 +16279,12 @@ def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_min_length_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15295,11 +16296,12 @@ def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_min_length_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet minLength with value
@@ -15311,6 +16313,6 @@ def test_list_negative_integer_min_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_5000.py
+++ b/tests/test_nist_meta_5000.py
@@ -1,5 +1,3 @@
-import pytest
-
 from tests.utils import assert_bindings
 
 
@@ -11908,7 +11906,6 @@ def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_5(save_xm
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11924,7 +11921,6 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_1(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11940,7 +11936,6 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_2(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11956,7 +11951,6 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_3(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11972,7 +11966,6 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_4(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11988,7 +11981,6 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_5(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12004,7 +11996,6 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_1(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12020,7 +12011,6 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_2(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12036,7 +12026,6 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_3(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12052,7 +12041,6 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_4(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12068,7 +12056,6 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_5(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12084,7 +12071,6 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_1(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12100,7 +12086,6 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_2(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12116,7 +12101,6 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_3(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12132,7 +12116,6 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_4(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12148,7 +12131,6 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_5(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12164,7 +12146,6 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_1(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12180,7 +12161,6 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_2(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12196,7 +12176,6 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_3(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12212,7 +12191,6 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_4(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12228,7 +12206,6 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_5(save_
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12244,7 +12221,6 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_1(save_xm
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12260,7 +12236,6 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_2(save_xm
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12276,7 +12251,6 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_3(save_xm
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12292,7 +12266,6 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_4(save_xm
     )
 
 
-@pytest.mark.xfail
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.

--- a/tests/test_nist_meta_5000.py
+++ b/tests/test_nist_meta_5000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_max_length_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -12,11 +15,12 @@ def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_max_length_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -28,11 +32,12 @@ def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_max_length_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -44,11 +49,12 @@ def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_max_length_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -60,11 +66,12 @@ def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_max_length_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -76,11 +83,12 @@ def test_list_negative_integer_max_length_9_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_max_length_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -92,11 +100,12 @@ def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_max_length_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -108,11 +117,12 @@ def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_max_length_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -124,11 +134,12 @@ def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_max_length_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -140,11 +151,12 @@ def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_max_length_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -156,11 +168,12 @@ def test_list_negative_integer_max_length_8_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_max_length_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -172,11 +185,12 @@ def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_max_length_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -188,11 +202,12 @@ def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_max_length_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -204,11 +219,12 @@ def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_max_length_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -220,11 +236,12 @@ def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_max_length_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -236,11 +253,12 @@ def test_list_negative_integer_max_length_7_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_max_length_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -252,11 +270,12 @@ def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_max_length_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -268,11 +287,12 @@ def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_max_length_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -284,11 +304,12 @@ def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_max_length_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -300,11 +321,12 @@ def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_max_length_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -316,11 +338,12 @@ def test_list_negative_integer_max_length_6_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_max_length_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -332,11 +355,12 @@ def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_max_length_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -348,11 +372,12 @@ def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_max_length_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -364,11 +389,12 @@ def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_max_length_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -380,11 +406,12 @@ def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_max_length_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet maxLength with value
@@ -396,11 +423,12 @@ def test_list_negative_integer_max_length_5_nistxml_sv_ii_list_negative_integer_
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-II-list-negativeInteger-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive_integer_enumeration_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -411,11 +439,12 @@ def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive_integer_enumeration_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -426,11 +455,12 @@ def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive_integer_enumeration_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -441,11 +471,12 @@ def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive_integer_enumeration_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -456,11 +487,12 @@ def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive_integer_enumeration_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -471,11 +503,12 @@ def test_list_non_positive_integer_enumeration_9_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive_integer_enumeration_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -486,11 +519,12 @@ def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive_integer_enumeration_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -501,11 +535,12 @@ def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive_integer_enumeration_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -516,11 +551,12 @@ def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive_integer_enumeration_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -531,11 +567,12 @@ def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive_integer_enumeration_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -546,11 +583,12 @@ def test_list_non_positive_integer_enumeration_8_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive_integer_enumeration_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -561,11 +599,12 @@ def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive_integer_enumeration_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -576,11 +615,12 @@ def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive_integer_enumeration_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -591,11 +631,12 @@ def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive_integer_enumeration_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -606,11 +647,12 @@ def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive_integer_enumeration_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -621,11 +663,12 @@ def test_list_non_positive_integer_enumeration_7_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive_integer_enumeration_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -636,11 +679,12 @@ def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive_integer_enumeration_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -651,11 +695,12 @@ def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive_integer_enumeration_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -666,11 +711,12 @@ def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive_integer_enumeration_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -681,11 +727,12 @@ def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive_integer_enumeration_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -696,11 +743,12 @@ def test_list_non_positive_integer_enumeration_6_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive_integer_enumeration_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -711,11 +759,12 @@ def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive_integer_enumeration_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -726,11 +775,12 @@ def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive_integer_enumeration_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -741,11 +791,12 @@ def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive_integer_enumeration_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -756,11 +807,12 @@ def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive_integer_enumeration_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet enumeration.
@@ -771,11 +823,12 @@ def test_list_non_positive_integer_enumeration_5_nistxml_sv_ii_list_non_positive
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_integer_pattern_5_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -787,11 +840,12 @@ def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_integer_pattern_5_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -803,11 +857,12 @@ def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_integer_pattern_5_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -819,11 +874,12 @@ def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_integer_pattern_5_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -835,11 +891,12 @@ def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_integer_pattern_5_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -851,11 +908,12 @@ def test_list_non_positive_integer_pattern_9_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_integer_pattern_4_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -867,11 +925,12 @@ def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_integer_pattern_4_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -883,11 +942,12 @@ def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_integer_pattern_4_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -899,11 +959,12 @@ def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_integer_pattern_4_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -915,11 +976,12 @@ def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_integer_pattern_4_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -931,11 +993,12 @@ def test_list_non_positive_integer_pattern_8_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_integer_pattern_3_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -947,11 +1010,12 @@ def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_integer_pattern_3_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -963,11 +1027,12 @@ def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_integer_pattern_3_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -979,11 +1044,12 @@ def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_integer_pattern_3_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -995,11 +1061,12 @@ def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_integer_pattern_3_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1011,11 +1078,12 @@ def test_list_non_positive_integer_pattern_7_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_integer_pattern_2_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1028,11 +1096,12 @@ def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_integer_pattern_2_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1045,11 +1114,12 @@ def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_integer_pattern_2_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1062,11 +1132,12 @@ def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_integer_pattern_2_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1079,11 +1150,12 @@ def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_integer_pattern_2_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1096,11 +1168,12 @@ def test_list_non_positive_integer_pattern_6_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_integer_pattern_1_1(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1112,11 +1185,12 @@ def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_integer_pattern_1_2(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1128,11 +1202,12 @@ def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_integer_pattern_1_3(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1144,11 +1219,12 @@ def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_integer_pattern_1_4(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1160,11 +1236,12 @@ def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_integer_pattern_1_5(save_xml):
     r"""
     Type list/nonPositiveInteger is restricted by facet pattern with value
@@ -1176,11 +1253,12 @@ def test_list_non_positive_integer_pattern_5_nistxml_sv_ii_list_non_positive_int
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_integer_length_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1192,11 +1270,12 @@ def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_integer_length_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1208,11 +1287,12 @@ def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_integer_length_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1224,11 +1304,12 @@ def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_integer_length_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1240,11 +1321,12 @@ def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_integer_length_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1256,11 +1338,12 @@ def test_list_non_positive_integer_length_9_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_integer_length_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1272,11 +1355,12 @@ def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_integer_length_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1288,11 +1372,12 @@ def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_integer_length_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1304,11 +1389,12 @@ def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_integer_length_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1320,11 +1406,12 @@ def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_integer_length_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1336,11 +1423,12 @@ def test_list_non_positive_integer_length_8_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_integer_length_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1352,11 +1440,12 @@ def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_integer_length_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1368,11 +1457,12 @@ def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_integer_length_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1384,11 +1474,12 @@ def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_integer_length_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1400,11 +1491,12 @@ def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_integer_length_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1416,11 +1508,12 @@ def test_list_non_positive_integer_length_7_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_integer_length_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1432,11 +1525,12 @@ def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_integer_length_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1448,11 +1542,12 @@ def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_integer_length_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1464,11 +1559,12 @@ def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_integer_length_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1480,11 +1576,12 @@ def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_integer_length_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1496,11 +1593,12 @@ def test_list_non_positive_integer_length_6_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_integer_length_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1512,11 +1610,12 @@ def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_integer_length_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1528,11 +1627,12 @@ def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_integer_length_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1544,11 +1644,12 @@ def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_integer_length_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1560,11 +1661,12 @@ def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_integer_length_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet length with value
@@ -1576,11 +1678,12 @@ def test_list_non_positive_integer_length_5_nistxml_sv_ii_list_non_positive_inte
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_integer_min_length_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1592,11 +1695,12 @@ def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_integer_min_length_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1608,11 +1712,12 @@ def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_integer_min_length_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1624,11 +1729,12 @@ def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_integer_min_length_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1640,11 +1746,12 @@ def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_integer_min_length_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1656,11 +1763,12 @@ def test_list_non_positive_integer_min_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_integer_min_length_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1672,11 +1780,12 @@ def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_integer_min_length_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1688,11 +1797,12 @@ def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_integer_min_length_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1704,11 +1814,12 @@ def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_integer_min_length_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1720,11 +1831,12 @@ def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_integer_min_length_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1736,11 +1848,12 @@ def test_list_non_positive_integer_min_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_integer_min_length_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1752,11 +1865,12 @@ def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_integer_min_length_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1768,11 +1882,12 @@ def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_integer_min_length_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1784,11 +1899,12 @@ def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_integer_min_length_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1800,11 +1916,12 @@ def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_integer_min_length_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1816,11 +1933,12 @@ def test_list_non_positive_integer_min_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_integer_min_length_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1832,11 +1950,12 @@ def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_integer_min_length_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1848,11 +1967,12 @@ def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_integer_min_length_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1864,11 +1984,12 @@ def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_integer_min_length_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1880,11 +2001,12 @@ def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_integer_min_length_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1896,11 +2018,12 @@ def test_list_non_positive_integer_min_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_integer_min_length_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1912,11 +2035,12 @@ def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_integer_min_length_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1928,11 +2052,12 @@ def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_integer_min_length_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1944,11 +2069,12 @@ def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_integer_min_length_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1960,11 +2086,12 @@ def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_integer_min_length_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet minLength with
@@ -1976,11 +2103,12 @@ def test_list_non_positive_integer_min_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_integer_max_length_5_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -1992,11 +2120,12 @@ def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_integer_max_length_5_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2008,11 +2137,12 @@ def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_integer_max_length_5_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2024,11 +2154,12 @@ def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_integer_max_length_5_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2040,11 +2171,12 @@ def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_integer_max_length_5_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2056,11 +2188,12 @@ def test_list_non_positive_integer_max_length_9_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_integer_max_length_4_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2072,11 +2205,12 @@ def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_integer_max_length_4_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2088,11 +2222,12 @@ def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_integer_max_length_4_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2104,11 +2239,12 @@ def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_integer_max_length_4_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2120,11 +2256,12 @@ def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_integer_max_length_4_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2136,11 +2273,12 @@ def test_list_non_positive_integer_max_length_8_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_integer_max_length_3_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2152,11 +2290,12 @@ def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_integer_max_length_3_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2168,11 +2307,12 @@ def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_integer_max_length_3_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2184,11 +2324,12 @@ def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_integer_max_length_3_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2200,11 +2341,12 @@ def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_integer_max_length_3_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2216,11 +2358,12 @@ def test_list_non_positive_integer_max_length_7_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_integer_max_length_2_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2232,11 +2375,12 @@ def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_integer_max_length_2_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2248,11 +2392,12 @@ def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_integer_max_length_2_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2264,11 +2409,12 @@ def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_integer_max_length_2_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2280,11 +2426,12 @@ def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_integer_max_length_2_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2296,11 +2443,12 @@ def test_list_non_positive_integer_max_length_6_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_integer_max_length_1_1(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2312,11 +2460,12 @@ def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_integer_max_length_1_2(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2328,11 +2477,12 @@ def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_integer_max_length_1_3(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2344,11 +2494,12 @@ def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_integer_max_length_1_4(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2360,11 +2511,12 @@ def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_integer_max_length_1_5(save_xml):
     """
     Type list/nonPositiveInteger is restricted by facet maxLength with
@@ -2376,11 +2528,12 @@ def test_list_non_positive_integer_max_length_5_nistxml_sv_ii_list_non_positive_
         instance="nistData/list/nonPositiveInteger/Schema+Instance/NISTXML-SV-II-list-nonPositiveInteger-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListNonPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2391,11 +2544,12 @@ def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2406,11 +2560,12 @@ def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2421,11 +2576,12 @@ def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2436,11 +2592,12 @@ def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2451,11 +2608,12 @@ def test_list_integer_enumeration_9_nistxml_sv_ii_list_integer_enumeration_5_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2466,11 +2624,12 @@ def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2481,11 +2640,12 @@ def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2496,11 +2656,12 @@ def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2511,11 +2672,12 @@ def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2526,11 +2688,12 @@ def test_list_integer_enumeration_8_nistxml_sv_ii_list_integer_enumeration_4_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2541,11 +2704,12 @@ def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2556,11 +2720,12 @@ def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2571,11 +2736,12 @@ def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2586,11 +2752,12 @@ def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2601,11 +2768,12 @@ def test_list_integer_enumeration_7_nistxml_sv_ii_list_integer_enumeration_3_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2616,11 +2784,12 @@ def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2631,11 +2800,12 @@ def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2646,11 +2816,12 @@ def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2661,11 +2832,12 @@ def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2676,11 +2848,12 @@ def test_list_integer_enumeration_6_nistxml_sv_ii_list_integer_enumeration_2_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_1(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2691,11 +2864,12 @@ def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_1(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_2(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2706,11 +2880,12 @@ def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_2(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_3(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2721,11 +2896,12 @@ def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_3(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_4(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2736,11 +2912,12 @@ def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_4(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_5(save_xml):
     """
     Type list/integer is restricted by facet enumeration.
@@ -2751,11 +2928,12 @@ def test_list_integer_enumeration_5_nistxml_sv_ii_list_integer_enumeration_1_5(s
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2767,11 +2945,12 @@ def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2783,11 +2962,12 @@ def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2799,11 +2979,12 @@ def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2815,11 +2996,12 @@ def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2831,11 +3013,12 @@ def test_list_integer_pattern_9_nistxml_sv_ii_list_integer_pattern_5_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2847,11 +3030,12 @@ def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2863,11 +3047,12 @@ def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2879,11 +3064,12 @@ def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2895,11 +3081,12 @@ def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2911,11 +3098,12 @@ def test_list_integer_pattern_8_nistxml_sv_ii_list_integer_pattern_4_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2927,11 +3115,12 @@ def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2943,11 +3132,12 @@ def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2959,11 +3149,12 @@ def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2975,11 +3166,12 @@ def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -2991,11 +3183,12 @@ def test_list_integer_pattern_7_nistxml_sv_ii_list_integer_pattern_3_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3007,11 +3200,12 @@ def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3023,11 +3217,12 @@ def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3039,11 +3234,12 @@ def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3055,11 +3251,12 @@ def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3071,11 +3268,12 @@ def test_list_integer_pattern_6_nistxml_sv_ii_list_integer_pattern_2_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_1(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3087,11 +3285,12 @@ def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_1(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_2(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3103,11 +3302,12 @@ def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_2(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_3(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3119,11 +3319,12 @@ def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_3(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_4(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3135,11 +3336,12 @@ def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_4(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_5(save_xml):
     r"""
     Type list/integer is restricted by facet pattern with value \-\d{18}
@@ -3151,11 +3353,12 @@ def test_list_integer_pattern_5_nistxml_sv_ii_list_integer_pattern_1_5(save_xml)
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3166,11 +3369,12 @@ def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3181,11 +3385,12 @@ def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3196,11 +3401,12 @@ def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3211,11 +3417,12 @@ def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 10.
@@ -3226,11 +3433,12 @@ def test_list_integer_length_9_nistxml_sv_ii_list_integer_length_5_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3241,11 +3449,12 @@ def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3256,11 +3465,12 @@ def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3271,11 +3481,12 @@ def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3286,11 +3497,12 @@ def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 8.
@@ -3301,11 +3513,12 @@ def test_list_integer_length_8_nistxml_sv_ii_list_integer_length_4_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3316,11 +3529,12 @@ def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3331,11 +3545,12 @@ def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3346,11 +3561,12 @@ def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3361,11 +3577,12 @@ def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 7.
@@ -3376,11 +3593,12 @@ def test_list_integer_length_7_nistxml_sv_ii_list_integer_length_3_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -3391,11 +3609,12 @@ def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -3406,11 +3625,12 @@ def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -3421,11 +3641,12 @@ def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -3436,11 +3657,12 @@ def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 6.
@@ -3451,11 +3673,12 @@ def test_list_integer_length_6_nistxml_sv_ii_list_integer_length_2_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_1(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -3466,11 +3689,12 @@ def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_1(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_2(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -3481,11 +3705,12 @@ def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_2(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_3(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -3496,11 +3721,12 @@ def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_3(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_4(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -3511,11 +3737,12 @@ def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_4(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_5(save_xml):
     """
     Type list/integer is restricted by facet length with value 5.
@@ -3526,11 +3753,12 @@ def test_list_integer_length_5_nistxml_sv_ii_list_integer_length_1_5(save_xml):
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -3541,11 +3769,12 @@ def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -3556,11 +3785,12 @@ def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -3571,11 +3801,12 @@ def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -3586,11 +3817,12 @@ def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 10.
@@ -3601,11 +3833,12 @@ def test_list_integer_min_length_9_nistxml_sv_ii_list_integer_min_length_5_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -3616,11 +3849,12 @@ def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -3631,11 +3865,12 @@ def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -3646,11 +3881,12 @@ def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -3661,11 +3897,12 @@ def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 8.
@@ -3676,11 +3913,12 @@ def test_list_integer_min_length_8_nistxml_sv_ii_list_integer_min_length_4_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -3691,11 +3929,12 @@ def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -3706,11 +3945,12 @@ def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -3721,11 +3961,12 @@ def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -3736,11 +3977,12 @@ def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 7.
@@ -3751,11 +3993,12 @@ def test_list_integer_min_length_7_nistxml_sv_ii_list_integer_min_length_3_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -3766,11 +4009,12 @@ def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -3781,11 +4025,12 @@ def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -3796,11 +4041,12 @@ def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -3811,11 +4057,12 @@ def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 6.
@@ -3826,11 +4073,12 @@ def test_list_integer_min_length_6_nistxml_sv_ii_list_integer_min_length_2_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_1(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -3841,11 +4089,12 @@ def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_2(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -3856,11 +4105,12 @@ def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_3(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -3871,11 +4121,12 @@ def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_4(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -3886,11 +4137,12 @@ def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_5(save_xml):
     """
     Type list/integer is restricted by facet minLength with value 5.
@@ -3901,11 +4153,12 @@ def test_list_integer_min_length_5_nistxml_sv_ii_list_integer_min_length_1_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -3916,11 +4169,12 @@ def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -3931,11 +4185,12 @@ def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -3946,11 +4201,12 @@ def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -3961,11 +4217,12 @@ def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 10.
@@ -3976,11 +4233,12 @@ def test_list_integer_max_length_9_nistxml_sv_ii_list_integer_max_length_5_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -3991,11 +4249,12 @@ def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4006,11 +4265,12 @@ def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4021,11 +4281,12 @@ def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4036,11 +4297,12 @@ def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 8.
@@ -4051,11 +4313,12 @@ def test_list_integer_max_length_8_nistxml_sv_ii_list_integer_max_length_4_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4066,11 +4329,12 @@ def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4081,11 +4345,12 @@ def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4096,11 +4361,12 @@ def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4111,11 +4377,12 @@ def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 7.
@@ -4126,11 +4393,12 @@ def test_list_integer_max_length_7_nistxml_sv_ii_list_integer_max_length_3_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4141,11 +4409,12 @@ def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4156,11 +4425,12 @@ def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4171,11 +4441,12 @@ def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4186,11 +4457,12 @@ def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 6.
@@ -4201,11 +4473,12 @@ def test_list_integer_max_length_6_nistxml_sv_ii_list_integer_max_length_2_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_1(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4216,11 +4489,12 @@ def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_1(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_2(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4231,11 +4505,12 @@ def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_2(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_3(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4246,11 +4521,12 @@ def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_3(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_4(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4261,11 +4537,12 @@ def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_4(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_5(save_xml):
     """
     Type list/integer is restricted by facet maxLength with value 5.
@@ -4276,11 +4553,12 @@ def test_list_integer_max_length_5_nistxml_sv_ii_list_integer_max_length_1_5(sav
         instance="nistData/list/integer/Schema+Instance/NISTXML-SV-II-list-integer-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4291,11 +4569,12 @@ def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4306,11 +4585,12 @@ def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4321,11 +4601,12 @@ def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4336,11 +4617,12 @@ def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4351,11 +4633,12 @@ def test_list_decimal_enumeration_9_nistxml_sv_ii_list_decimal_enumeration_5_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4366,11 +4649,12 @@ def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4381,11 +4665,12 @@ def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4396,11 +4681,12 @@ def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4411,11 +4697,12 @@ def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4426,11 +4713,12 @@ def test_list_decimal_enumeration_8_nistxml_sv_ii_list_decimal_enumeration_4_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4441,11 +4729,12 @@ def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4456,11 +4745,12 @@ def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4471,11 +4761,12 @@ def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4486,11 +4777,12 @@ def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4501,11 +4793,12 @@ def test_list_decimal_enumeration_7_nistxml_sv_ii_list_decimal_enumeration_3_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4516,11 +4809,12 @@ def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4531,11 +4825,12 @@ def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4546,11 +4841,12 @@ def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4561,11 +4857,12 @@ def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4576,11 +4873,12 @@ def test_list_decimal_enumeration_6_nistxml_sv_ii_list_decimal_enumeration_2_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_1(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4591,11 +4889,12 @@ def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_1(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_2(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4606,11 +4905,12 @@ def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_2(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_3(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4621,11 +4921,12 @@ def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_3(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_4(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4636,11 +4937,12 @@ def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_4(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_5(save_xml):
     """
     Type list/decimal is restricted by facet enumeration.
@@ -4651,11 +4953,12 @@ def test_list_decimal_enumeration_5_nistxml_sv_ii_list_decimal_enumeration_1_5(s
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-enumeration-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4668,11 +4971,12 @@ def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4685,11 +4989,12 @@ def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4702,11 +5007,12 @@ def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4719,11 +5025,12 @@ def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4736,11 +5043,12 @@ def test_list_decimal_pattern_9_nistxml_sv_ii_list_decimal_pattern_5_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4753,11 +5061,12 @@ def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4770,11 +5079,12 @@ def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4787,11 +5097,12 @@ def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4804,11 +5115,12 @@ def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4821,11 +5133,12 @@ def test_list_decimal_pattern_8_nistxml_sv_ii_list_decimal_pattern_4_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4838,11 +5151,12 @@ def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4855,11 +5169,12 @@ def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4872,11 +5187,12 @@ def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4889,11 +5205,12 @@ def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \d{1}
@@ -4906,11 +5223,12 @@ def test_list_decimal_pattern_7_nistxml_sv_ii_list_decimal_pattern_3_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -4922,11 +5240,12 @@ def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -4938,11 +5257,12 @@ def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -4954,11 +5274,12 @@ def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -4970,11 +5291,12 @@ def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -4986,11 +5308,12 @@ def test_list_decimal_pattern_6_nistxml_sv_ii_list_decimal_pattern_2_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_1(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5003,11 +5326,12 @@ def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_1(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_2(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5020,11 +5344,12 @@ def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_2(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_3(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5037,11 +5362,12 @@ def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_3(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_4(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5054,11 +5380,12 @@ def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_4(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_5(save_xml):
     r"""
     Type list/decimal is restricted by facet pattern with value \-\d{1}
@@ -5071,11 +5398,12 @@ def test_list_decimal_pattern_5_nistxml_sv_ii_list_decimal_pattern_1_5(save_xml)
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-pattern-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5086,11 +5414,12 @@ def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5101,11 +5430,12 @@ def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5116,11 +5446,12 @@ def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5131,11 +5462,12 @@ def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 10.
@@ -5146,11 +5478,12 @@ def test_list_decimal_length_9_nistxml_sv_ii_list_decimal_length_5_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5161,11 +5494,12 @@ def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5176,11 +5510,12 @@ def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5191,11 +5526,12 @@ def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5206,11 +5542,12 @@ def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 8.
@@ -5221,11 +5558,12 @@ def test_list_decimal_length_8_nistxml_sv_ii_list_decimal_length_4_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5236,11 +5574,12 @@ def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5251,11 +5590,12 @@ def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5266,11 +5606,12 @@ def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5281,11 +5622,12 @@ def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 7.
@@ -5296,11 +5638,12 @@ def test_list_decimal_length_7_nistxml_sv_ii_list_decimal_length_3_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -5311,11 +5654,12 @@ def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -5326,11 +5670,12 @@ def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -5341,11 +5686,12 @@ def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -5356,11 +5702,12 @@ def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 6.
@@ -5371,11 +5718,12 @@ def test_list_decimal_length_6_nistxml_sv_ii_list_decimal_length_2_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_1(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -5386,11 +5734,12 @@ def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_1(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_2(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -5401,11 +5750,12 @@ def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_2(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_3(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -5416,11 +5766,12 @@ def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_3(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_4(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -5431,11 +5782,12 @@ def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_4(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_5(save_xml):
     """
     Type list/decimal is restricted by facet length with value 5.
@@ -5446,11 +5798,12 @@ def test_list_decimal_length_5_nistxml_sv_ii_list_decimal_length_1_5(save_xml):
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-length-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -5461,11 +5814,12 @@ def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -5476,11 +5830,12 @@ def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -5491,11 +5846,12 @@ def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -5506,11 +5862,12 @@ def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 10.
@@ -5521,11 +5878,12 @@ def test_list_decimal_min_length_9_nistxml_sv_ii_list_decimal_min_length_5_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -5536,11 +5894,12 @@ def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -5551,11 +5910,12 @@ def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -5566,11 +5926,12 @@ def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -5581,11 +5942,12 @@ def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 8.
@@ -5596,11 +5958,12 @@ def test_list_decimal_min_length_8_nistxml_sv_ii_list_decimal_min_length_4_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -5611,11 +5974,12 @@ def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -5626,11 +5990,12 @@ def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -5641,11 +6006,12 @@ def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -5656,11 +6022,12 @@ def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 7.
@@ -5671,11 +6038,12 @@ def test_list_decimal_min_length_7_nistxml_sv_ii_list_decimal_min_length_3_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -5686,11 +6054,12 @@ def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -5701,11 +6070,12 @@ def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -5716,11 +6086,12 @@ def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -5731,11 +6102,12 @@ def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 6.
@@ -5746,11 +6118,12 @@ def test_list_decimal_min_length_6_nistxml_sv_ii_list_decimal_min_length_2_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_1(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -5761,11 +6134,12 @@ def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_2(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -5776,11 +6150,12 @@ def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_3(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -5791,11 +6166,12 @@ def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_4(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -5806,11 +6182,12 @@ def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_5(save_xml):
     """
     Type list/decimal is restricted by facet minLength with value 5.
@@ -5821,11 +6198,12 @@ def test_list_decimal_min_length_5_nistxml_sv_ii_list_decimal_min_length_1_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-minLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -5836,11 +6214,12 @@ def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-5-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -5851,11 +6230,12 @@ def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-5-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -5866,11 +6246,12 @@ def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-5-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -5881,11 +6262,12 @@ def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-5-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 10.
@@ -5896,11 +6278,12 @@ def test_list_decimal_max_length_9_nistxml_sv_ii_list_decimal_max_length_5_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-5-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -5911,11 +6294,12 @@ def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-4-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -5926,11 +6310,12 @@ def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-4-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -5941,11 +6326,12 @@ def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-4-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -5956,11 +6342,12 @@ def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-4-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 8.
@@ -5971,11 +6358,12 @@ def test_list_decimal_max_length_8_nistxml_sv_ii_list_decimal_max_length_4_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-4-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -5986,11 +6374,12 @@ def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-3-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6001,11 +6390,12 @@ def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-3-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6016,11 +6406,12 @@ def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-3-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6031,11 +6422,12 @@ def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-3-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 7.
@@ -6046,11 +6438,12 @@ def test_list_decimal_max_length_7_nistxml_sv_ii_list_decimal_max_length_3_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-3-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6061,11 +6454,12 @@ def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-2-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6076,11 +6470,12 @@ def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-2-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6091,11 +6486,12 @@ def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-2-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6106,11 +6502,12 @@ def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-2-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 6.
@@ -6121,11 +6518,12 @@ def test_list_decimal_max_length_6_nistxml_sv_ii_list_decimal_max_length_2_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-2-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_1(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6136,11 +6534,12 @@ def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_1(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-1-1.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_2(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6151,11 +6550,12 @@ def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_2(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-1-2.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_3(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6166,11 +6566,12 @@ def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_3(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-1-3.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_4(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6181,11 +6582,12 @@ def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_4(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-1-4.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_5(save_xml):
     """
     Type list/decimal is restricted by facet maxLength with value 5.
@@ -6196,11 +6598,12 @@ def test_list_decimal_max_length_5_nistxml_sv_ii_list_decimal_max_length_1_5(sav
         instance="nistData/list/decimal/Schema+Instance/NISTXML-SV-II-list-decimal-maxLength-1-5.xml",
         instance_is_valid=False,
         class_name="NistschemaSvIiListDecimalMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1_1(save_xml):
     """
     Type list/hexBinary is restricted by facet whiteSpace with value
@@ -6212,11 +6615,12 @@ def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1_2(save_xml):
     """
     Type list/hexBinary is restricted by facet whiteSpace with value
@@ -6228,11 +6632,12 @@ def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1_3(save_xml):
     """
     Type list/hexBinary is restricted by facet whiteSpace with value
@@ -6244,11 +6649,12 @@ def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1_4(save_xml):
     """
     Type list/hexBinary is restricted by facet whiteSpace with value
@@ -6260,11 +6666,12 @@ def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1_5(save_xml):
     """
     Type list/hexBinary is restricted by facet whiteSpace with value
@@ -6276,11 +6683,12 @@ def test_list_hex_binary_white_space_nistxml_sv_iv_list_hex_binary_white_space_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration_5_1(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6291,11 +6699,12 @@ def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration_5_2(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6306,11 +6715,12 @@ def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration_5_3(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6321,11 +6731,12 @@ def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration_5_4(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6336,11 +6747,12 @@ def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration_5_5(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6351,11 +6763,12 @@ def test_list_hex_binary_enumeration_4_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration_4_1(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6366,11 +6779,12 @@ def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration_4_2(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6381,11 +6795,12 @@ def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration_4_3(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6396,11 +6811,12 @@ def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration_4_4(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6411,11 +6827,12 @@ def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration_4_5(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6426,11 +6843,12 @@ def test_list_hex_binary_enumeration_3_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration_3_1(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6441,11 +6859,12 @@ def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration_3_2(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6456,11 +6875,12 @@ def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration_3_3(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6471,11 +6891,12 @@ def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration_3_4(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6486,11 +6907,12 @@ def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration_3_5(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6501,11 +6923,12 @@ def test_list_hex_binary_enumeration_2_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration_2_1(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6516,11 +6939,12 @@ def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration_2_2(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6531,11 +6955,12 @@ def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration_2_3(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6546,11 +6971,12 @@ def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration_2_4(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6561,11 +6987,12 @@ def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration_2_5(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6576,11 +7003,12 @@ def test_list_hex_binary_enumeration_1_nistxml_sv_iv_list_hex_binary_enumeration
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1_1(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6591,11 +7019,12 @@ def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1_2(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6606,11 +7035,12 @@ def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1_3(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6621,11 +7051,12 @@ def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1_4(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6636,11 +7067,12 @@ def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1_5(save_xml):
     """
     Type list/hexBinary is restricted by facet enumeration.
@@ -6651,11 +7083,12 @@ def test_list_hex_binary_enumeration_nistxml_sv_iv_list_hex_binary_enumeration_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_1(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6668,11 +7101,12 @@ def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_1(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_2(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6685,11 +7119,12 @@ def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_2(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_3(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6702,11 +7137,12 @@ def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_3(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_4(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6719,11 +7155,12 @@ def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_4(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_5(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6736,11 +7173,12 @@ def test_list_hex_binary_pattern_4_nistxml_sv_iv_list_hex_binary_pattern_5_5(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_1(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6753,11 +7191,12 @@ def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_1(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_2(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6770,11 +7209,12 @@ def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_2(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_3(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6787,11 +7227,12 @@ def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_3(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_4(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6804,11 +7245,12 @@ def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_4(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_5(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6821,11 +7263,12 @@ def test_list_hex_binary_pattern_3_nistxml_sv_iv_list_hex_binary_pattern_4_5(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_1(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6837,11 +7280,12 @@ def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_1(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_2(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6853,11 +7297,12 @@ def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_2(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_3(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6869,11 +7314,12 @@ def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_3(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_4(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6885,11 +7331,12 @@ def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_4(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_5(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6901,11 +7348,12 @@ def test_list_hex_binary_pattern_2_nistxml_sv_iv_list_hex_binary_pattern_3_5(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_1(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6918,11 +7366,12 @@ def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_1(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_2(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6935,11 +7384,12 @@ def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_2(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_3(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6952,11 +7402,12 @@ def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_3(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_4(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6969,11 +7420,12 @@ def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_4(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_5(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -6986,11 +7438,12 @@ def test_list_hex_binary_pattern_1_nistxml_sv_iv_list_hex_binary_pattern_2_5(sav
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_1(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -7003,11 +7456,12 @@ def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_1(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_2(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -7020,11 +7474,12 @@ def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_2(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_3(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -7037,11 +7492,12 @@ def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_3(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_4(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -7054,11 +7510,12 @@ def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_4(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_5(save_xml):
     """
     Type list/hexBinary is restricted by facet pattern with value
@@ -7071,11 +7528,12 @@ def test_list_hex_binary_pattern_nistxml_sv_iv_list_hex_binary_pattern_1_5(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_1(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 10.
@@ -7086,11 +7544,12 @@ def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_1(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_2(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 10.
@@ -7101,11 +7560,12 @@ def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_2(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_3(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 10.
@@ -7116,11 +7576,12 @@ def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_3(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_4(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 10.
@@ -7131,11 +7592,12 @@ def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_4(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_5(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 10.
@@ -7146,11 +7608,12 @@ def test_list_hex_binary_length_4_nistxml_sv_iv_list_hex_binary_length_5_5(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_1(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 8.
@@ -7161,11 +7624,12 @@ def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_1(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_2(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 8.
@@ -7176,11 +7640,12 @@ def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_2(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_3(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 8.
@@ -7191,11 +7656,12 @@ def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_3(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_4(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 8.
@@ -7206,11 +7672,12 @@ def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_4(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_5(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 8.
@@ -7221,11 +7688,12 @@ def test_list_hex_binary_length_3_nistxml_sv_iv_list_hex_binary_length_4_5(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_1(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 7.
@@ -7236,11 +7704,12 @@ def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_1(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_2(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 7.
@@ -7251,11 +7720,12 @@ def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_2(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_3(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 7.
@@ -7266,11 +7736,12 @@ def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_3(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_4(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 7.
@@ -7281,11 +7752,12 @@ def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_4(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_5(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 7.
@@ -7296,11 +7768,12 @@ def test_list_hex_binary_length_2_nistxml_sv_iv_list_hex_binary_length_3_5(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_1(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 6.
@@ -7311,11 +7784,12 @@ def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_1(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_2(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 6.
@@ -7326,11 +7800,12 @@ def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_2(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_3(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 6.
@@ -7341,11 +7816,12 @@ def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_3(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_4(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 6.
@@ -7356,11 +7832,12 @@ def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_4(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_5(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 6.
@@ -7371,11 +7848,12 @@ def test_list_hex_binary_length_1_nistxml_sv_iv_list_hex_binary_length_2_5(save_
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_1(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 5.
@@ -7386,11 +7864,12 @@ def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_1(save_xm
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_2(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 5.
@@ -7401,11 +7880,12 @@ def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_2(save_xm
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_3(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 5.
@@ -7416,11 +7896,12 @@ def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_3(save_xm
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_4(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 5.
@@ -7431,11 +7912,12 @@ def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_4(save_xm
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_5(save_xml):
     """
     Type list/hexBinary is restricted by facet length with value 5.
@@ -7446,11 +7928,12 @@ def test_list_hex_binary_length_nistxml_sv_iv_list_hex_binary_length_1_5(save_xm
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5_1(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 10.
@@ -7461,11 +7944,12 @@ def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5_2(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 10.
@@ -7476,11 +7960,12 @@ def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5_3(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 10.
@@ -7491,11 +7976,12 @@ def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5_4(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 10.
@@ -7506,11 +7992,12 @@ def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5_5(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 10.
@@ -7521,11 +8008,12 @@ def test_list_hex_binary_min_length_4_nistxml_sv_iv_list_hex_binary_min_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4_1(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 8.
@@ -7536,11 +8024,12 @@ def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4_2(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 8.
@@ -7551,11 +8040,12 @@ def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4_3(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 8.
@@ -7566,11 +8056,12 @@ def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4_4(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 8.
@@ -7581,11 +8072,12 @@ def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4_5(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 8.
@@ -7596,11 +8088,12 @@ def test_list_hex_binary_min_length_3_nistxml_sv_iv_list_hex_binary_min_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3_1(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 7.
@@ -7611,11 +8104,12 @@ def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3_2(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 7.
@@ -7626,11 +8120,12 @@ def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3_3(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 7.
@@ -7641,11 +8136,12 @@ def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3_4(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 7.
@@ -7656,11 +8152,12 @@ def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3_5(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 7.
@@ -7671,11 +8168,12 @@ def test_list_hex_binary_min_length_2_nistxml_sv_iv_list_hex_binary_min_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2_1(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 6.
@@ -7686,11 +8184,12 @@ def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2_2(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 6.
@@ -7701,11 +8200,12 @@ def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2_3(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 6.
@@ -7716,11 +8216,12 @@ def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2_4(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 6.
@@ -7731,11 +8232,12 @@ def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2_5(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 6.
@@ -7746,11 +8248,12 @@ def test_list_hex_binary_min_length_1_nistxml_sv_iv_list_hex_binary_min_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_1(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 5.
@@ -7761,11 +8264,12 @@ def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_2(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 5.
@@ -7776,11 +8280,12 @@ def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_3(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 5.
@@ -7791,11 +8296,12 @@ def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_4(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 5.
@@ -7806,11 +8312,12 @@ def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_5(save_xml):
     """
     Type list/hexBinary is restricted by facet minLength with value 5.
@@ -7821,11 +8328,12 @@ def test_list_hex_binary_min_length_nistxml_sv_iv_list_hex_binary_min_length_1_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5_1(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 10.
@@ -7836,11 +8344,12 @@ def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5_2(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 10.
@@ -7851,11 +8360,12 @@ def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5_3(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 10.
@@ -7866,11 +8376,12 @@ def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5_4(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 10.
@@ -7881,11 +8392,12 @@ def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5_5(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 10.
@@ -7896,11 +8408,12 @@ def test_list_hex_binary_max_length_4_nistxml_sv_iv_list_hex_binary_max_length_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4_1(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 8.
@@ -7911,11 +8424,12 @@ def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4_2(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 8.
@@ -7926,11 +8440,12 @@ def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4_3(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 8.
@@ -7941,11 +8456,12 @@ def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4_4(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 8.
@@ -7956,11 +8472,12 @@ def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4_5(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 8.
@@ -7971,11 +8488,12 @@ def test_list_hex_binary_max_length_3_nistxml_sv_iv_list_hex_binary_max_length_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3_1(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 7.
@@ -7986,11 +8504,12 @@ def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3_2(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 7.
@@ -8001,11 +8520,12 @@ def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3_3(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 7.
@@ -8016,11 +8536,12 @@ def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3_4(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 7.
@@ -8031,11 +8552,12 @@ def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3_5(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 7.
@@ -8046,11 +8568,12 @@ def test_list_hex_binary_max_length_2_nistxml_sv_iv_list_hex_binary_max_length_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2_1(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 6.
@@ -8061,11 +8584,12 @@ def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2_2(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 6.
@@ -8076,11 +8600,12 @@ def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2_3(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 6.
@@ -8091,11 +8616,12 @@ def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2_4(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 6.
@@ -8106,11 +8632,12 @@ def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2_5(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 6.
@@ -8121,11 +8648,12 @@ def test_list_hex_binary_max_length_1_nistxml_sv_iv_list_hex_binary_max_length_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_1(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 5.
@@ -8136,11 +8664,12 @@ def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_1
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_2(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 5.
@@ -8151,11 +8680,12 @@ def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_2
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_3(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 5.
@@ -8166,11 +8696,12 @@ def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_3
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_4(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 5.
@@ -8181,11 +8712,12 @@ def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_4
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_5(save_xml):
     """
     Type list/hexBinary is restricted by facet maxLength with value 5.
@@ -8196,11 +8728,12 @@ def test_list_hex_binary_max_length_nistxml_sv_iv_list_hex_binary_max_length_1_5
         instance="nistData/list/hexBinary/Schema+Instance/NISTXML-SV-IV-list-hexBinary-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListHexBinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_space_1_1(save_xml):
     """
     Type list/base64Binary is restricted by facet whiteSpace with value
@@ -8212,11 +8745,12 @@ def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_space_1_2(save_xml):
     """
     Type list/base64Binary is restricted by facet whiteSpace with value
@@ -8228,11 +8762,12 @@ def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_space_1_3(save_xml):
     """
     Type list/base64Binary is restricted by facet whiteSpace with value
@@ -8244,11 +8779,12 @@ def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_space_1_4(save_xml):
     """
     Type list/base64Binary is restricted by facet whiteSpace with value
@@ -8260,11 +8796,12 @@ def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_space_1_5(save_xml):
     """
     Type list/base64Binary is restricted by facet whiteSpace with value
@@ -8276,11 +8813,12 @@ def test_list_base64_binary_white_space_nistxml_sv_iv_list_base64_binary_white_s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enumeration_5_1(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8291,11 +8829,12 @@ def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enumeration_5_2(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8306,11 +8845,12 @@ def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enumeration_5_3(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8321,11 +8861,12 @@ def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enumeration_5_4(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8336,11 +8877,12 @@ def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enumeration_5_5(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8351,11 +8893,12 @@ def test_list_base64_binary_enumeration_4_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enumeration_4_1(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8366,11 +8909,12 @@ def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enumeration_4_2(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8381,11 +8925,12 @@ def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enumeration_4_3(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8396,11 +8941,12 @@ def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enumeration_4_4(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8411,11 +8957,12 @@ def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enumeration_4_5(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8426,11 +8973,12 @@ def test_list_base64_binary_enumeration_3_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enumeration_3_1(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8441,11 +8989,12 @@ def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enumeration_3_2(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8456,11 +9005,12 @@ def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enumeration_3_3(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8471,11 +9021,12 @@ def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enumeration_3_4(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8486,11 +9037,12 @@ def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enumeration_3_5(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8501,11 +9053,12 @@ def test_list_base64_binary_enumeration_2_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enumeration_2_1(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8516,11 +9069,12 @@ def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enumeration_2_2(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8531,11 +9085,12 @@ def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enumeration_2_3(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8546,11 +9101,12 @@ def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enumeration_2_4(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8561,11 +9117,12 @@ def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enumeration_2_5(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8576,11 +9133,12 @@ def test_list_base64_binary_enumeration_1_nistxml_sv_iv_list_base64_binary_enume
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumeration_1_1(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8591,11 +9149,12 @@ def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumera
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumeration_1_2(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8606,11 +9165,12 @@ def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumera
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumeration_1_3(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8621,11 +9181,12 @@ def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumera
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumeration_1_4(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8636,11 +9197,12 @@ def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumera
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumeration_1_5(save_xml):
     """
     Type list/base64Binary is restricted by facet enumeration.
@@ -8651,11 +9213,12 @@ def test_list_base64_binary_enumeration_nistxml_sv_iv_list_base64_binary_enumera
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5_1(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8669,11 +9232,12 @@ def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5_2(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8687,11 +9251,12 @@ def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5_3(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8705,11 +9270,12 @@ def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5_4(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8723,11 +9289,12 @@ def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5_5(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8741,11 +9308,12 @@ def test_list_base64_binary_pattern_4_nistxml_sv_iv_list_base64_binary_pattern_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4_1(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8759,11 +9327,12 @@ def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4_2(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8777,11 +9346,12 @@ def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4_3(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8795,11 +9365,12 @@ def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4_4(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8813,11 +9384,12 @@ def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4_5(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8831,11 +9403,12 @@ def test_list_base64_binary_pattern_3_nistxml_sv_iv_list_base64_binary_pattern_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3_1(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8849,11 +9422,12 @@ def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3_2(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8867,11 +9441,12 @@ def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3_3(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8885,11 +9460,12 @@ def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3_4(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8903,11 +9479,12 @@ def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3_5(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8921,11 +9498,12 @@ def test_list_base64_binary_pattern_2_nistxml_sv_iv_list_base64_binary_pattern_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2_1(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8939,11 +9517,12 @@ def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2_2(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8957,11 +9536,12 @@ def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2_3(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8975,11 +9555,12 @@ def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2_4(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -8993,11 +9574,12 @@ def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2_5(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -9011,11 +9593,12 @@ def test_list_base64_binary_pattern_1_nistxml_sv_iv_list_base64_binary_pattern_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_1(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -9028,11 +9611,12 @@ def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_1
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_2(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -9045,11 +9629,12 @@ def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_3(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -9062,11 +9647,12 @@ def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_4(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -9079,11 +9665,12 @@ def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_5(save_xml):
     """
     Type list/base64Binary is restricted by facet pattern with value
@@ -9096,11 +9683,12 @@ def test_list_base64_binary_pattern_nistxml_sv_iv_list_base64_binary_pattern_1_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_1(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 10.
@@ -9111,11 +9699,12 @@ def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_1
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_2(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 10.
@@ -9126,11 +9715,12 @@ def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_3(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 10.
@@ -9141,11 +9731,12 @@ def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_4(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 10.
@@ -9156,11 +9747,12 @@ def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_5(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 10.
@@ -9171,11 +9763,12 @@ def test_list_base64_binary_length_4_nistxml_sv_iv_list_base64_binary_length_5_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_1(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 8.
@@ -9186,11 +9779,12 @@ def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_1
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_2(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 8.
@@ -9201,11 +9795,12 @@ def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_3(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 8.
@@ -9216,11 +9811,12 @@ def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_4(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 8.
@@ -9231,11 +9827,12 @@ def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_5(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 8.
@@ -9246,11 +9843,12 @@ def test_list_base64_binary_length_3_nistxml_sv_iv_list_base64_binary_length_4_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_1(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 7.
@@ -9261,11 +9859,12 @@ def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_1
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_2(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 7.
@@ -9276,11 +9875,12 @@ def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_3(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 7.
@@ -9291,11 +9891,12 @@ def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_4(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 7.
@@ -9306,11 +9907,12 @@ def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_5(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 7.
@@ -9321,11 +9923,12 @@ def test_list_base64_binary_length_2_nistxml_sv_iv_list_base64_binary_length_3_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_1(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 6.
@@ -9336,11 +9939,12 @@ def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_1
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_2(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 6.
@@ -9351,11 +9955,12 @@ def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_2
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_3(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 6.
@@ -9366,11 +9971,12 @@ def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_3
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_4(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 6.
@@ -9381,11 +9987,12 @@ def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_4
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_5(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 6.
@@ -9396,11 +10003,12 @@ def test_list_base64_binary_length_1_nistxml_sv_iv_list_base64_binary_length_2_5
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_1(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 5.
@@ -9411,11 +10019,12 @@ def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_1(s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_2(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 5.
@@ -9426,11 +10035,12 @@ def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_2(s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_3(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 5.
@@ -9441,11 +10051,12 @@ def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_3(s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_4(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 5.
@@ -9456,11 +10067,12 @@ def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_4(s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_5(save_xml):
     """
     Type list/base64Binary is restricted by facet length with value 5.
@@ -9471,11 +10083,12 @@ def test_list_base64_binary_length_nistxml_sv_iv_list_base64_binary_length_1_5(s
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_length_5_1(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 10.
@@ -9486,11 +10099,12 @@ def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_length_5_2(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 10.
@@ -9501,11 +10115,12 @@ def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_length_5_3(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 10.
@@ -9516,11 +10131,12 @@ def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_length_5_4(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 10.
@@ -9531,11 +10147,12 @@ def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_length_5_5(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 10.
@@ -9546,11 +10163,12 @@ def test_list_base64_binary_min_length_4_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_length_4_1(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 8.
@@ -9561,11 +10179,12 @@ def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_length_4_2(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 8.
@@ -9576,11 +10195,12 @@ def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_length_4_3(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 8.
@@ -9591,11 +10211,12 @@ def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_length_4_4(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 8.
@@ -9606,11 +10227,12 @@ def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_length_4_5(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 8.
@@ -9621,11 +10243,12 @@ def test_list_base64_binary_min_length_3_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_length_3_1(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 7.
@@ -9636,11 +10259,12 @@ def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_length_3_2(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 7.
@@ -9651,11 +10275,12 @@ def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_length_3_3(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 7.
@@ -9666,11 +10291,12 @@ def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_length_3_4(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 7.
@@ -9681,11 +10307,12 @@ def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_length_3_5(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 7.
@@ -9696,11 +10323,12 @@ def test_list_base64_binary_min_length_2_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_length_2_1(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 6.
@@ -9711,11 +10339,12 @@ def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_length_2_2(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 6.
@@ -9726,11 +10355,12 @@ def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_length_2_3(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 6.
@@ -9741,11 +10371,12 @@ def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_length_2_4(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 6.
@@ -9756,11 +10387,12 @@ def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_length_2_5(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 6.
@@ -9771,11 +10403,12 @@ def test_list_base64_binary_min_length_1_nistxml_sv_iv_list_base64_binary_min_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_length_1_1(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 5.
@@ -9786,11 +10419,12 @@ def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_length_1_2(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 5.
@@ -9801,11 +10435,12 @@ def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_length_1_3(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 5.
@@ -9816,11 +10451,12 @@ def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_length_1_4(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 5.
@@ -9831,11 +10467,12 @@ def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_length_1_5(save_xml):
     """
     Type list/base64Binary is restricted by facet minLength with value 5.
@@ -9846,11 +10483,12 @@ def test_list_base64_binary_min_length_nistxml_sv_iv_list_base64_binary_min_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_length_5_1(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 10.
@@ -9861,11 +10499,12 @@ def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_length_5_2(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 10.
@@ -9876,11 +10515,12 @@ def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_length_5_3(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 10.
@@ -9891,11 +10531,12 @@ def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_length_5_4(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 10.
@@ -9906,11 +10547,12 @@ def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_length_5_5(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 10.
@@ -9921,11 +10563,12 @@ def test_list_base64_binary_max_length_4_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_length_4_1(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 8.
@@ -9936,11 +10579,12 @@ def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_length_4_2(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 8.
@@ -9951,11 +10595,12 @@ def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_length_4_3(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 8.
@@ -9966,11 +10611,12 @@ def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_length_4_4(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 8.
@@ -9981,11 +10627,12 @@ def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_length_4_5(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 8.
@@ -9996,11 +10643,12 @@ def test_list_base64_binary_max_length_3_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_length_3_1(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 7.
@@ -10011,11 +10659,12 @@ def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_length_3_2(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 7.
@@ -10026,11 +10675,12 @@ def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_length_3_3(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 7.
@@ -10041,11 +10691,12 @@ def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_length_3_4(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 7.
@@ -10056,11 +10707,12 @@ def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_length_3_5(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 7.
@@ -10071,11 +10723,12 @@ def test_list_base64_binary_max_length_2_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_length_2_1(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 6.
@@ -10086,11 +10739,12 @@ def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_length_2_2(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 6.
@@ -10101,11 +10755,12 @@ def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_length_2_3(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 6.
@@ -10116,11 +10771,12 @@ def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_length_2_4(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 6.
@@ -10131,11 +10787,12 @@ def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_length_2_5(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 6.
@@ -10146,11 +10803,12 @@ def test_list_base64_binary_max_length_1_nistxml_sv_iv_list_base64_binary_max_le
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_length_1_1(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 5.
@@ -10161,11 +10819,12 @@ def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_length_1_2(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 5.
@@ -10176,11 +10835,12 @@ def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_length_1_3(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 5.
@@ -10191,11 +10851,12 @@ def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_length_1_4(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 5.
@@ -10206,11 +10867,12 @@ def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_length_1_5(save_xml):
     """
     Type list/base64Binary is restricted by facet maxLength with value 5.
@@ -10221,11 +10883,12 @@ def test_list_base64_binary_max_length_nistxml_sv_iv_list_base64_binary_max_leng
         instance="nistData/list/base64Binary/Schema+Instance/NISTXML-SV-IV-list-base64Binary-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBase64BinaryMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_1(save_xml):
     """
     Type list/boolean is restricted by facet whiteSpace with value
@@ -10237,11 +10900,12 @@ def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_2(save_xml):
     """
     Type list/boolean is restricted by facet whiteSpace with value
@@ -10253,11 +10917,12 @@ def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_3(save_xml):
     """
     Type list/boolean is restricted by facet whiteSpace with value
@@ -10269,11 +10934,12 @@ def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_4(save_xml):
     """
     Type list/boolean is restricted by facet whiteSpace with value
@@ -10285,11 +10951,12 @@ def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_5(save_xml):
     """
     Type list/boolean is restricted by facet whiteSpace with value
@@ -10301,11 +10968,12 @@ def test_list_boolean_white_space_nistxml_sv_iv_list_boolean_white_space_1_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_1(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10317,11 +10985,12 @@ def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_1(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_2(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10333,11 +11002,12 @@ def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_2(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_3(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10349,11 +11019,12 @@ def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_3(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_4(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10365,11 +11036,12 @@ def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_4(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_5(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10381,11 +11053,12 @@ def test_list_boolean_pattern_4_nistxml_sv_iv_list_boolean_pattern_5_5(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_1(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10397,11 +11070,12 @@ def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_1(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_2(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10413,11 +11087,12 @@ def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_2(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_3(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10429,11 +11104,12 @@ def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_3(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_4(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10445,11 +11121,12 @@ def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_4(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_5(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10461,11 +11138,12 @@ def test_list_boolean_pattern_3_nistxml_sv_iv_list_boolean_pattern_4_5(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_1(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10477,11 +11155,12 @@ def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_1(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_2(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10493,11 +11172,12 @@ def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_2(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_3(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10509,11 +11189,12 @@ def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_3(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_4(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10525,11 +11206,12 @@ def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_4(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_5(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10541,11 +11223,12 @@ def test_list_boolean_pattern_2_nistxml_sv_iv_list_boolean_pattern_3_5(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_1(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10557,11 +11240,12 @@ def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_1(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_2(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10573,11 +11257,12 @@ def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_2(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_3(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10589,11 +11274,12 @@ def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_3(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_4(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10605,11 +11291,12 @@ def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_4(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_5(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value [1]{1}
@@ -10621,11 +11308,12 @@ def test_list_boolean_pattern_1_nistxml_sv_iv_list_boolean_pattern_2_5(save_xml)
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_1(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value true
@@ -10637,11 +11325,12 @@ def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_1(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_2(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value true
@@ -10653,11 +11342,12 @@ def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_2(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_3(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value true
@@ -10669,11 +11359,12 @@ def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_3(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_4(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value true
@@ -10685,11 +11376,12 @@ def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_4(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_5(save_xml):
     """
     Type list/boolean is restricted by facet pattern with value true
@@ -10701,11 +11393,12 @@ def test_list_boolean_pattern_nistxml_sv_iv_list_boolean_pattern_1_5(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_1(save_xml):
     """
     Type list/boolean is restricted by facet length with value 10.
@@ -10716,11 +11409,12 @@ def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_1(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_2(save_xml):
     """
     Type list/boolean is restricted by facet length with value 10.
@@ -10731,11 +11425,12 @@ def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_2(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_3(save_xml):
     """
     Type list/boolean is restricted by facet length with value 10.
@@ -10746,11 +11441,12 @@ def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_3(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_4(save_xml):
     """
     Type list/boolean is restricted by facet length with value 10.
@@ -10761,11 +11457,12 @@ def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_4(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_5(save_xml):
     """
     Type list/boolean is restricted by facet length with value 10.
@@ -10776,11 +11473,12 @@ def test_list_boolean_length_4_nistxml_sv_iv_list_boolean_length_5_5(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_1(save_xml):
     """
     Type list/boolean is restricted by facet length with value 8.
@@ -10791,11 +11489,12 @@ def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_1(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_2(save_xml):
     """
     Type list/boolean is restricted by facet length with value 8.
@@ -10806,11 +11505,12 @@ def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_2(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_3(save_xml):
     """
     Type list/boolean is restricted by facet length with value 8.
@@ -10821,11 +11521,12 @@ def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_3(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_4(save_xml):
     """
     Type list/boolean is restricted by facet length with value 8.
@@ -10836,11 +11537,12 @@ def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_4(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_5(save_xml):
     """
     Type list/boolean is restricted by facet length with value 8.
@@ -10851,11 +11553,12 @@ def test_list_boolean_length_3_nistxml_sv_iv_list_boolean_length_4_5(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_1(save_xml):
     """
     Type list/boolean is restricted by facet length with value 7.
@@ -10866,11 +11569,12 @@ def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_1(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_2(save_xml):
     """
     Type list/boolean is restricted by facet length with value 7.
@@ -10881,11 +11585,12 @@ def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_2(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_3(save_xml):
     """
     Type list/boolean is restricted by facet length with value 7.
@@ -10896,11 +11601,12 @@ def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_3(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_4(save_xml):
     """
     Type list/boolean is restricted by facet length with value 7.
@@ -10911,11 +11617,12 @@ def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_4(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_5(save_xml):
     """
     Type list/boolean is restricted by facet length with value 7.
@@ -10926,11 +11633,12 @@ def test_list_boolean_length_2_nistxml_sv_iv_list_boolean_length_3_5(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_1(save_xml):
     """
     Type list/boolean is restricted by facet length with value 6.
@@ -10941,11 +11649,12 @@ def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_1(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_2(save_xml):
     """
     Type list/boolean is restricted by facet length with value 6.
@@ -10956,11 +11665,12 @@ def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_2(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_3(save_xml):
     """
     Type list/boolean is restricted by facet length with value 6.
@@ -10971,11 +11681,12 @@ def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_3(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_4(save_xml):
     """
     Type list/boolean is restricted by facet length with value 6.
@@ -10986,11 +11697,12 @@ def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_4(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_5(save_xml):
     """
     Type list/boolean is restricted by facet length with value 6.
@@ -11001,11 +11713,12 @@ def test_list_boolean_length_1_nistxml_sv_iv_list_boolean_length_2_5(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_1(save_xml):
     """
     Type list/boolean is restricted by facet length with value 5.
@@ -11016,11 +11729,12 @@ def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_1(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_2(save_xml):
     """
     Type list/boolean is restricted by facet length with value 5.
@@ -11031,11 +11745,12 @@ def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_2(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_3(save_xml):
     """
     Type list/boolean is restricted by facet length with value 5.
@@ -11046,11 +11761,12 @@ def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_3(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_4(save_xml):
     """
     Type list/boolean is restricted by facet length with value 5.
@@ -11061,11 +11777,12 @@ def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_4(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_5(save_xml):
     """
     Type list/boolean is restricted by facet length with value 5.
@@ -11076,11 +11793,12 @@ def test_list_boolean_length_nistxml_sv_iv_list_boolean_length_1_5(save_xml):
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_1(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 10.
@@ -11091,11 +11809,12 @@ def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_2(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 10.
@@ -11106,11 +11825,12 @@ def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_3(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 10.
@@ -11121,11 +11841,12 @@ def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_4(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 10.
@@ -11136,11 +11857,12 @@ def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_5(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 10.
@@ -11151,11 +11873,12 @@ def test_list_boolean_min_length_4_nistxml_sv_iv_list_boolean_min_length_5_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_1(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 8.
@@ -11166,11 +11889,12 @@ def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_2(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 8.
@@ -11181,11 +11905,12 @@ def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_3(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 8.
@@ -11196,11 +11921,12 @@ def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_4(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 8.
@@ -11211,11 +11937,12 @@ def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_5(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 8.
@@ -11226,11 +11953,12 @@ def test_list_boolean_min_length_3_nistxml_sv_iv_list_boolean_min_length_4_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_1(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 7.
@@ -11241,11 +11969,12 @@ def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_2(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 7.
@@ -11256,11 +11985,12 @@ def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_3(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 7.
@@ -11271,11 +12001,12 @@ def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_4(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 7.
@@ -11286,11 +12017,12 @@ def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_5(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 7.
@@ -11301,11 +12033,12 @@ def test_list_boolean_min_length_2_nistxml_sv_iv_list_boolean_min_length_3_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_1(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 6.
@@ -11316,11 +12049,12 @@ def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_2(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 6.
@@ -11331,11 +12065,12 @@ def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_3(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 6.
@@ -11346,11 +12081,12 @@ def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_4(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 6.
@@ -11361,11 +12097,12 @@ def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_5(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 6.
@@ -11376,11 +12113,12 @@ def test_list_boolean_min_length_1_nistxml_sv_iv_list_boolean_min_length_2_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_1(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 5.
@@ -11391,11 +12129,12 @@ def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_1(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_2(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 5.
@@ -11406,11 +12145,12 @@ def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_2(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_3(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 5.
@@ -11421,11 +12161,12 @@ def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_3(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_4(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 5.
@@ -11436,11 +12177,12 @@ def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_4(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_5(save_xml):
     """
     Type list/boolean is restricted by facet minLength with value 5.
@@ -11451,11 +12193,12 @@ def test_list_boolean_min_length_nistxml_sv_iv_list_boolean_min_length_1_5(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_1(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 10.
@@ -11466,11 +12209,12 @@ def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_2(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 10.
@@ -11481,11 +12225,12 @@ def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_3(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 10.
@@ -11496,11 +12241,12 @@ def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_4(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 10.
@@ -11511,11 +12257,12 @@ def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_5(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 10.
@@ -11526,11 +12273,12 @@ def test_list_boolean_max_length_4_nistxml_sv_iv_list_boolean_max_length_5_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_1(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 8.
@@ -11541,11 +12289,12 @@ def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_2(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 8.
@@ -11556,11 +12305,12 @@ def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_3(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 8.
@@ -11571,11 +12321,12 @@ def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_4(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 8.
@@ -11586,11 +12337,12 @@ def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_5(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 8.
@@ -11601,11 +12353,12 @@ def test_list_boolean_max_length_3_nistxml_sv_iv_list_boolean_max_length_4_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_1(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 7.
@@ -11616,11 +12369,12 @@ def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_2(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 7.
@@ -11631,11 +12385,12 @@ def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_3(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 7.
@@ -11646,11 +12401,12 @@ def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_4(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 7.
@@ -11661,11 +12417,12 @@ def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_5(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 7.
@@ -11676,11 +12433,12 @@ def test_list_boolean_max_length_2_nistxml_sv_iv_list_boolean_max_length_3_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_1(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 6.
@@ -11691,11 +12449,12 @@ def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_1(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_2(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 6.
@@ -11706,11 +12465,12 @@ def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_2(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_3(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 6.
@@ -11721,11 +12481,12 @@ def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_3(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_4(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 6.
@@ -11736,11 +12497,12 @@ def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_4(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_5(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 6.
@@ -11751,11 +12513,12 @@ def test_list_boolean_max_length_1_nistxml_sv_iv_list_boolean_max_length_2_5(sav
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_1(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 5.
@@ -11766,11 +12529,12 @@ def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_1(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_2(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 5.
@@ -11781,11 +12545,12 @@ def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_2(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_3(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 5.
@@ -11796,11 +12561,12 @@ def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_3(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_4(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 5.
@@ -11811,11 +12577,12 @@ def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_4(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_5(save_xml):
     """
     Type list/boolean is restricted by facet maxLength with value 5.
@@ -11826,11 +12593,12 @@ def test_list_boolean_max_length_nistxml_sv_iv_list_boolean_max_length_1_5(save_
         instance="nistData/list/boolean/Schema+Instance/NISTXML-SV-IV-list-boolean-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBooleanMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_1(save_xml):
     """
     Type list/QName is restricted by facet whiteSpace with value collapse.
@@ -11841,11 +12609,12 @@ def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_2(save_xml):
     """
     Type list/QName is restricted by facet whiteSpace with value collapse.
@@ -11856,11 +12625,12 @@ def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_3(save_xml):
     """
     Type list/QName is restricted by facet whiteSpace with value collapse.
@@ -11871,11 +12641,12 @@ def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_4(save_xml):
     """
     Type list/QName is restricted by facet whiteSpace with value collapse.
@@ -11886,11 +12657,12 @@ def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_5(save_xml):
     """
     Type list/QName is restricted by facet whiteSpace with value collapse.
@@ -11901,11 +12673,12 @@ def test_list_qname_white_space_nistxml_sv_iv_list_qname_white_space_1_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11916,11 +12689,12 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_1(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11931,11 +12705,12 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_2(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11946,11 +12721,12 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_3(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11961,11 +12737,12 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_4(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11976,11 +12753,12 @@ def test_list_qname_enumeration_4_nistxml_sv_iv_list_qname_enumeration_5_5(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -11991,11 +12769,12 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_1(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12006,11 +12785,12 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_2(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12021,11 +12801,12 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_3(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12036,11 +12817,12 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_4(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12051,11 +12833,12 @@ def test_list_qname_enumeration_3_nistxml_sv_iv_list_qname_enumeration_4_5(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12066,11 +12849,12 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_1(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12081,11 +12865,12 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_2(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12096,11 +12881,12 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_3(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12111,11 +12897,12 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_4(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12126,11 +12913,12 @@ def test_list_qname_enumeration_2_nistxml_sv_iv_list_qname_enumeration_3_5(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12141,11 +12929,12 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_1(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12156,11 +12945,12 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_2(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12171,11 +12961,12 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_3(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12186,11 +12977,12 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_4(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12201,11 +12993,12 @@ def test_list_qname_enumeration_1_nistxml_sv_iv_list_qname_enumeration_2_5(save_
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_1(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12216,11 +13009,12 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_2(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12231,11 +13025,12 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_3(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12246,11 +13041,12 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_4(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12261,11 +13057,12 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_5(save_xml):
     """
     Type list/QName is restricted by facet enumeration.
@@ -12276,11 +13073,12 @@ def test_list_qname_enumeration_nistxml_sv_iv_list_qname_enumeration_1_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_1(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12297,11 +13095,12 @@ def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_2(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12318,11 +13117,12 @@ def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_3(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12339,11 +13139,12 @@ def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_4(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12360,11 +13161,12 @@ def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_5(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12381,11 +13183,12 @@ def test_list_qname_pattern_4_nistxml_sv_iv_list_qname_pattern_5_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_1(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12403,11 +13206,12 @@ def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_2(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12425,11 +13229,12 @@ def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_3(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12447,11 +13252,12 @@ def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_4(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12469,11 +13275,12 @@ def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_5(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12491,11 +13298,12 @@ def test_list_qname_pattern_3_nistxml_sv_iv_list_qname_pattern_4_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_1(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12511,11 +13319,12 @@ def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_2(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12531,11 +13340,12 @@ def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_3(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12551,11 +13361,12 @@ def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_4(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12571,11 +13382,12 @@ def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_5(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12591,11 +13403,12 @@ def test_list_qname_pattern_2_nistxml_sv_iv_list_qname_pattern_3_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_1(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12616,11 +13429,12 @@ def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_2(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12641,11 +13455,12 @@ def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_3(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12666,11 +13481,12 @@ def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_4(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12691,11 +13507,12 @@ def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_5(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12716,11 +13533,12 @@ def test_list_qname_pattern_1_nistxml_sv_iv_list_qname_pattern_2_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_1(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12738,11 +13556,12 @@ def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_2(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12760,11 +13579,12 @@ def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_3(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12782,11 +13602,12 @@ def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_4(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12804,11 +13625,12 @@ def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_5(save_xml):
     r"""
     Type list/QName is restricted by facet pattern with value
@@ -12826,11 +13648,12 @@ def test_list_qname_pattern_nistxml_sv_iv_list_qname_pattern_1_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -12841,11 +13664,12 @@ def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -12856,11 +13680,12 @@ def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -12871,11 +13696,12 @@ def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -12886,11 +13712,12 @@ def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 10.
@@ -12901,11 +13728,12 @@ def test_list_qname_length_4_nistxml_sv_iv_list_qname_length_5_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -12916,11 +13744,12 @@ def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -12931,11 +13760,12 @@ def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -12946,11 +13776,12 @@ def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -12961,11 +13792,12 @@ def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 8.
@@ -12976,11 +13808,12 @@ def test_list_qname_length_3_nistxml_sv_iv_list_qname_length_4_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -12991,11 +13824,12 @@ def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -13006,11 +13840,12 @@ def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -13021,11 +13856,12 @@ def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -13036,11 +13872,12 @@ def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 7.
@@ -13051,11 +13888,12 @@ def test_list_qname_length_2_nistxml_sv_iv_list_qname_length_3_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -13066,11 +13904,12 @@ def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -13081,11 +13920,12 @@ def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -13096,11 +13936,12 @@ def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -13111,11 +13952,12 @@ def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 6.
@@ -13126,11 +13968,12 @@ def test_list_qname_length_1_nistxml_sv_iv_list_qname_length_2_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_1(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -13141,11 +13984,12 @@ def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_1(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_2(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -13156,11 +14000,12 @@ def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_2(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_3(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -13171,11 +14016,12 @@ def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_3(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_4(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -13186,11 +14032,12 @@ def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_4(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_5(save_xml):
     """
     Type list/QName is restricted by facet length with value 5.
@@ -13201,11 +14048,12 @@ def test_list_qname_length_nistxml_sv_iv_list_qname_length_1_5(save_xml):
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -13216,11 +14064,12 @@ def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -13231,11 +14080,12 @@ def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -13246,11 +14096,12 @@ def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -13261,11 +14112,12 @@ def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 10.
@@ -13276,11 +14128,12 @@ def test_list_qname_min_length_4_nistxml_sv_iv_list_qname_min_length_5_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -13291,11 +14144,12 @@ def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -13306,11 +14160,12 @@ def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -13321,11 +14176,12 @@ def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -13336,11 +14192,12 @@ def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 8.
@@ -13351,11 +14208,12 @@ def test_list_qname_min_length_3_nistxml_sv_iv_list_qname_min_length_4_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -13366,11 +14224,12 @@ def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -13381,11 +14240,12 @@ def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -13396,11 +14256,12 @@ def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -13411,11 +14272,12 @@ def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 7.
@@ -13426,11 +14288,12 @@ def test_list_qname_min_length_2_nistxml_sv_iv_list_qname_min_length_3_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -13441,11 +14304,12 @@ def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -13456,11 +14320,12 @@ def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -13471,11 +14336,12 @@ def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -13486,11 +14352,12 @@ def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 6.
@@ -13501,11 +14368,12 @@ def test_list_qname_min_length_1_nistxml_sv_iv_list_qname_min_length_2_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_1(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -13516,11 +14384,12 @@ def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_1(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_2(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -13531,11 +14400,12 @@ def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_2(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_3(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -13546,11 +14416,12 @@ def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_3(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_4(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -13561,11 +14432,12 @@ def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_4(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_5(save_xml):
     """
     Type list/QName is restricted by facet minLength with value 5.
@@ -13576,11 +14448,12 @@ def test_list_qname_min_length_nistxml_sv_iv_list_qname_min_length_1_5(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -13591,11 +14464,12 @@ def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -13606,11 +14480,12 @@ def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -13621,11 +14496,12 @@ def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -13636,11 +14512,12 @@ def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 10.
@@ -13651,11 +14528,12 @@ def test_list_qname_max_length_4_nistxml_sv_iv_list_qname_max_length_5_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -13666,11 +14544,12 @@ def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -13681,11 +14560,12 @@ def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -13696,11 +14576,12 @@ def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -13711,11 +14592,12 @@ def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 8.
@@ -13726,11 +14608,12 @@ def test_list_qname_max_length_3_nistxml_sv_iv_list_qname_max_length_4_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -13741,11 +14624,12 @@ def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -13756,11 +14640,12 @@ def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -13771,11 +14656,12 @@ def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -13786,11 +14672,12 @@ def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 7.
@@ -13801,11 +14688,12 @@ def test_list_qname_max_length_2_nistxml_sv_iv_list_qname_max_length_3_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -13816,11 +14704,12 @@ def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_1(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -13831,11 +14720,12 @@ def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_2(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -13846,11 +14736,12 @@ def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_3(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -13861,11 +14752,12 @@ def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_4(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 6.
@@ -13876,11 +14768,12 @@ def test_list_qname_max_length_1_nistxml_sv_iv_list_qname_max_length_2_5(save_xm
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_1(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -13891,11 +14784,12 @@ def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_1(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_2(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -13906,11 +14800,12 @@ def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_2(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_3(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -13921,11 +14816,12 @@ def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_3(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_4(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -13936,11 +14832,12 @@ def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_4(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_5(save_xml):
     """
     Type list/QName is restricted by facet maxLength with value 5.
@@ -13951,11 +14848,12 @@ def test_list_qname_max_length_nistxml_sv_iv_list_qname_max_length_1_5(save_xml)
         instance="nistData/list/QName/Schema+Instance/NISTXML-SV-IV-list-QName-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListQnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet whiteSpace with value
@@ -13967,11 +14865,12 @@ def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet whiteSpace with value
@@ -13983,11 +14882,12 @@ def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet whiteSpace with value
@@ -13999,11 +14899,12 @@ def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet whiteSpace with value
@@ -14015,11 +14916,12 @@ def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet whiteSpace with value
@@ -14031,11 +14933,12 @@ def test_list_any_uri_white_space_nistxml_sv_iv_list_any_uri_white_space_1_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14046,11 +14949,12 @@ def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14061,11 +14965,12 @@ def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14076,11 +14981,12 @@ def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14091,11 +14997,12 @@ def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14106,11 +15013,12 @@ def test_list_any_uri_enumeration_4_nistxml_sv_iv_list_any_uri_enumeration_5_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14121,11 +15029,12 @@ def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14136,11 +15045,12 @@ def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14151,11 +15061,12 @@ def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14166,11 +15077,12 @@ def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14181,11 +15093,12 @@ def test_list_any_uri_enumeration_3_nistxml_sv_iv_list_any_uri_enumeration_4_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14196,11 +15109,12 @@ def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14211,11 +15125,12 @@ def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14226,11 +15141,12 @@ def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14241,11 +15157,12 @@ def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14256,11 +15173,12 @@ def test_list_any_uri_enumeration_2_nistxml_sv_iv_list_any_uri_enumeration_3_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14271,11 +15189,12 @@ def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_1(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14286,11 +15205,12 @@ def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_2(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14301,11 +15221,12 @@ def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_3(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14316,11 +15237,12 @@ def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_4(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14331,11 +15253,12 @@ def test_list_any_uri_enumeration_1_nistxml_sv_iv_list_any_uri_enumeration_2_5(s
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14346,11 +15269,12 @@ def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14361,11 +15285,12 @@ def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14376,11 +15301,12 @@ def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14391,11 +15317,12 @@ def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet enumeration.
@@ -14406,11 +15333,12 @@ def test_list_any_uri_enumeration_nistxml_sv_iv_list_any_uri_enumeration_1_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14425,11 +15353,12 @@ def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14444,11 +15373,12 @@ def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14463,11 +15393,12 @@ def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14482,11 +15413,12 @@ def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14501,11 +15433,12 @@ def test_list_any_uri_pattern_4_nistxml_sv_iv_list_any_uri_pattern_5_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14521,11 +15454,12 @@ def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14541,11 +15475,12 @@ def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14561,11 +15496,12 @@ def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14581,11 +15517,12 @@ def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14601,11 +15538,12 @@ def test_list_any_uri_pattern_3_nistxml_sv_iv_list_any_uri_pattern_4_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14620,11 +15558,12 @@ def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14639,11 +15578,12 @@ def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14658,11 +15598,12 @@ def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14677,11 +15618,12 @@ def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14696,11 +15638,12 @@ def test_list_any_uri_pattern_2_nistxml_sv_iv_list_any_uri_pattern_3_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14715,11 +15658,12 @@ def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_1(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14734,11 +15678,12 @@ def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_2(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14753,11 +15698,12 @@ def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_3(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14772,11 +15718,12 @@ def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_4(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14791,11 +15738,12 @@ def test_list_any_uri_pattern_1_nistxml_sv_iv_list_any_uri_pattern_2_5(save_xml)
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_1(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14811,11 +15759,12 @@ def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_2(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14831,11 +15780,12 @@ def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_3(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14851,11 +15801,12 @@ def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_4(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14871,11 +15822,12 @@ def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_5(save_xml):
     r"""
     Type list/anyURI is restricted by facet pattern with value
@@ -14891,11 +15843,12 @@ def test_list_any_uri_pattern_nistxml_sv_iv_list_any_uri_pattern_1_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -14906,11 +15859,12 @@ def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -14921,11 +15875,12 @@ def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -14936,11 +15891,12 @@ def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -14951,11 +15907,12 @@ def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 10.
@@ -14966,11 +15923,12 @@ def test_list_any_uri_length_4_nistxml_sv_iv_list_any_uri_length_5_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -14981,11 +15939,12 @@ def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -14996,11 +15955,12 @@ def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -15011,11 +15971,12 @@ def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -15026,11 +15987,12 @@ def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 8.
@@ -15041,11 +16003,12 @@ def test_list_any_uri_length_3_nistxml_sv_iv_list_any_uri_length_4_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -15056,11 +16019,12 @@ def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -15071,11 +16035,12 @@ def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -15086,11 +16051,12 @@ def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -15101,11 +16067,12 @@ def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 7.
@@ -15116,11 +16083,12 @@ def test_list_any_uri_length_2_nistxml_sv_iv_list_any_uri_length_3_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -15131,11 +16099,12 @@ def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -15146,11 +16115,12 @@ def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -15161,11 +16131,12 @@ def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -15176,11 +16147,12 @@ def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 6.
@@ -15191,11 +16163,12 @@ def test_list_any_uri_length_1_nistxml_sv_iv_list_any_uri_length_2_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -15206,11 +16179,12 @@ def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_1(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -15221,11 +16195,12 @@ def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_2(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -15236,11 +16211,12 @@ def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_3(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -15251,11 +16227,12 @@ def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_4(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet length with value 5.
@@ -15266,11 +16243,12 @@ def test_list_any_uri_length_nistxml_sv_iv_list_any_uri_length_1_5(save_xml):
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -15281,11 +16259,12 @@ def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -15296,11 +16275,12 @@ def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -15311,11 +16291,12 @@ def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -15326,11 +16307,12 @@ def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 10.
@@ -15341,11 +16323,12 @@ def test_list_any_uri_min_length_4_nistxml_sv_iv_list_any_uri_min_length_5_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -15356,11 +16339,12 @@ def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -15371,11 +16355,12 @@ def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -15386,11 +16371,12 @@ def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -15401,11 +16387,12 @@ def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 8.
@@ -15416,11 +16403,12 @@ def test_list_any_uri_min_length_3_nistxml_sv_iv_list_any_uri_min_length_4_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -15431,11 +16419,12 @@ def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -15446,11 +16435,12 @@ def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -15461,11 +16451,12 @@ def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -15476,11 +16467,12 @@ def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 7.
@@ -15491,11 +16483,12 @@ def test_list_any_uri_min_length_2_nistxml_sv_iv_list_any_uri_min_length_3_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -15506,11 +16499,12 @@ def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -15521,11 +16515,12 @@ def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -15536,11 +16531,12 @@ def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -15551,11 +16547,12 @@ def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 6.
@@ -15566,11 +16563,12 @@ def test_list_any_uri_min_length_1_nistxml_sv_iv_list_any_uri_min_length_2_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -15581,11 +16579,12 @@ def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_1(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -15596,11 +16595,12 @@ def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_2(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -15611,11 +16611,12 @@ def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_3(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -15626,11 +16627,12 @@ def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_4(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet minLength with value 5.
@@ -15641,6 +16643,6 @@ def test_list_any_uri_min_length_nistxml_sv_iv_list_any_uri_min_length_1_5(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_6000.py
+++ b/tests/test_nist_meta_6000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -11,11 +14,12 @@ def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -26,11 +30,12 @@ def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -41,11 +46,12 @@ def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -56,11 +62,12 @@ def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 10.
@@ -71,11 +78,12 @@ def test_list_any_uri_max_length_4_nistxml_sv_iv_list_any_uri_max_length_5_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -86,11 +94,12 @@ def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -101,11 +110,12 @@ def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -116,11 +126,12 @@ def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -131,11 +142,12 @@ def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 8.
@@ -146,11 +158,12 @@ def test_list_any_uri_max_length_3_nistxml_sv_iv_list_any_uri_max_length_4_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -161,11 +174,12 @@ def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -176,11 +190,12 @@ def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -191,11 +206,12 @@ def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -206,11 +222,12 @@ def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 7.
@@ -221,11 +238,12 @@ def test_list_any_uri_max_length_2_nistxml_sv_iv_list_any_uri_max_length_3_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -236,11 +254,12 @@ def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_1(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -251,11 +270,12 @@ def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_2(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -266,11 +286,12 @@ def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_3(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -281,11 +302,12 @@ def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_4(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 6.
@@ -296,11 +318,12 @@ def test_list_any_uri_max_length_1_nistxml_sv_iv_list_any_uri_max_length_2_5(sav
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_1(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -311,11 +334,12 @@ def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_1(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_2(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -326,11 +350,12 @@ def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_2(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_3(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -341,11 +366,12 @@ def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_3(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_4(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -356,11 +382,12 @@ def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_4(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_5(save_xml):
     """
     Type list/anyURI is restricted by facet maxLength with value 5.
@@ -371,11 +398,12 @@ def test_list_any_uri_max_length_nistxml_sv_iv_list_any_uri_max_length_1_5(save_
         instance="nistData/list/anyURI/Schema+Instance/NISTXML-SV-IV-list-anyURI-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListAnyUriMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_1(save_xml):
     """
     Type list/language is restricted by facet whiteSpace with value
@@ -387,11 +415,12 @@ def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_2(save_xml):
     """
     Type list/language is restricted by facet whiteSpace with value
@@ -403,11 +432,12 @@ def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_3(save_xml):
     """
     Type list/language is restricted by facet whiteSpace with value
@@ -419,11 +449,12 @@ def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_4(save_xml):
     """
     Type list/language is restricted by facet whiteSpace with value
@@ -435,11 +466,12 @@ def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_5(save_xml):
     """
     Type list/language is restricted by facet whiteSpace with value
@@ -451,11 +483,12 @@ def test_list_language_white_space_nistxml_sv_iv_list_language_white_space_1_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_1(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -466,11 +499,12 @@ def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_1
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_2(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -481,11 +515,12 @@ def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_2
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_3(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -496,11 +531,12 @@ def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_3
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_4(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -511,11 +547,12 @@ def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_4
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_5(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -526,11 +563,12 @@ def test_list_language_enumeration_4_nistxml_sv_iv_list_language_enumeration_5_5
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_1(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -541,11 +579,12 @@ def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_1
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_2(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -556,11 +595,12 @@ def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_2
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_3(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -571,11 +611,12 @@ def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_3
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_4(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -586,11 +627,12 @@ def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_4
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_5(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -601,11 +643,12 @@ def test_list_language_enumeration_3_nistxml_sv_iv_list_language_enumeration_4_5
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_1(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -616,11 +659,12 @@ def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_1
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_2(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -631,11 +675,12 @@ def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_2
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_3(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -646,11 +691,12 @@ def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_3
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_4(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -661,11 +707,12 @@ def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_4
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_5(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -676,11 +723,12 @@ def test_list_language_enumeration_2_nistxml_sv_iv_list_language_enumeration_3_5
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_1(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -691,11 +739,12 @@ def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_1
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_2(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -706,11 +755,12 @@ def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_2
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_3(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -721,11 +771,12 @@ def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_3
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_4(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -736,11 +787,12 @@ def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_4
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_5(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -751,11 +803,12 @@ def test_list_language_enumeration_1_nistxml_sv_iv_list_language_enumeration_2_5
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_1(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -766,11 +819,12 @@ def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_2(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -781,11 +835,12 @@ def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_3(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -796,11 +851,12 @@ def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_4(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -811,11 +867,12 @@ def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_5(save_xml):
     """
     Type list/language is restricted by facet enumeration.
@@ -826,11 +883,12 @@ def test_list_language_enumeration_nistxml_sv_iv_list_language_enumeration_1_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_1(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -849,11 +907,12 @@ def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_1(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_2(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -872,11 +931,12 @@ def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_2(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_3(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -895,11 +955,12 @@ def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_3(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_4(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -918,11 +979,12 @@ def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_4(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_5(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -941,11 +1003,12 @@ def test_list_language_pattern_4_nistxml_sv_iv_list_language_pattern_5_5(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_1(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -965,11 +1028,12 @@ def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_1(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_2(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -989,11 +1053,12 @@ def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_2(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_3(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1013,11 +1078,12 @@ def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_3(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_4(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1037,11 +1103,12 @@ def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_4(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_5(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1061,11 +1128,12 @@ def test_list_language_pattern_3_nistxml_sv_iv_list_language_pattern_4_5(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_1(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1085,11 +1153,12 @@ def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_1(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_2(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1109,11 +1178,12 @@ def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_2(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_3(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1133,11 +1203,12 @@ def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_3(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_4(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1157,11 +1228,12 @@ def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_4(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_5(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1181,11 +1253,12 @@ def test_list_language_pattern_2_nistxml_sv_iv_list_language_pattern_3_5(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_1(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1205,11 +1278,12 @@ def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_1(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_2(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1229,11 +1303,12 @@ def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_2(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_3(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1253,11 +1328,12 @@ def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_3(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_4(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1277,11 +1353,12 @@ def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_4(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_5(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1301,11 +1378,12 @@ def test_list_language_pattern_1_nistxml_sv_iv_list_language_pattern_2_5(save_xm
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_1(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1323,11 +1401,12 @@ def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_2(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1345,11 +1424,12 @@ def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_3(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1367,11 +1447,12 @@ def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_4(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1389,11 +1470,12 @@ def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_5(save_xml):
     """
     Type list/language is restricted by facet pattern with value
@@ -1411,11 +1493,12 @@ def test_list_language_pattern_nistxml_sv_iv_list_language_pattern_1_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguagePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_1(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -1426,11 +1509,12 @@ def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_2(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -1441,11 +1525,12 @@ def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_3(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -1456,11 +1541,12 @@ def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_4(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -1471,11 +1557,12 @@ def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_5(save_xml):
     """
     Type list/language is restricted by facet length with value 10.
@@ -1486,11 +1573,12 @@ def test_list_language_length_4_nistxml_sv_iv_list_language_length_5_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_1(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -1501,11 +1589,12 @@ def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_2(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -1516,11 +1605,12 @@ def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_3(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -1531,11 +1621,12 @@ def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_4(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -1546,11 +1637,12 @@ def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_5(save_xml):
     """
     Type list/language is restricted by facet length with value 8.
@@ -1561,11 +1653,12 @@ def test_list_language_length_3_nistxml_sv_iv_list_language_length_4_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_1(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -1576,11 +1669,12 @@ def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_2(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -1591,11 +1685,12 @@ def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_3(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -1606,11 +1701,12 @@ def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_4(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -1621,11 +1717,12 @@ def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_5(save_xml):
     """
     Type list/language is restricted by facet length with value 7.
@@ -1636,11 +1733,12 @@ def test_list_language_length_2_nistxml_sv_iv_list_language_length_3_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_1(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -1651,11 +1749,12 @@ def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_1(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_2(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -1666,11 +1765,12 @@ def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_2(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_3(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -1681,11 +1781,12 @@ def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_3(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_4(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -1696,11 +1797,12 @@ def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_4(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_5(save_xml):
     """
     Type list/language is restricted by facet length with value 6.
@@ -1711,11 +1813,12 @@ def test_list_language_length_1_nistxml_sv_iv_list_language_length_2_5(save_xml)
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_nistxml_sv_iv_list_language_length_1_1(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -1726,11 +1829,12 @@ def test_list_language_length_nistxml_sv_iv_list_language_length_1_1(save_xml):
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_nistxml_sv_iv_list_language_length_1_2(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -1741,11 +1845,12 @@ def test_list_language_length_nistxml_sv_iv_list_language_length_1_2(save_xml):
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_nistxml_sv_iv_list_language_length_1_3(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -1756,11 +1861,12 @@ def test_list_language_length_nistxml_sv_iv_list_language_length_1_3(save_xml):
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_nistxml_sv_iv_list_language_length_1_4(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -1771,11 +1877,12 @@ def test_list_language_length_nistxml_sv_iv_list_language_length_1_4(save_xml):
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_length_nistxml_sv_iv_list_language_length_1_5(save_xml):
     """
     Type list/language is restricted by facet length with value 5.
@@ -1786,11 +1893,12 @@ def test_list_language_length_nistxml_sv_iv_list_language_length_1_5(save_xml):
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -1801,11 +1909,12 @@ def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -1816,11 +1925,12 @@ def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -1831,11 +1941,12 @@ def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -1846,11 +1957,12 @@ def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 10.
@@ -1861,11 +1973,12 @@ def test_list_language_min_length_4_nistxml_sv_iv_list_language_min_length_5_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -1876,11 +1989,12 @@ def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -1891,11 +2005,12 @@ def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -1906,11 +2021,12 @@ def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -1921,11 +2037,12 @@ def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 8.
@@ -1936,11 +2053,12 @@ def test_list_language_min_length_3_nistxml_sv_iv_list_language_min_length_4_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -1951,11 +2069,12 @@ def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -1966,11 +2085,12 @@ def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -1981,11 +2101,12 @@ def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -1996,11 +2117,12 @@ def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 7.
@@ -2011,11 +2133,12 @@ def test_list_language_min_length_2_nistxml_sv_iv_list_language_min_length_3_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -2026,11 +2149,12 @@ def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -2041,11 +2165,12 @@ def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -2056,11 +2181,12 @@ def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -2071,11 +2197,12 @@ def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 6.
@@ -2086,11 +2213,12 @@ def test_list_language_min_length_1_nistxml_sv_iv_list_language_min_length_2_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_1(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -2101,11 +2229,12 @@ def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_1(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_2(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -2116,11 +2245,12 @@ def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_2(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_3(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -2131,11 +2261,12 @@ def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_3(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_4(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -2146,11 +2277,12 @@ def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_4(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_5(save_xml):
     """
     Type list/language is restricted by facet minLength with value 5.
@@ -2161,11 +2293,12 @@ def test_list_language_min_length_nistxml_sv_iv_list_language_min_length_1_5(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -2176,11 +2309,12 @@ def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -2191,11 +2325,12 @@ def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -2206,11 +2341,12 @@ def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -2221,11 +2357,12 @@ def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 10.
@@ -2236,11 +2373,12 @@ def test_list_language_max_length_4_nistxml_sv_iv_list_language_max_length_5_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -2251,11 +2389,12 @@ def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -2266,11 +2405,12 @@ def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -2281,11 +2421,12 @@ def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -2296,11 +2437,12 @@ def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 8.
@@ -2311,11 +2453,12 @@ def test_list_language_max_length_3_nistxml_sv_iv_list_language_max_length_4_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -2326,11 +2469,12 @@ def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -2341,11 +2485,12 @@ def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -2356,11 +2501,12 @@ def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -2371,11 +2517,12 @@ def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 7.
@@ -2386,11 +2533,12 @@ def test_list_language_max_length_2_nistxml_sv_iv_list_language_max_length_3_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -2401,11 +2549,12 @@ def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_1(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -2416,11 +2565,12 @@ def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_2(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -2431,11 +2581,12 @@ def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_3(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -2446,11 +2597,12 @@ def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_4(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 6.
@@ -2461,11 +2613,12 @@ def test_list_language_max_length_1_nistxml_sv_iv_list_language_max_length_2_5(s
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_1(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -2476,11 +2629,12 @@ def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_1(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_2(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -2491,11 +2645,12 @@ def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_2(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_3(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -2506,11 +2661,12 @@ def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_3(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_4(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -2521,11 +2677,12 @@ def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_4(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_5(save_xml):
     """
     Type list/language is restricted by facet maxLength with value 5.
@@ -2536,11 +2693,12 @@ def test_list_language_max_length_nistxml_sv_iv_list_language_max_length_1_5(sav
         instance="nistData/list/language/Schema+Instance/NISTXML-SV-IV-list-language-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLanguageMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_1(save_xml):
     """
     Type list/ID is restricted by facet whiteSpace with value collapse.
@@ -2551,11 +2709,12 @@ def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_2(save_xml):
     """
     Type list/ID is restricted by facet whiteSpace with value collapse.
@@ -2566,11 +2725,12 @@ def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_3(save_xml):
     """
     Type list/ID is restricted by facet whiteSpace with value collapse.
@@ -2581,11 +2741,12 @@ def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_4(save_xml):
     """
     Type list/ID is restricted by facet whiteSpace with value collapse.
@@ -2596,11 +2757,12 @@ def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_5(save_xml):
     """
     Type list/ID is restricted by facet whiteSpace with value collapse.
@@ -2611,11 +2773,12 @@ def test_list_id_white_space_nistxml_sv_iv_list_id_white_space_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_1(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2626,11 +2789,12 @@ def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_2(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2641,11 +2805,12 @@ def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_3(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2656,11 +2821,12 @@ def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_4(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2671,11 +2837,12 @@ def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_5(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2686,11 +2853,12 @@ def test_list_id_enumeration_4_nistxml_sv_iv_list_id_enumeration_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_1(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2701,11 +2869,12 @@ def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_2(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2716,11 +2885,12 @@ def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_3(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2731,11 +2901,12 @@ def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_4(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2746,11 +2917,12 @@ def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_5(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2761,11 +2933,12 @@ def test_list_id_enumeration_3_nistxml_sv_iv_list_id_enumeration_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_1(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2776,11 +2949,12 @@ def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_2(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2791,11 +2965,12 @@ def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_3(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2806,11 +2981,12 @@ def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_4(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2821,11 +2997,12 @@ def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_5(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2836,11 +3013,12 @@ def test_list_id_enumeration_2_nistxml_sv_iv_list_id_enumeration_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_1(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2851,11 +3029,12 @@ def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_2(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2866,11 +3045,12 @@ def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_3(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2881,11 +3061,12 @@ def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_4(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2896,11 +3077,12 @@ def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_5(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2911,11 +3093,12 @@ def test_list_id_enumeration_1_nistxml_sv_iv_list_id_enumeration_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_1(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2926,11 +3109,12 @@ def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_2(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2941,11 +3125,12 @@ def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_3(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2956,11 +3141,12 @@ def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_4(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2971,11 +3157,12 @@ def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_5(save_xml):
     """
     Type list/ID is restricted by facet enumeration.
@@ -2986,11 +3173,12 @@ def test_list_id_enumeration_nistxml_sv_iv_list_id_enumeration_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_1(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3004,11 +3192,12 @@ def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_2(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3022,11 +3211,12 @@ def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_3(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3040,11 +3230,12 @@ def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_4(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3058,11 +3249,12 @@ def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_5(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3076,11 +3268,12 @@ def test_list_id_pattern_4_nistxml_sv_iv_list_id_pattern_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_1(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3093,11 +3286,12 @@ def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_2(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3110,11 +3304,12 @@ def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_3(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3127,11 +3322,12 @@ def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_4(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3144,11 +3340,12 @@ def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_5(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3161,11 +3358,12 @@ def test_list_id_pattern_3_nistxml_sv_iv_list_id_pattern_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_1(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3179,11 +3377,12 @@ def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_2(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3197,11 +3396,12 @@ def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_3(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3215,11 +3415,12 @@ def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_4(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3233,11 +3434,12 @@ def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_5(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3251,11 +3453,12 @@ def test_list_id_pattern_2_nistxml_sv_iv_list_id_pattern_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_1(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3269,11 +3472,12 @@ def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_2(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3287,11 +3491,12 @@ def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_3(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3305,11 +3510,12 @@ def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_4(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3323,11 +3529,12 @@ def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_5(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3341,11 +3548,12 @@ def test_list_id_pattern_1_nistxml_sv_iv_list_id_pattern_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_1(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3359,11 +3567,12 @@ def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_2(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3377,11 +3586,12 @@ def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_3(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3395,11 +3605,12 @@ def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_4(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3413,11 +3624,12 @@ def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_5(save_xml):
     r"""
     Type list/ID is restricted by facet pattern with value
@@ -3431,11 +3643,12 @@ def test_list_id_pattern_nistxml_sv_iv_list_id_pattern_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -3446,11 +3659,12 @@ def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -3461,11 +3675,12 @@ def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -3476,11 +3691,12 @@ def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -3491,11 +3707,12 @@ def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 10.
@@ -3506,11 +3723,12 @@ def test_list_id_length_4_nistxml_sv_iv_list_id_length_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -3521,11 +3739,12 @@ def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -3536,11 +3755,12 @@ def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -3551,11 +3771,12 @@ def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -3566,11 +3787,12 @@ def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 8.
@@ -3581,11 +3803,12 @@ def test_list_id_length_3_nistxml_sv_iv_list_id_length_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -3596,11 +3819,12 @@ def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -3611,11 +3835,12 @@ def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -3626,11 +3851,12 @@ def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -3641,11 +3867,12 @@ def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 7.
@@ -3656,11 +3883,12 @@ def test_list_id_length_2_nistxml_sv_iv_list_id_length_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -3671,11 +3899,12 @@ def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -3686,11 +3915,12 @@ def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -3701,11 +3931,12 @@ def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -3716,11 +3947,12 @@ def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 6.
@@ -3731,11 +3963,12 @@ def test_list_id_length_1_nistxml_sv_iv_list_id_length_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_nistxml_sv_iv_list_id_length_1_1(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -3746,11 +3979,12 @@ def test_list_id_length_nistxml_sv_iv_list_id_length_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_nistxml_sv_iv_list_id_length_1_2(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -3761,11 +3995,12 @@ def test_list_id_length_nistxml_sv_iv_list_id_length_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_nistxml_sv_iv_list_id_length_1_3(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -3776,11 +4011,12 @@ def test_list_id_length_nistxml_sv_iv_list_id_length_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_nistxml_sv_iv_list_id_length_1_4(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -3791,11 +4027,12 @@ def test_list_id_length_nistxml_sv_iv_list_id_length_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_length_nistxml_sv_iv_list_id_length_1_5(save_xml):
     """
     Type list/ID is restricted by facet length with value 5.
@@ -3806,11 +4043,12 @@ def test_list_id_length_nistxml_sv_iv_list_id_length_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-length-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -3821,11 +4059,12 @@ def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -3836,11 +4075,12 @@ def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -3851,11 +4091,12 @@ def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -3866,11 +4107,12 @@ def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 10.
@@ -3881,11 +4123,12 @@ def test_list_id_min_length_4_nistxml_sv_iv_list_id_min_length_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -3896,11 +4139,12 @@ def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -3911,11 +4155,12 @@ def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -3926,11 +4171,12 @@ def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -3941,11 +4187,12 @@ def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 8.
@@ -3956,11 +4203,12 @@ def test_list_id_min_length_3_nistxml_sv_iv_list_id_min_length_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -3971,11 +4219,12 @@ def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -3986,11 +4235,12 @@ def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -4001,11 +4251,12 @@ def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -4016,11 +4267,12 @@ def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 7.
@@ -4031,11 +4283,12 @@ def test_list_id_min_length_2_nistxml_sv_iv_list_id_min_length_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -4046,11 +4299,12 @@ def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -4061,11 +4315,12 @@ def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -4076,11 +4331,12 @@ def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -4091,11 +4347,12 @@ def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 6.
@@ -4106,11 +4363,12 @@ def test_list_id_min_length_1_nistxml_sv_iv_list_id_min_length_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_1(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -4121,11 +4379,12 @@ def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_2(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -4136,11 +4395,12 @@ def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_3(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -4151,11 +4411,12 @@ def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_4(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -4166,11 +4427,12 @@ def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_5(save_xml):
     """
     Type list/ID is restricted by facet minLength with value 5.
@@ -4181,11 +4443,12 @@ def test_list_id_min_length_nistxml_sv_iv_list_id_min_length_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -4196,11 +4459,12 @@ def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -4211,11 +4475,12 @@ def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -4226,11 +4491,12 @@ def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -4241,11 +4507,12 @@ def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 10.
@@ -4256,11 +4523,12 @@ def test_list_id_max_length_4_nistxml_sv_iv_list_id_max_length_5_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -4271,11 +4539,12 @@ def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -4286,11 +4555,12 @@ def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -4301,11 +4571,12 @@ def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -4316,11 +4587,12 @@ def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 8.
@@ -4331,11 +4603,12 @@ def test_list_id_max_length_3_nistxml_sv_iv_list_id_max_length_4_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -4346,11 +4619,12 @@ def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -4361,11 +4635,12 @@ def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -4376,11 +4651,12 @@ def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -4391,11 +4667,12 @@ def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 7.
@@ -4406,11 +4683,12 @@ def test_list_id_max_length_2_nistxml_sv_iv_list_id_max_length_3_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -4421,11 +4699,12 @@ def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -4436,11 +4715,12 @@ def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -4451,11 +4731,12 @@ def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -4466,11 +4747,12 @@ def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 6.
@@ -4481,11 +4763,12 @@ def test_list_id_max_length_1_nistxml_sv_iv_list_id_max_length_2_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_1(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -4496,11 +4779,12 @@ def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_1(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_2(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -4511,11 +4795,12 @@ def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_2(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_3(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -4526,11 +4811,12 @@ def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_3(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_4(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -4541,11 +4827,12 @@ def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_4(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_5(save_xml):
     """
     Type list/ID is restricted by facet maxLength with value 5.
@@ -4556,11 +4843,12 @@ def test_list_id_max_length_nistxml_sv_iv_list_id_max_length_1_5(save_xml):
         instance="nistData/list/ID/Schema+Instance/NISTXML-SV-IV-list-ID-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="Out",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_1(save_xml):
     """
     Type list/NCName is restricted by facet whiteSpace with value
@@ -4572,11 +4860,12 @@ def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_2(save_xml):
     """
     Type list/NCName is restricted by facet whiteSpace with value
@@ -4588,11 +4877,12 @@ def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_3(save_xml):
     """
     Type list/NCName is restricted by facet whiteSpace with value
@@ -4604,11 +4894,12 @@ def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_4(save_xml):
     """
     Type list/NCName is restricted by facet whiteSpace with value
@@ -4620,11 +4911,12 @@ def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_5(save_xml):
     """
     Type list/NCName is restricted by facet whiteSpace with value
@@ -4636,11 +4928,12 @@ def test_list_ncname_white_space_nistxml_sv_iv_list_ncname_white_space_1_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_1(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4651,11 +4944,12 @@ def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_1(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_2(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4666,11 +4960,12 @@ def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_2(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_3(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4681,11 +4976,12 @@ def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_3(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_4(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4696,11 +4992,12 @@ def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_4(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_5(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4711,11 +5008,12 @@ def test_list_ncname_enumeration_4_nistxml_sv_iv_list_ncname_enumeration_5_5(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_1(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4726,11 +5024,12 @@ def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_1(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_2(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4741,11 +5040,12 @@ def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_2(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_3(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4756,11 +5056,12 @@ def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_3(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_4(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4771,11 +5072,12 @@ def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_4(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_5(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4786,11 +5088,12 @@ def test_list_ncname_enumeration_3_nistxml_sv_iv_list_ncname_enumeration_4_5(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_1(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4801,11 +5104,12 @@ def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_1(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_2(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4816,11 +5120,12 @@ def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_2(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_3(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4831,11 +5136,12 @@ def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_3(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_4(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4846,11 +5152,12 @@ def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_4(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_5(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4861,11 +5168,12 @@ def test_list_ncname_enumeration_2_nistxml_sv_iv_list_ncname_enumeration_3_5(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_1(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4876,11 +5184,12 @@ def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_1(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_2(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4891,11 +5200,12 @@ def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_2(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_3(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4906,11 +5216,12 @@ def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_3(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_4(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4921,11 +5232,12 @@ def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_4(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_5(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4936,11 +5248,12 @@ def test_list_ncname_enumeration_1_nistxml_sv_iv_list_ncname_enumeration_2_5(sav
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_1(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4951,11 +5264,12 @@ def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_2(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4966,11 +5280,12 @@ def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_3(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4981,11 +5296,12 @@ def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_4(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -4996,11 +5312,12 @@ def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_5(save_xml):
     """
     Type list/NCName is restricted by facet enumeration.
@@ -5011,11 +5328,12 @@ def test_list_ncname_enumeration_nistxml_sv_iv_list_ncname_enumeration_1_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_1(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5028,11 +5346,12 @@ def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_2(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5045,11 +5364,12 @@ def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_3(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5062,11 +5382,12 @@ def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_4(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5079,11 +5400,12 @@ def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_5(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5096,11 +5418,12 @@ def test_list_ncname_pattern_4_nistxml_sv_iv_list_ncname_pattern_5_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_1(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5115,11 +5438,12 @@ def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_2(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5134,11 +5458,12 @@ def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_3(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5153,11 +5478,12 @@ def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_4(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5172,11 +5498,12 @@ def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_5(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5191,11 +5518,12 @@ def test_list_ncname_pattern_3_nistxml_sv_iv_list_ncname_pattern_4_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_1(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5208,11 +5536,12 @@ def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_2(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5225,11 +5554,12 @@ def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_3(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5242,11 +5572,12 @@ def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_4(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5259,11 +5590,12 @@ def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_5(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5276,11 +5608,12 @@ def test_list_ncname_pattern_2_nistxml_sv_iv_list_ncname_pattern_3_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_1(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5294,11 +5627,12 @@ def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_2(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5312,11 +5646,12 @@ def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_3(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5330,11 +5665,12 @@ def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_4(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5348,11 +5684,12 @@ def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_5(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5366,11 +5703,12 @@ def test_list_ncname_pattern_1_nistxml_sv_iv_list_ncname_pattern_2_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_1(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5384,11 +5722,12 @@ def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_2(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5402,11 +5741,12 @@ def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_3(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5420,11 +5760,12 @@ def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_4(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5438,11 +5779,12 @@ def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_5(save_xml):
     r"""
     Type list/NCName is restricted by facet pattern with value
@@ -5456,11 +5798,12 @@ def test_list_ncname_pattern_nistxml_sv_iv_list_ncname_pattern_1_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -5471,11 +5814,12 @@ def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -5486,11 +5830,12 @@ def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -5501,11 +5846,12 @@ def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -5516,11 +5862,12 @@ def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 10.
@@ -5531,11 +5878,12 @@ def test_list_ncname_length_4_nistxml_sv_iv_list_ncname_length_5_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -5546,11 +5894,12 @@ def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -5561,11 +5910,12 @@ def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -5576,11 +5926,12 @@ def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -5591,11 +5942,12 @@ def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 8.
@@ -5606,11 +5958,12 @@ def test_list_ncname_length_3_nistxml_sv_iv_list_ncname_length_4_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -5621,11 +5974,12 @@ def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -5636,11 +5990,12 @@ def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -5651,11 +6006,12 @@ def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -5666,11 +6022,12 @@ def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 7.
@@ -5681,11 +6038,12 @@ def test_list_ncname_length_2_nistxml_sv_iv_list_ncname_length_3_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -5696,11 +6054,12 @@ def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -5711,11 +6070,12 @@ def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -5726,11 +6086,12 @@ def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -5741,11 +6102,12 @@ def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 6.
@@ -5756,11 +6118,12 @@ def test_list_ncname_length_1_nistxml_sv_iv_list_ncname_length_2_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_1(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -5771,11 +6134,12 @@ def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_1(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_2(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -5786,11 +6150,12 @@ def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_2(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_3(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -5801,11 +6166,12 @@ def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_3(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_4(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -5816,11 +6182,12 @@ def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_4(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_5(save_xml):
     """
     Type list/NCName is restricted by facet length with value 5.
@@ -5831,11 +6198,12 @@ def test_list_ncname_length_nistxml_sv_iv_list_ncname_length_1_5(save_xml):
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -5846,11 +6214,12 @@ def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -5861,11 +6230,12 @@ def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -5876,11 +6246,12 @@ def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -5891,11 +6262,12 @@ def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 10.
@@ -5906,11 +6278,12 @@ def test_list_ncname_min_length_4_nistxml_sv_iv_list_ncname_min_length_5_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -5921,11 +6294,12 @@ def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -5936,11 +6310,12 @@ def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -5951,11 +6326,12 @@ def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -5966,11 +6342,12 @@ def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 8.
@@ -5981,11 +6358,12 @@ def test_list_ncname_min_length_3_nistxml_sv_iv_list_ncname_min_length_4_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -5996,11 +6374,12 @@ def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -6011,11 +6390,12 @@ def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -6026,11 +6406,12 @@ def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -6041,11 +6422,12 @@ def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 7.
@@ -6056,11 +6438,12 @@ def test_list_ncname_min_length_2_nistxml_sv_iv_list_ncname_min_length_3_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -6071,11 +6454,12 @@ def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -6086,11 +6470,12 @@ def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -6101,11 +6486,12 @@ def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -6116,11 +6502,12 @@ def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 6.
@@ -6131,11 +6518,12 @@ def test_list_ncname_min_length_1_nistxml_sv_iv_list_ncname_min_length_2_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_1(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -6146,11 +6534,12 @@ def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_1(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_2(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -6161,11 +6550,12 @@ def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_2(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_3(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -6176,11 +6566,12 @@ def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_3(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_4(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -6191,11 +6582,12 @@ def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_4(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_5(save_xml):
     """
     Type list/NCName is restricted by facet minLength with value 5.
@@ -6206,11 +6598,12 @@ def test_list_ncname_min_length_nistxml_sv_iv_list_ncname_min_length_1_5(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -6221,11 +6614,12 @@ def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -6236,11 +6630,12 @@ def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -6251,11 +6646,12 @@ def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -6266,11 +6662,12 @@ def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 10.
@@ -6281,11 +6678,12 @@ def test_list_ncname_max_length_4_nistxml_sv_iv_list_ncname_max_length_5_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -6296,11 +6694,12 @@ def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -6311,11 +6710,12 @@ def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -6326,11 +6726,12 @@ def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -6341,11 +6742,12 @@ def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 8.
@@ -6356,11 +6758,12 @@ def test_list_ncname_max_length_3_nistxml_sv_iv_list_ncname_max_length_4_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -6371,11 +6774,12 @@ def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -6386,11 +6790,12 @@ def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -6401,11 +6806,12 @@ def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -6416,11 +6822,12 @@ def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 7.
@@ -6431,11 +6838,12 @@ def test_list_ncname_max_length_2_nistxml_sv_iv_list_ncname_max_length_3_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -6446,11 +6854,12 @@ def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_1(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -6461,11 +6870,12 @@ def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_2(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -6476,11 +6886,12 @@ def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_3(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -6491,11 +6902,12 @@ def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_4(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 6.
@@ -6506,11 +6918,12 @@ def test_list_ncname_max_length_1_nistxml_sv_iv_list_ncname_max_length_2_5(save_
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_1(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -6521,11 +6934,12 @@ def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_1(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_2(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -6536,11 +6950,12 @@ def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_2(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_3(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -6551,11 +6966,12 @@ def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_3(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_4(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -6566,11 +6982,12 @@ def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_4(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_5(save_xml):
     """
     Type list/NCName is restricted by facet maxLength with value 5.
@@ -6581,11 +6998,12 @@ def test_list_ncname_max_length_nistxml_sv_iv_list_ncname_max_length_1_5(save_xm
         instance="nistData/list/NCName/Schema+Instance/NISTXML-SV-IV-list-NCName-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNcnameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet whiteSpace with value
@@ -6597,11 +7015,12 @@ def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet whiteSpace with value
@@ -6613,11 +7032,12 @@ def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet whiteSpace with value
@@ -6629,11 +7049,12 @@ def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet whiteSpace with value
@@ -6645,11 +7066,12 @@ def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet whiteSpace with value
@@ -6661,11 +7083,12 @@ def test_list_nmtokens_white_space_nistxml_sv_iv_list_nmtokens_white_space_1_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6676,11 +7099,12 @@ def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_1
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6691,11 +7115,12 @@ def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_2
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6706,11 +7131,12 @@ def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_3
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6721,11 +7147,12 @@ def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_4
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6736,11 +7163,12 @@ def test_list_nmtokens_enumeration_4_nistxml_sv_iv_list_nmtokens_enumeration_5_5
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6751,11 +7179,12 @@ def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_1
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6766,11 +7195,12 @@ def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_2
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6781,11 +7211,12 @@ def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_3
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6796,11 +7227,12 @@ def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_4
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6811,11 +7243,12 @@ def test_list_nmtokens_enumeration_3_nistxml_sv_iv_list_nmtokens_enumeration_4_5
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6826,11 +7259,12 @@ def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_1
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6841,11 +7275,12 @@ def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_2
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6856,11 +7291,12 @@ def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_3
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6871,11 +7307,12 @@ def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_4
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6886,11 +7323,12 @@ def test_list_nmtokens_enumeration_2_nistxml_sv_iv_list_nmtokens_enumeration_3_5
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6901,11 +7339,12 @@ def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_1
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6916,11 +7355,12 @@ def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_2
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6931,11 +7371,12 @@ def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_3
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6946,11 +7387,12 @@ def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_4
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6961,11 +7403,12 @@ def test_list_nmtokens_enumeration_1_nistxml_sv_iv_list_nmtokens_enumeration_2_5
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6976,11 +7419,12 @@ def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -6991,11 +7435,12 @@ def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -7006,11 +7451,12 @@ def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -7021,11 +7467,12 @@ def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet enumeration.
@@ -7036,11 +7483,12 @@ def test_list_nmtokens_enumeration_nistxml_sv_iv_list_nmtokens_enumeration_1_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_1(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{44}
@@ -7052,11 +7500,12 @@ def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_1(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_2(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{44}
@@ -7068,11 +7517,12 @@ def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_2(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_3(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{44}
@@ -7084,11 +7534,12 @@ def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_3(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_4(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{44}
@@ -7100,11 +7551,12 @@ def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_4(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_5(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{44}
@@ -7116,11 +7568,12 @@ def test_list_nmtokens_pattern_4_nistxml_sv_iv_list_nmtokens_pattern_5_5(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_1(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{29}
@@ -7132,11 +7585,12 @@ def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_1(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_2(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{29}
@@ -7148,11 +7602,12 @@ def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_2(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_3(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{29}
@@ -7164,11 +7619,12 @@ def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_3(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_4(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{29}
@@ -7180,11 +7636,12 @@ def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_4(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_5(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{29}
@@ -7196,11 +7653,12 @@ def test_list_nmtokens_pattern_3_nistxml_sv_iv_list_nmtokens_pattern_4_5(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_1(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{20}
@@ -7212,11 +7670,12 @@ def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_1(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_2(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{20}
@@ -7228,11 +7687,12 @@ def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_2(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_3(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{20}
@@ -7244,11 +7704,12 @@ def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_3(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_4(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{20}
@@ -7260,11 +7721,12 @@ def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_4(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_5(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{20}
@@ -7276,11 +7738,12 @@ def test_list_nmtokens_pattern_2_nistxml_sv_iv_list_nmtokens_pattern_3_5(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_1(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{64}
@@ -7292,11 +7755,12 @@ def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_1(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_2(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{64}
@@ -7308,11 +7772,12 @@ def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_2(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_3(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{64}
@@ -7324,11 +7789,12 @@ def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_3(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_4(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{64}
@@ -7340,11 +7806,12 @@ def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_4(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_5(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{64}
@@ -7356,11 +7823,12 @@ def test_list_nmtokens_pattern_1_nistxml_sv_iv_list_nmtokens_pattern_2_5(save_xm
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_1(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{16}
@@ -7372,11 +7840,12 @@ def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_2(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{16}
@@ -7388,11 +7857,12 @@ def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_3(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{16}
@@ -7404,11 +7874,12 @@ def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_4(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{16}
@@ -7420,11 +7891,12 @@ def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_5(save_xml):
     r"""
     Type list/NMTOKENS is restricted by facet pattern with value \c{16}
@@ -7436,11 +7908,12 @@ def test_list_nmtokens_pattern_nistxml_sv_iv_list_nmtokens_pattern_1_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -7451,11 +7924,12 @@ def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -7466,11 +7940,12 @@ def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -7481,11 +7956,12 @@ def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -7496,11 +7972,12 @@ def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 10.
@@ -7511,11 +7988,12 @@ def test_list_nmtokens_length_4_nistxml_sv_iv_list_nmtokens_length_5_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -7526,11 +8004,12 @@ def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -7541,11 +8020,12 @@ def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -7556,11 +8036,12 @@ def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -7571,11 +8052,12 @@ def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 8.
@@ -7586,11 +8068,12 @@ def test_list_nmtokens_length_3_nistxml_sv_iv_list_nmtokens_length_4_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -7601,11 +8084,12 @@ def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -7616,11 +8100,12 @@ def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -7631,11 +8116,12 @@ def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -7646,11 +8132,12 @@ def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 7.
@@ -7661,11 +8148,12 @@ def test_list_nmtokens_length_2_nistxml_sv_iv_list_nmtokens_length_3_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -7676,11 +8164,12 @@ def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_1(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -7691,11 +8180,12 @@ def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_2(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -7706,11 +8196,12 @@ def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_3(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -7721,11 +8212,12 @@ def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_4(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 6.
@@ -7736,11 +8228,12 @@ def test_list_nmtokens_length_1_nistxml_sv_iv_list_nmtokens_length_2_5(save_xml)
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -7751,11 +8244,12 @@ def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_1(save_xml):
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -7766,11 +8260,12 @@ def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_2(save_xml):
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -7781,11 +8276,12 @@ def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_3(save_xml):
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -7796,11 +8292,12 @@ def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_4(save_xml):
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet length with value 5.
@@ -7811,11 +8308,12 @@ def test_list_nmtokens_length_nistxml_sv_iv_list_nmtokens_length_1_5(save_xml):
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -7826,11 +8324,12 @@ def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -7841,11 +8340,12 @@ def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -7856,11 +8356,12 @@ def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -7871,11 +8372,12 @@ def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 10.
@@ -7886,11 +8388,12 @@ def test_list_nmtokens_min_length_4_nistxml_sv_iv_list_nmtokens_min_length_5_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -7901,11 +8404,12 @@ def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -7916,11 +8420,12 @@ def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -7931,11 +8436,12 @@ def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -7946,11 +8452,12 @@ def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 8.
@@ -7961,11 +8468,12 @@ def test_list_nmtokens_min_length_3_nistxml_sv_iv_list_nmtokens_min_length_4_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -7976,11 +8484,12 @@ def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -7991,11 +8500,12 @@ def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -8006,11 +8516,12 @@ def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -8021,11 +8532,12 @@ def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 7.
@@ -8036,11 +8548,12 @@ def test_list_nmtokens_min_length_2_nistxml_sv_iv_list_nmtokens_min_length_3_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -8051,11 +8564,12 @@ def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -8066,11 +8580,12 @@ def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -8081,11 +8596,12 @@ def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -8096,11 +8612,12 @@ def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 6.
@@ -8111,11 +8628,12 @@ def test_list_nmtokens_min_length_1_nistxml_sv_iv_list_nmtokens_min_length_2_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -8126,11 +8644,12 @@ def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_1(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -8141,11 +8660,12 @@ def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_2(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -8156,11 +8676,12 @@ def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_3(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -8171,11 +8692,12 @@ def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_4(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet minLength with value 5.
@@ -8186,11 +8708,12 @@ def test_list_nmtokens_min_length_nistxml_sv_iv_list_nmtokens_min_length_1_5(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -8201,11 +8724,12 @@ def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -8216,11 +8740,12 @@ def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -8231,11 +8756,12 @@ def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -8246,11 +8772,12 @@ def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 10.
@@ -8261,11 +8788,12 @@ def test_list_nmtokens_max_length_4_nistxml_sv_iv_list_nmtokens_max_length_5_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -8276,11 +8804,12 @@ def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -8291,11 +8820,12 @@ def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -8306,11 +8836,12 @@ def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -8321,11 +8852,12 @@ def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 8.
@@ -8336,11 +8868,12 @@ def test_list_nmtokens_max_length_3_nistxml_sv_iv_list_nmtokens_max_length_4_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -8351,11 +8884,12 @@ def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -8366,11 +8900,12 @@ def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -8381,11 +8916,12 @@ def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -8396,11 +8932,12 @@ def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 7.
@@ -8411,11 +8948,12 @@ def test_list_nmtokens_max_length_2_nistxml_sv_iv_list_nmtokens_max_length_3_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -8426,11 +8964,12 @@ def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_1(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -8441,11 +8980,12 @@ def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_2(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -8456,11 +8996,12 @@ def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_3(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -8471,11 +9012,12 @@ def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_4(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 6.
@@ -8486,11 +9028,12 @@ def test_list_nmtokens_max_length_1_nistxml_sv_iv_list_nmtokens_max_length_2_5(s
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_1(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -8501,11 +9044,12 @@ def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_1(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_2(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -8516,11 +9060,12 @@ def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_2(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_3(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -8531,11 +9076,12 @@ def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_3(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_4(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -8546,11 +9092,12 @@ def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_4(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_5(save_xml):
     """
     Type list/NMTOKENS is restricted by facet maxLength with value 5.
@@ -8561,11 +9108,12 @@ def test_list_nmtokens_max_length_nistxml_sv_iv_list_nmtokens_max_length_1_5(sav
         instance="nistData/list/NMTOKENS/Schema+Instance/NISTXML-SV-IV-list-NMTOKENS-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokensMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet whiteSpace with value
@@ -8577,11 +9125,12 @@ def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet whiteSpace with value
@@ -8593,11 +9142,12 @@ def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet whiteSpace with value
@@ -8609,11 +9159,12 @@ def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet whiteSpace with value
@@ -8625,11 +9176,12 @@ def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet whiteSpace with value
@@ -8641,11 +9193,12 @@ def test_list_nmtoken_white_space_nistxml_sv_iv_list_nmtoken_white_space_1_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8656,11 +9209,12 @@ def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_1(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8671,11 +9225,12 @@ def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_2(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8686,11 +9241,12 @@ def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_3(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8701,11 +9257,12 @@ def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_4(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8716,11 +9273,12 @@ def test_list_nmtoken_enumeration_4_nistxml_sv_iv_list_nmtoken_enumeration_5_5(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8731,11 +9289,12 @@ def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_1(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8746,11 +9305,12 @@ def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_2(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8761,11 +9321,12 @@ def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_3(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8776,11 +9337,12 @@ def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_4(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8791,11 +9353,12 @@ def test_list_nmtoken_enumeration_3_nistxml_sv_iv_list_nmtoken_enumeration_4_5(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8806,11 +9369,12 @@ def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_1(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8821,11 +9385,12 @@ def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_2(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8836,11 +9401,12 @@ def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_3(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8851,11 +9417,12 @@ def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_4(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8866,11 +9433,12 @@ def test_list_nmtoken_enumeration_2_nistxml_sv_iv_list_nmtoken_enumeration_3_5(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8881,11 +9449,12 @@ def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_1(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8896,11 +9465,12 @@ def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_2(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8911,11 +9481,12 @@ def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_3(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8926,11 +9497,12 @@ def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_4(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8941,11 +9513,12 @@ def test_list_nmtoken_enumeration_1_nistxml_sv_iv_list_nmtoken_enumeration_2_5(s
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8956,11 +9529,12 @@ def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8971,11 +9545,12 @@ def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -8986,11 +9561,12 @@ def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -9001,11 +9577,12 @@ def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet enumeration.
@@ -9016,11 +9593,12 @@ def test_list_nmtoken_enumeration_nistxml_sv_iv_list_nmtoken_enumeration_1_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_1(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{45}
@@ -9032,11 +9610,12 @@ def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_1(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_2(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{45}
@@ -9048,11 +9627,12 @@ def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_2(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_3(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{45}
@@ -9064,11 +9644,12 @@ def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_3(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_4(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{45}
@@ -9080,11 +9661,12 @@ def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_4(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_5(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{45}
@@ -9096,11 +9678,12 @@ def test_list_nmtoken_pattern_4_nistxml_sv_iv_list_nmtoken_pattern_5_5(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_1(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{35}
@@ -9112,11 +9695,12 @@ def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_1(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_2(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{35}
@@ -9128,11 +9712,12 @@ def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_2(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_3(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{35}
@@ -9144,11 +9729,12 @@ def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_3(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_4(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{35}
@@ -9160,11 +9746,12 @@ def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_4(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_5(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{35}
@@ -9176,11 +9763,12 @@ def test_list_nmtoken_pattern_3_nistxml_sv_iv_list_nmtoken_pattern_4_5(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_1(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{1}
@@ -9192,11 +9780,12 @@ def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_1(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_2(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{1}
@@ -9208,11 +9797,12 @@ def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_2(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_3(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{1}
@@ -9224,11 +9814,12 @@ def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_3(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_4(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{1}
@@ -9240,11 +9831,12 @@ def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_4(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_5(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{1}
@@ -9256,11 +9848,12 @@ def test_list_nmtoken_pattern_2_nistxml_sv_iv_list_nmtoken_pattern_3_5(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_1(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{20}
@@ -9272,11 +9865,12 @@ def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_1(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_2(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{20}
@@ -9288,11 +9882,12 @@ def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_2(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_3(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{20}
@@ -9304,11 +9899,12 @@ def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_3(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_4(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{20}
@@ -9320,11 +9916,12 @@ def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_4(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_5(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{20}
@@ -9336,11 +9933,12 @@ def test_list_nmtoken_pattern_1_nistxml_sv_iv_list_nmtoken_pattern_2_5(save_xml)
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_1(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{40}
@@ -9352,11 +9950,12 @@ def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_2(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{40}
@@ -9368,11 +9967,12 @@ def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_3(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{40}
@@ -9384,11 +9984,12 @@ def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_4(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{40}
@@ -9400,11 +10001,12 @@ def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_5(save_xml):
     r"""
     Type list/NMTOKEN is restricted by facet pattern with value \c{40}
@@ -9416,11 +10018,12 @@ def test_list_nmtoken_pattern_nistxml_sv_iv_list_nmtoken_pattern_1_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -9431,11 +10034,12 @@ def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -9446,11 +10050,12 @@ def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -9461,11 +10066,12 @@ def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -9476,11 +10082,12 @@ def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 10.
@@ -9491,11 +10098,12 @@ def test_list_nmtoken_length_4_nistxml_sv_iv_list_nmtoken_length_5_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -9506,11 +10114,12 @@ def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -9521,11 +10130,12 @@ def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -9536,11 +10146,12 @@ def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -9551,11 +10162,12 @@ def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 8.
@@ -9566,11 +10178,12 @@ def test_list_nmtoken_length_3_nistxml_sv_iv_list_nmtoken_length_4_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -9581,11 +10194,12 @@ def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -9596,11 +10210,12 @@ def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -9611,11 +10226,12 @@ def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -9626,11 +10242,12 @@ def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 7.
@@ -9641,11 +10258,12 @@ def test_list_nmtoken_length_2_nistxml_sv_iv_list_nmtoken_length_3_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -9656,11 +10274,12 @@ def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -9671,11 +10290,12 @@ def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -9686,11 +10306,12 @@ def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -9701,11 +10322,12 @@ def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 6.
@@ -9716,11 +10338,12 @@ def test_list_nmtoken_length_1_nistxml_sv_iv_list_nmtoken_length_2_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -9731,11 +10354,12 @@ def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_1(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -9746,11 +10370,12 @@ def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_2(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -9761,11 +10386,12 @@ def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_3(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -9776,11 +10402,12 @@ def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_4(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet length with value 5.
@@ -9791,11 +10418,12 @@ def test_list_nmtoken_length_nistxml_sv_iv_list_nmtoken_length_1_5(save_xml):
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -9806,11 +10434,12 @@ def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -9821,11 +10450,12 @@ def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -9836,11 +10466,12 @@ def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -9851,11 +10482,12 @@ def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 10.
@@ -9866,11 +10498,12 @@ def test_list_nmtoken_min_length_4_nistxml_sv_iv_list_nmtoken_min_length_5_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -9881,11 +10514,12 @@ def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -9896,11 +10530,12 @@ def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -9911,11 +10546,12 @@ def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -9926,11 +10562,12 @@ def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 8.
@@ -9941,11 +10578,12 @@ def test_list_nmtoken_min_length_3_nistxml_sv_iv_list_nmtoken_min_length_4_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -9956,11 +10594,12 @@ def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -9971,11 +10610,12 @@ def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -9986,11 +10626,12 @@ def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -10001,11 +10642,12 @@ def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 7.
@@ -10016,11 +10658,12 @@ def test_list_nmtoken_min_length_2_nistxml_sv_iv_list_nmtoken_min_length_3_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -10031,11 +10674,12 @@ def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -10046,11 +10690,12 @@ def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -10061,11 +10706,12 @@ def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -10076,11 +10722,12 @@ def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 6.
@@ -10091,11 +10738,12 @@ def test_list_nmtoken_min_length_1_nistxml_sv_iv_list_nmtoken_min_length_2_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -10106,11 +10754,12 @@ def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_1(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -10121,11 +10770,12 @@ def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_2(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -10136,11 +10786,12 @@ def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_3(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -10151,11 +10802,12 @@ def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_4(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet minLength with value 5.
@@ -10166,11 +10818,12 @@ def test_list_nmtoken_min_length_nistxml_sv_iv_list_nmtoken_min_length_1_5(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -10181,11 +10834,12 @@ def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -10196,11 +10850,12 @@ def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -10211,11 +10866,12 @@ def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -10226,11 +10882,12 @@ def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 10.
@@ -10241,11 +10898,12 @@ def test_list_nmtoken_max_length_4_nistxml_sv_iv_list_nmtoken_max_length_5_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -10256,11 +10914,12 @@ def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -10271,11 +10930,12 @@ def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -10286,11 +10946,12 @@ def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -10301,11 +10962,12 @@ def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 8.
@@ -10316,11 +10978,12 @@ def test_list_nmtoken_max_length_3_nistxml_sv_iv_list_nmtoken_max_length_4_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -10331,11 +10994,12 @@ def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -10346,11 +11010,12 @@ def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -10361,11 +11026,12 @@ def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -10376,11 +11042,12 @@ def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 7.
@@ -10391,11 +11058,12 @@ def test_list_nmtoken_max_length_2_nistxml_sv_iv_list_nmtoken_max_length_3_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -10406,11 +11074,12 @@ def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_1(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -10421,11 +11090,12 @@ def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_2(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -10436,11 +11106,12 @@ def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_3(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -10451,11 +11122,12 @@ def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_4(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 6.
@@ -10466,11 +11138,12 @@ def test_list_nmtoken_max_length_1_nistxml_sv_iv_list_nmtoken_max_length_2_5(sav
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_1(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -10481,11 +11154,12 @@ def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_1(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_2(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -10496,11 +11170,12 @@ def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_2(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_3(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -10511,11 +11186,12 @@ def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_3(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_4(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -10526,11 +11202,12 @@ def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_4(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_5(save_xml):
     """
     Type list/NMTOKEN is restricted by facet maxLength with value 5.
@@ -10541,11 +11218,12 @@ def test_list_nmtoken_max_length_nistxml_sv_iv_list_nmtoken_max_length_1_5(save_
         instance="nistData/list/NMTOKEN/Schema+Instance/NISTXML-SV-IV-list-NMTOKEN-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNmtokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_1(save_xml):
     """
     Type list/Name is restricted by facet whiteSpace with value collapse.
@@ -10556,11 +11234,12 @@ def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_2(save_xml):
     """
     Type list/Name is restricted by facet whiteSpace with value collapse.
@@ -10571,11 +11250,12 @@ def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_3(save_xml):
     """
     Type list/Name is restricted by facet whiteSpace with value collapse.
@@ -10586,11 +11266,12 @@ def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_4(save_xml):
     """
     Type list/Name is restricted by facet whiteSpace with value collapse.
@@ -10601,11 +11282,12 @@ def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_5(save_xml):
     """
     Type list/Name is restricted by facet whiteSpace with value collapse.
@@ -10616,11 +11298,12 @@ def test_list_name_white_space_nistxml_sv_iv_list_name_white_space_1_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_1(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10631,11 +11314,12 @@ def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_1(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_2(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10646,11 +11330,12 @@ def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_2(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_3(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10661,11 +11346,12 @@ def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_3(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_4(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10676,11 +11362,12 @@ def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_4(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_5(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10691,11 +11378,12 @@ def test_list_name_enumeration_4_nistxml_sv_iv_list_name_enumeration_5_5(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_1(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10706,11 +11394,12 @@ def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_1(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_2(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10721,11 +11410,12 @@ def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_2(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_3(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10736,11 +11426,12 @@ def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_3(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_4(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10751,11 +11442,12 @@ def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_4(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_5(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10766,11 +11458,12 @@ def test_list_name_enumeration_3_nistxml_sv_iv_list_name_enumeration_4_5(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_1(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10781,11 +11474,12 @@ def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_1(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_2(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10796,11 +11490,12 @@ def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_2(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_3(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10811,11 +11506,12 @@ def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_3(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_4(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10826,11 +11522,12 @@ def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_4(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_5(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10841,11 +11538,12 @@ def test_list_name_enumeration_2_nistxml_sv_iv_list_name_enumeration_3_5(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_1(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10856,11 +11554,12 @@ def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_1(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_2(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10871,11 +11570,12 @@ def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_2(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_3(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10886,11 +11586,12 @@ def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_3(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_4(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10901,11 +11602,12 @@ def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_4(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_5(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10916,11 +11618,12 @@ def test_list_name_enumeration_1_nistxml_sv_iv_list_name_enumeration_2_5(save_xm
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_1(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10931,11 +11634,12 @@ def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_2(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10946,11 +11650,12 @@ def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_3(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10961,11 +11666,12 @@ def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_4(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10976,11 +11682,12 @@ def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_5(save_xml):
     """
     Type list/Name is restricted by facet enumeration.
@@ -10991,11 +11698,12 @@ def test_list_name_enumeration_nistxml_sv_iv_list_name_enumeration_1_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_1(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{21}
@@ -11008,11 +11716,12 @@ def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_2(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{21}
@@ -11025,11 +11734,12 @@ def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_3(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{21}
@@ -11042,11 +11752,12 @@ def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_4(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{21}
@@ -11059,11 +11770,12 @@ def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_5(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{21}
@@ -11076,11 +11788,12 @@ def test_list_name_pattern_4_nistxml_sv_iv_list_name_pattern_5_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_1(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{19}
@@ -11093,11 +11806,12 @@ def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_2(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{19}
@@ -11110,11 +11824,12 @@ def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_3(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{19}
@@ -11127,11 +11842,12 @@ def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_4(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{19}
@@ -11144,11 +11860,12 @@ def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_5(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{19}
@@ -11161,11 +11878,12 @@ def test_list_name_pattern_3_nistxml_sv_iv_list_name_pattern_4_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_1(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{24}
@@ -11177,11 +11895,12 @@ def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_2(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{24}
@@ -11193,11 +11912,12 @@ def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_3(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{24}
@@ -11209,11 +11929,12 @@ def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_4(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{24}
@@ -11225,11 +11946,12 @@ def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_5(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{24}
@@ -11241,11 +11963,12 @@ def test_list_name_pattern_2_nistxml_sv_iv_list_name_pattern_3_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_1(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{33}
@@ -11257,11 +11980,12 @@ def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_2(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{33}
@@ -11273,11 +11997,12 @@ def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_3(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{33}
@@ -11289,11 +12014,12 @@ def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_4(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{33}
@@ -11305,11 +12031,12 @@ def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_5(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{33}
@@ -11321,11 +12048,12 @@ def test_list_name_pattern_1_nistxml_sv_iv_list_name_pattern_2_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_1(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{48}
@@ -11337,11 +12065,12 @@ def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_2(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{48}
@@ -11353,11 +12082,12 @@ def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_3(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{48}
@@ -11369,11 +12099,12 @@ def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_4(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{48}
@@ -11385,11 +12116,12 @@ def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_5(save_xml):
     r"""
     Type list/Name is restricted by facet pattern with value \i\c{48}
@@ -11401,11 +12133,12 @@ def test_list_name_pattern_nistxml_sv_iv_list_name_pattern_1_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNamePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -11416,11 +12149,12 @@ def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -11431,11 +12165,12 @@ def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -11446,11 +12181,12 @@ def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -11461,11 +12197,12 @@ def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 10.
@@ -11476,11 +12213,12 @@ def test_list_name_length_4_nistxml_sv_iv_list_name_length_5_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -11491,11 +12229,12 @@ def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -11506,11 +12245,12 @@ def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -11521,11 +12261,12 @@ def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -11536,11 +12277,12 @@ def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 8.
@@ -11551,11 +12293,12 @@ def test_list_name_length_3_nistxml_sv_iv_list_name_length_4_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -11566,11 +12309,12 @@ def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -11581,11 +12325,12 @@ def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -11596,11 +12341,12 @@ def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -11611,11 +12357,12 @@ def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 7.
@@ -11626,11 +12373,12 @@ def test_list_name_length_2_nistxml_sv_iv_list_name_length_3_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -11641,11 +12389,12 @@ def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -11656,11 +12405,12 @@ def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -11671,11 +12421,12 @@ def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -11686,11 +12437,12 @@ def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 6.
@@ -11701,11 +12453,12 @@ def test_list_name_length_1_nistxml_sv_iv_list_name_length_2_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_nistxml_sv_iv_list_name_length_1_1(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -11716,11 +12469,12 @@ def test_list_name_length_nistxml_sv_iv_list_name_length_1_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_nistxml_sv_iv_list_name_length_1_2(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -11731,11 +12485,12 @@ def test_list_name_length_nistxml_sv_iv_list_name_length_1_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_nistxml_sv_iv_list_name_length_1_3(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -11746,11 +12501,12 @@ def test_list_name_length_nistxml_sv_iv_list_name_length_1_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_nistxml_sv_iv_list_name_length_1_4(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -11761,11 +12517,12 @@ def test_list_name_length_nistxml_sv_iv_list_name_length_1_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_length_nistxml_sv_iv_list_name_length_1_5(save_xml):
     """
     Type list/Name is restricted by facet length with value 5.
@@ -11776,11 +12533,12 @@ def test_list_name_length_nistxml_sv_iv_list_name_length_1_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -11791,11 +12549,12 @@ def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -11806,11 +12565,12 @@ def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -11821,11 +12581,12 @@ def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -11836,11 +12597,12 @@ def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 10.
@@ -11851,11 +12613,12 @@ def test_list_name_min_length_4_nistxml_sv_iv_list_name_min_length_5_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -11866,11 +12629,12 @@ def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -11881,11 +12645,12 @@ def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -11896,11 +12661,12 @@ def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -11911,11 +12677,12 @@ def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 8.
@@ -11926,11 +12693,12 @@ def test_list_name_min_length_3_nistxml_sv_iv_list_name_min_length_4_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -11941,11 +12709,12 @@ def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -11956,11 +12725,12 @@ def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -11971,11 +12741,12 @@ def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -11986,11 +12757,12 @@ def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 7.
@@ -12001,11 +12773,12 @@ def test_list_name_min_length_2_nistxml_sv_iv_list_name_min_length_3_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -12016,11 +12789,12 @@ def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -12031,11 +12805,12 @@ def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -12046,11 +12821,12 @@ def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -12061,11 +12837,12 @@ def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 6.
@@ -12076,11 +12853,12 @@ def test_list_name_min_length_1_nistxml_sv_iv_list_name_min_length_2_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_1(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -12091,11 +12869,12 @@ def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_2(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -12106,11 +12885,12 @@ def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_3(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -12121,11 +12901,12 @@ def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_4(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -12136,11 +12917,12 @@ def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_5(save_xml):
     """
     Type list/Name is restricted by facet minLength with value 5.
@@ -12151,11 +12933,12 @@ def test_list_name_min_length_nistxml_sv_iv_list_name_min_length_1_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -12166,11 +12949,12 @@ def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -12181,11 +12965,12 @@ def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -12196,11 +12981,12 @@ def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -12211,11 +12997,12 @@ def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 10.
@@ -12226,11 +13013,12 @@ def test_list_name_max_length_4_nistxml_sv_iv_list_name_max_length_5_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -12241,11 +13029,12 @@ def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -12256,11 +13045,12 @@ def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -12271,11 +13061,12 @@ def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -12286,11 +13077,12 @@ def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 8.
@@ -12301,11 +13093,12 @@ def test_list_name_max_length_3_nistxml_sv_iv_list_name_max_length_4_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -12316,11 +13109,12 @@ def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -12331,11 +13125,12 @@ def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -12346,11 +13141,12 @@ def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -12361,11 +13157,12 @@ def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 7.
@@ -12376,11 +13173,12 @@ def test_list_name_max_length_2_nistxml_sv_iv_list_name_max_length_3_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -12391,11 +13189,12 @@ def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_1(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -12406,11 +13205,12 @@ def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_2(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -12421,11 +13221,12 @@ def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_3(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -12436,11 +13237,12 @@ def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_4(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 6.
@@ -12451,11 +13253,12 @@ def test_list_name_max_length_1_nistxml_sv_iv_list_name_max_length_2_5(save_xml)
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_1(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -12466,11 +13269,12 @@ def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_1(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_2(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -12481,11 +13285,12 @@ def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_2(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_3(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -12496,11 +13301,12 @@ def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_3(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_4(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -12511,11 +13317,12 @@ def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_4(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_5(save_xml):
     """
     Type list/Name is restricted by facet maxLength with value 5.
@@ -12526,11 +13333,12 @@ def test_list_name_max_length_nistxml_sv_iv_list_name_max_length_1_5(save_xml):
         instance="nistData/list/Name/Schema+Instance/NISTXML-SV-IV-list-Name-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNameMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_1(save_xml):
     """
     Type list/token is restricted by facet whiteSpace with value collapse.
@@ -12541,11 +13349,12 @@ def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_2(save_xml):
     """
     Type list/token is restricted by facet whiteSpace with value collapse.
@@ -12556,11 +13365,12 @@ def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_3(save_xml):
     """
     Type list/token is restricted by facet whiteSpace with value collapse.
@@ -12571,11 +13381,12 @@ def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_4(save_xml):
     """
     Type list/token is restricted by facet whiteSpace with value collapse.
@@ -12586,11 +13397,12 @@ def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_5(save_xml):
     """
     Type list/token is restricted by facet whiteSpace with value collapse.
@@ -12601,11 +13413,12 @@ def test_list_token_white_space_nistxml_sv_iv_list_token_white_space_1_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_1(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12616,11 +13429,12 @@ def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_1(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_2(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12631,11 +13445,12 @@ def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_2(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_3(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12646,11 +13461,12 @@ def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_3(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_4(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12661,11 +13477,12 @@ def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_4(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_5(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12676,11 +13493,12 @@ def test_list_token_enumeration_4_nistxml_sv_iv_list_token_enumeration_5_5(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_1(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12691,11 +13509,12 @@ def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_1(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_2(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12706,11 +13525,12 @@ def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_2(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_3(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12721,11 +13541,12 @@ def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_3(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_4(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12736,11 +13557,12 @@ def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_4(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_5(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12751,11 +13573,12 @@ def test_list_token_enumeration_3_nistxml_sv_iv_list_token_enumeration_4_5(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_1(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12766,11 +13589,12 @@ def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_1(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_2(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12781,11 +13605,12 @@ def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_2(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_3(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12796,11 +13621,12 @@ def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_3(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_4(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12811,11 +13637,12 @@ def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_4(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_5(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12826,11 +13653,12 @@ def test_list_token_enumeration_2_nistxml_sv_iv_list_token_enumeration_3_5(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_1(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12841,11 +13669,12 @@ def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_1(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_2(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12856,11 +13685,12 @@ def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_2(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_3(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12871,11 +13701,12 @@ def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_3(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_4(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12886,11 +13717,12 @@ def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_4(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_5(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12901,11 +13733,12 @@ def test_list_token_enumeration_1_nistxml_sv_iv_list_token_enumeration_2_5(save_
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_1(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12916,11 +13749,12 @@ def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_2(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12931,11 +13765,12 @@ def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_3(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12946,11 +13781,12 @@ def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_4(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12961,11 +13797,12 @@ def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_5(save_xml):
     """
     Type list/token is restricted by facet enumeration.
@@ -12976,11 +13813,12 @@ def test_list_token_enumeration_nistxml_sv_iv_list_token_enumeration_1_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_1(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13000,11 +13838,12 @@ def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_2(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13024,11 +13863,12 @@ def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_3(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13048,11 +13888,12 @@ def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_4(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13072,11 +13913,12 @@ def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_5(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13096,11 +13938,12 @@ def test_list_token_pattern_4_nistxml_sv_iv_list_token_pattern_5_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_1(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13121,11 +13964,12 @@ def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_2(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13146,11 +13990,12 @@ def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_3(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13171,11 +14016,12 @@ def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_4(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13196,11 +14042,12 @@ def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_5(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13221,11 +14068,12 @@ def test_list_token_pattern_3_nistxml_sv_iv_list_token_pattern_4_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_1(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13244,11 +14092,12 @@ def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_2(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13267,11 +14116,12 @@ def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_3(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13290,11 +14140,12 @@ def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_4(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13313,11 +14164,12 @@ def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_5(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13336,11 +14188,12 @@ def test_list_token_pattern_2_nistxml_sv_iv_list_token_pattern_3_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_1(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13362,11 +14215,12 @@ def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_2(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13388,11 +14242,12 @@ def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_3(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13414,11 +14269,12 @@ def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_4(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13440,11 +14296,12 @@ def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_5(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13466,11 +14323,12 @@ def test_list_token_pattern_1_nistxml_sv_iv_list_token_pattern_2_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_1(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13487,11 +14345,12 @@ def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_2(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13508,11 +14367,12 @@ def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_3(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13529,11 +14389,12 @@ def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_4(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13550,11 +14411,12 @@ def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_5(save_xml):
     r"""
     Type list/token is restricted by facet pattern with value \d{1,5}_([A-
@@ -13571,11 +14433,12 @@ def test_list_token_pattern_nistxml_sv_iv_list_token_pattern_1_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_1(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -13586,11 +14449,12 @@ def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_2(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -13601,11 +14465,12 @@ def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_3(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -13616,11 +14481,12 @@ def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_4(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -13631,11 +14497,12 @@ def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_5(save_xml):
     """
     Type list/token is restricted by facet length with value 10.
@@ -13646,11 +14513,12 @@ def test_list_token_length_4_nistxml_sv_iv_list_token_length_5_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_1(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -13661,11 +14529,12 @@ def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_2(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -13676,11 +14545,12 @@ def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_3(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -13691,11 +14561,12 @@ def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_4(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -13706,11 +14577,12 @@ def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_5(save_xml):
     """
     Type list/token is restricted by facet length with value 8.
@@ -13721,11 +14593,12 @@ def test_list_token_length_3_nistxml_sv_iv_list_token_length_4_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_1(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -13736,11 +14609,12 @@ def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_2(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -13751,11 +14625,12 @@ def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_3(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -13766,11 +14641,12 @@ def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_4(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -13781,11 +14657,12 @@ def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_5(save_xml):
     """
     Type list/token is restricted by facet length with value 7.
@@ -13796,11 +14673,12 @@ def test_list_token_length_2_nistxml_sv_iv_list_token_length_3_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_1(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -13811,11 +14689,12 @@ def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_2(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -13826,11 +14705,12 @@ def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_3(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -13841,11 +14721,12 @@ def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_4(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -13856,11 +14737,12 @@ def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_5(save_xml):
     """
     Type list/token is restricted by facet length with value 6.
@@ -13871,11 +14753,12 @@ def test_list_token_length_1_nistxml_sv_iv_list_token_length_2_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_nistxml_sv_iv_list_token_length_1_1(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -13886,11 +14769,12 @@ def test_list_token_length_nistxml_sv_iv_list_token_length_1_1(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_nistxml_sv_iv_list_token_length_1_2(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -13901,11 +14785,12 @@ def test_list_token_length_nistxml_sv_iv_list_token_length_1_2(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_nistxml_sv_iv_list_token_length_1_3(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -13916,11 +14801,12 @@ def test_list_token_length_nistxml_sv_iv_list_token_length_1_3(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_nistxml_sv_iv_list_token_length_1_4(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -13931,11 +14817,12 @@ def test_list_token_length_nistxml_sv_iv_list_token_length_1_4(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_length_nistxml_sv_iv_list_token_length_1_5(save_xml):
     """
     Type list/token is restricted by facet length with value 5.
@@ -13946,11 +14833,12 @@ def test_list_token_length_nistxml_sv_iv_list_token_length_1_5(save_xml):
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -13961,11 +14849,12 @@ def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -13976,11 +14865,12 @@ def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -13991,11 +14881,12 @@ def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14006,11 +14897,12 @@ def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 10.
@@ -14021,11 +14913,12 @@ def test_list_token_min_length_4_nistxml_sv_iv_list_token_min_length_5_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14036,11 +14929,12 @@ def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14051,11 +14945,12 @@ def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14066,11 +14961,12 @@ def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14081,11 +14977,12 @@ def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 8.
@@ -14096,11 +14993,12 @@ def test_list_token_min_length_3_nistxml_sv_iv_list_token_min_length_4_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14111,11 +15009,12 @@ def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14126,11 +15025,12 @@ def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14141,11 +15041,12 @@ def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14156,11 +15057,12 @@ def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 7.
@@ -14171,11 +15073,12 @@ def test_list_token_min_length_2_nistxml_sv_iv_list_token_min_length_3_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14186,11 +15089,12 @@ def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14201,11 +15105,12 @@ def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14216,11 +15121,12 @@ def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14231,11 +15137,12 @@ def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 6.
@@ -14246,11 +15153,12 @@ def test_list_token_min_length_1_nistxml_sv_iv_list_token_min_length_2_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_1(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14261,11 +15169,12 @@ def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_1(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_2(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14276,11 +15185,12 @@ def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_2(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_3(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14291,11 +15201,12 @@ def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_3(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_4(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14306,11 +15217,12 @@ def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_4(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_5(save_xml):
     """
     Type list/token is restricted by facet minLength with value 5.
@@ -14321,11 +15233,12 @@ def test_list_token_min_length_nistxml_sv_iv_list_token_min_length_1_5(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14336,11 +15249,12 @@ def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14351,11 +15265,12 @@ def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14366,11 +15281,12 @@ def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14381,11 +15297,12 @@ def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 10.
@@ -14396,11 +15313,12 @@ def test_list_token_max_length_4_nistxml_sv_iv_list_token_max_length_5_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14411,11 +15329,12 @@ def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14426,11 +15345,12 @@ def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14441,11 +15361,12 @@ def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14456,11 +15377,12 @@ def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 8.
@@ -14471,11 +15393,12 @@ def test_list_token_max_length_3_nistxml_sv_iv_list_token_max_length_4_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -14486,11 +15409,12 @@ def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -14501,11 +15425,12 @@ def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -14516,11 +15441,12 @@ def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -14531,11 +15457,12 @@ def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 7.
@@ -14546,11 +15473,12 @@ def test_list_token_max_length_2_nistxml_sv_iv_list_token_max_length_3_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -14561,11 +15489,12 @@ def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_1(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -14576,11 +15505,12 @@ def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_2(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -14591,11 +15521,12 @@ def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_3(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -14606,11 +15537,12 @@ def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_4(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 6.
@@ -14621,11 +15553,12 @@ def test_list_token_max_length_1_nistxml_sv_iv_list_token_max_length_2_5(save_xm
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_1(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -14636,11 +15569,12 @@ def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_1(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_2(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -14651,11 +15585,12 @@ def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_2(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_3(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -14666,11 +15601,12 @@ def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_3(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_4(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -14681,11 +15617,12 @@ def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_4(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_5(save_xml):
     """
     Type list/token is restricted by facet maxLength with value 5.
@@ -14696,11 +15633,12 @@ def test_list_token_max_length_nistxml_sv_iv_list_token_max_length_1_5(save_xml)
         instance="nistData/list/token/Schema+Instance/NISTXML-SV-IV-list-token-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTokenMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string_white_space_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet whiteSpace with
@@ -14712,11 +15650,12 @@ def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string_white_space_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet whiteSpace with
@@ -14728,11 +15667,12 @@ def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string_white_space_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet whiteSpace with
@@ -14744,11 +15684,12 @@ def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string_white_space_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet whiteSpace with
@@ -14760,11 +15701,12 @@ def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string_white_space_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet whiteSpace with
@@ -14776,11 +15718,12 @@ def test_list_normalized_string_white_space_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_string_enumeration_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14791,11 +15734,12 @@ def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_string_enumeration_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14806,11 +15750,12 @@ def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_string_enumeration_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14821,11 +15766,12 @@ def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_string_enumeration_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14836,11 +15782,12 @@ def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_string_enumeration_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14851,11 +15798,12 @@ def test_list_normalized_string_enumeration_4_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_string_enumeration_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14866,11 +15814,12 @@ def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_string_enumeration_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14881,11 +15830,12 @@ def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_string_enumeration_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14896,11 +15846,12 @@ def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_string_enumeration_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14911,11 +15862,12 @@ def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_string_enumeration_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14926,11 +15878,12 @@ def test_list_normalized_string_enumeration_3_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_string_enumeration_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14941,11 +15894,12 @@ def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_string_enumeration_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14956,11 +15910,12 @@ def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_string_enumeration_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14971,11 +15926,12 @@ def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_string_enumeration_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -14986,11 +15942,12 @@ def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_string_enumeration_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15001,11 +15958,12 @@ def test_list_normalized_string_enumeration_2_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_string_enumeration_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15016,11 +15974,12 @@ def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_string_enumeration_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15031,11 +15990,12 @@ def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_string_enumeration_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15046,11 +16006,12 @@ def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_string_enumeration_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15061,11 +16022,12 @@ def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_string_enumeration_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15076,11 +16038,12 @@ def test_list_normalized_string_enumeration_1_nistxml_sv_iv_list_normalized_stri
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string_enumeration_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15091,11 +16054,12 @@ def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string_enumeration_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15106,11 +16070,12 @@ def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string_enumeration_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15121,11 +16086,12 @@ def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string_enumeration_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15136,11 +16102,12 @@ def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string_enumeration_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet enumeration.
@@ -15151,11 +16118,12 @@ def test_list_normalized_string_enumeration_nistxml_sv_iv_list_normalized_string
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_pattern_5_1(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15174,11 +16142,12 @@ def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_pattern_5_2(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15197,11 +16166,12 @@ def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_pattern_5_3(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15220,11 +16190,12 @@ def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_pattern_5_4(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15243,11 +16214,12 @@ def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_pattern_5_5(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15266,11 +16238,12 @@ def test_list_normalized_string_pattern_4_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_pattern_4_1(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15288,11 +16261,12 @@ def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_pattern_4_2(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15310,11 +16284,12 @@ def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_pattern_4_3(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15332,11 +16307,12 @@ def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_pattern_4_4(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15354,11 +16330,12 @@ def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_pattern_4_5(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15376,11 +16353,12 @@ def test_list_normalized_string_pattern_3_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_pattern_3_1(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15398,11 +16376,12 @@ def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_pattern_3_2(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15420,11 +16399,12 @@ def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_pattern_3_3(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15442,11 +16422,12 @@ def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_pattern_3_4(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15464,11 +16445,12 @@ def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_pattern_3_5(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15486,11 +16468,12 @@ def test_list_normalized_string_pattern_2_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_pattern_2_1(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15507,11 +16490,12 @@ def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_pattern_2_2(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15528,11 +16512,12 @@ def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_pattern_2_3(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15549,11 +16534,12 @@ def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_pattern_2_4(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15570,11 +16556,12 @@ def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_pattern_2_5(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15591,11 +16578,12 @@ def test_list_normalized_string_pattern_1_nistxml_sv_iv_list_normalized_string_p
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pattern_1_1(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15614,11 +16602,12 @@ def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pat
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pattern_1_2(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15637,11 +16626,12 @@ def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pat
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pattern_1_3(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15660,11 +16650,12 @@ def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pat
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pattern_1_4(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15683,11 +16674,12 @@ def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pat
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pattern_1_5(save_xml):
     r"""
     Type list/normalizedString is restricted by facet pattern with value \
@@ -15706,11 +16698,12 @@ def test_list_normalized_string_pattern_nistxml_sv_iv_list_normalized_string_pat
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_length_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -15722,11 +16715,12 @@ def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_length_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -15738,11 +16732,12 @@ def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_length_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -15754,11 +16749,12 @@ def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_length_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -15770,11 +16766,12 @@ def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_length_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value
@@ -15786,11 +16783,12 @@ def test_list_normalized_string_length_4_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_length_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -15801,11 +16799,12 @@ def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_length_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -15816,11 +16815,12 @@ def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_length_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -15831,11 +16831,12 @@ def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_length_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -15846,11 +16847,12 @@ def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_length_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 8.
@@ -15861,6 +16863,6 @@ def test_list_normalized_string_length_3_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_7000.py
+++ b/tests/test_nist_meta_7000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_length_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -11,11 +14,12 @@ def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_length_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -26,11 +30,12 @@ def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_length_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -41,11 +46,12 @@ def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_length_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -56,11 +62,12 @@ def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_length_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 7.
@@ -71,11 +78,12 @@ def test_list_normalized_string_length_2_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_length_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -86,11 +94,12 @@ def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_length_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -101,11 +110,12 @@ def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_length_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -116,11 +126,12 @@ def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_length_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -131,11 +142,12 @@ def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_length_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 6.
@@ -146,11 +158,12 @@ def test_list_normalized_string_length_1_nistxml_sv_iv_list_normalized_string_le
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_length_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -161,11 +174,12 @@ def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_leng
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_length_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -176,11 +190,12 @@ def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_leng
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_length_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -191,11 +206,12 @@ def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_leng
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_length_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -206,11 +222,12 @@ def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_leng
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_length_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet length with value 5.
@@ -221,11 +238,12 @@ def test_list_normalized_string_length_nistxml_sv_iv_list_normalized_string_leng
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_string_min_length_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -237,11 +255,12 @@ def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_string_min_length_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -253,11 +272,12 @@ def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_string_min_length_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -269,11 +289,12 @@ def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_string_min_length_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -285,11 +306,12 @@ def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_string_min_length_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -301,11 +323,12 @@ def test_list_normalized_string_min_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_string_min_length_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -317,11 +340,12 @@ def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_string_min_length_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -333,11 +357,12 @@ def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_string_min_length_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -349,11 +374,12 @@ def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_string_min_length_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -365,11 +391,12 @@ def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_string_min_length_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -381,11 +408,12 @@ def test_list_normalized_string_min_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_string_min_length_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -397,11 +425,12 @@ def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_string_min_length_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -413,11 +442,12 @@ def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_string_min_length_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -429,11 +459,12 @@ def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_string_min_length_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -445,11 +476,12 @@ def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_string_min_length_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -461,11 +493,12 @@ def test_list_normalized_string_min_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_string_min_length_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -477,11 +510,12 @@ def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_string_min_length_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -493,11 +527,12 @@ def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_string_min_length_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -509,11 +544,12 @@ def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_string_min_length_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -525,11 +561,12 @@ def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_string_min_length_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -541,11 +578,12 @@ def test_list_normalized_string_min_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_min_length_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -557,11 +595,12 @@ def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_min_length_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -573,11 +612,12 @@ def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_min_length_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -589,11 +629,12 @@ def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_min_length_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -605,11 +646,12 @@ def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_min_length_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet minLength with value
@@ -621,11 +663,12 @@ def test_list_normalized_string_min_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_string_max_length_5_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -637,11 +680,12 @@ def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_string_max_length_5_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -653,11 +697,12 @@ def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_string_max_length_5_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -669,11 +714,12 @@ def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_string_max_length_5_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -685,11 +731,12 @@ def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_string_max_length_5_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -701,11 +748,12 @@ def test_list_normalized_string_max_length_4_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_string_max_length_4_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -717,11 +765,12 @@ def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_string_max_length_4_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -733,11 +782,12 @@ def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_string_max_length_4_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -749,11 +799,12 @@ def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_string_max_length_4_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -765,11 +816,12 @@ def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_string_max_length_4_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -781,11 +833,12 @@ def test_list_normalized_string_max_length_3_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_string_max_length_3_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -797,11 +850,12 @@ def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_string_max_length_3_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -813,11 +867,12 @@ def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_string_max_length_3_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -829,11 +884,12 @@ def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_string_max_length_3_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -845,11 +901,12 @@ def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_string_max_length_3_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -861,11 +918,12 @@ def test_list_normalized_string_max_length_2_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_string_max_length_2_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -877,11 +935,12 @@ def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_string_max_length_2_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -893,11 +952,12 @@ def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_string_max_length_2_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -909,11 +969,12 @@ def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_string_max_length_2_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -925,11 +986,12 @@ def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_string_max_length_2_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -941,11 +1003,12 @@ def test_list_normalized_string_max_length_1_nistxml_sv_iv_list_normalized_strin
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_max_length_1_1(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -957,11 +1020,12 @@ def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_max_length_1_2(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -973,11 +1037,12 @@ def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_max_length_1_3(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -989,11 +1054,12 @@ def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_max_length_1_4(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1005,11 +1071,12 @@ def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_max_length_1_5(save_xml):
     """
     Type list/normalizedString is restricted by facet maxLength with value
@@ -1021,11 +1088,12 @@ def test_list_normalized_string_max_length_nistxml_sv_iv_list_normalized_string_
         instance="nistData/list/normalizedString/Schema+Instance/NISTXML-SV-IV-list-normalizedString-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNormalizedStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_1(save_xml):
     """
     Type list/string is restricted by facet whiteSpace with value
@@ -1037,11 +1105,12 @@ def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_2(save_xml):
     """
     Type list/string is restricted by facet whiteSpace with value
@@ -1053,11 +1122,12 @@ def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_3(save_xml):
     """
     Type list/string is restricted by facet whiteSpace with value
@@ -1069,11 +1139,12 @@ def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_4(save_xml):
     """
     Type list/string is restricted by facet whiteSpace with value
@@ -1085,11 +1156,12 @@ def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_5(save_xml):
     """
     Type list/string is restricted by facet whiteSpace with value
@@ -1101,11 +1173,12 @@ def test_list_string_white_space_nistxml_sv_iv_list_string_white_space_1_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_1(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1116,11 +1189,12 @@ def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_1(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_2(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1131,11 +1205,12 @@ def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_2(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_3(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1146,11 +1221,12 @@ def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_3(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_4(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1161,11 +1237,12 @@ def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_4(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_5(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1176,11 +1253,12 @@ def test_list_string_enumeration_4_nistxml_sv_iv_list_string_enumeration_5_5(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_1(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1191,11 +1269,12 @@ def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_1(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_2(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1206,11 +1285,12 @@ def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_2(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_3(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1221,11 +1301,12 @@ def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_3(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_4(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1236,11 +1317,12 @@ def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_4(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_5(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1251,11 +1333,12 @@ def test_list_string_enumeration_3_nistxml_sv_iv_list_string_enumeration_4_5(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_1(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1266,11 +1349,12 @@ def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_1(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_2(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1281,11 +1365,12 @@ def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_2(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_3(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1296,11 +1381,12 @@ def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_3(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_4(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1311,11 +1397,12 @@ def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_4(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_5(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1326,11 +1413,12 @@ def test_list_string_enumeration_2_nistxml_sv_iv_list_string_enumeration_3_5(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_1(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1341,11 +1429,12 @@ def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_1(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_2(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1356,11 +1445,12 @@ def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_2(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_3(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1371,11 +1461,12 @@ def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_3(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_4(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1386,11 +1477,12 @@ def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_4(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_5(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1401,11 +1493,12 @@ def test_list_string_enumeration_1_nistxml_sv_iv_list_string_enumeration_2_5(sav
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_1(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1416,11 +1509,12 @@ def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_2(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1431,11 +1525,12 @@ def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_3(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1446,11 +1541,12 @@ def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_4(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1461,11 +1557,12 @@ def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_5(save_xml):
     """
     Type list/string is restricted by facet enumeration.
@@ -1476,11 +1573,12 @@ def test_list_string_enumeration_nistxml_sv_iv_list_string_enumeration_1_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_1(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1501,11 +1599,12 @@ def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_2(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1526,11 +1625,12 @@ def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_3(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1551,11 +1651,12 @@ def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_4(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1576,11 +1677,12 @@ def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_5(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1601,11 +1703,12 @@ def test_list_string_pattern_4_nistxml_sv_iv_list_string_pattern_5_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_1(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1622,11 +1725,12 @@ def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_2(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1643,11 +1747,12 @@ def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_3(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1664,11 +1769,12 @@ def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_4(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1685,11 +1791,12 @@ def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_5(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1706,11 +1813,12 @@ def test_list_string_pattern_3_nistxml_sv_iv_list_string_pattern_4_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_1(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1727,11 +1835,12 @@ def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_2(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1748,11 +1857,12 @@ def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_3(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1769,11 +1879,12 @@ def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_4(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1790,11 +1901,12 @@ def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_5(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1811,11 +1923,12 @@ def test_list_string_pattern_2_nistxml_sv_iv_list_string_pattern_3_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_1(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1834,11 +1947,12 @@ def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_2(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1857,11 +1971,12 @@ def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_3(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1880,11 +1995,12 @@ def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_4(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1903,11 +2019,12 @@ def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_5(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1926,11 +2043,12 @@ def test_list_string_pattern_1_nistxml_sv_iv_list_string_pattern_2_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_1(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1951,11 +2069,12 @@ def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_2(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -1976,11 +2095,12 @@ def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_3(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -2001,11 +2121,12 @@ def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_4(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -2026,11 +2147,12 @@ def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_5(save_xml):
     r"""
     Type list/string is restricted by facet pattern with value \d{1,5}_([A
@@ -2051,11 +2173,12 @@ def test_list_string_pattern_nistxml_sv_iv_list_string_pattern_1_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_1(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -2066,11 +2189,12 @@ def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_2(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -2081,11 +2205,12 @@ def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_3(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -2096,11 +2221,12 @@ def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_4(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -2111,11 +2237,12 @@ def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_5(save_xml):
     """
     Type list/string is restricted by facet length with value 10.
@@ -2126,11 +2253,12 @@ def test_list_string_length_4_nistxml_sv_iv_list_string_length_5_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_1(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -2141,11 +2269,12 @@ def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_2(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -2156,11 +2285,12 @@ def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_3(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -2171,11 +2301,12 @@ def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_4(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -2186,11 +2317,12 @@ def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_5(save_xml):
     """
     Type list/string is restricted by facet length with value 8.
@@ -2201,11 +2333,12 @@ def test_list_string_length_3_nistxml_sv_iv_list_string_length_4_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_1(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -2216,11 +2349,12 @@ def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_2(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -2231,11 +2365,12 @@ def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_3(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -2246,11 +2381,12 @@ def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_4(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -2261,11 +2397,12 @@ def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_5(save_xml):
     """
     Type list/string is restricted by facet length with value 7.
@@ -2276,11 +2413,12 @@ def test_list_string_length_2_nistxml_sv_iv_list_string_length_3_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_1(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -2291,11 +2429,12 @@ def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_2(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -2306,11 +2445,12 @@ def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_3(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -2321,11 +2461,12 @@ def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_4(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -2336,11 +2477,12 @@ def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_5(save_xml):
     """
     Type list/string is restricted by facet length with value 6.
@@ -2351,11 +2493,12 @@ def test_list_string_length_1_nistxml_sv_iv_list_string_length_2_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_nistxml_sv_iv_list_string_length_1_1(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -2366,11 +2509,12 @@ def test_list_string_length_nistxml_sv_iv_list_string_length_1_1(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_nistxml_sv_iv_list_string_length_1_2(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -2381,11 +2525,12 @@ def test_list_string_length_nistxml_sv_iv_list_string_length_1_2(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_nistxml_sv_iv_list_string_length_1_3(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -2396,11 +2541,12 @@ def test_list_string_length_nistxml_sv_iv_list_string_length_1_3(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_nistxml_sv_iv_list_string_length_1_4(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -2411,11 +2557,12 @@ def test_list_string_length_nistxml_sv_iv_list_string_length_1_4(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_length_nistxml_sv_iv_list_string_length_1_5(save_xml):
     """
     Type list/string is restricted by facet length with value 5.
@@ -2426,11 +2573,12 @@ def test_list_string_length_nistxml_sv_iv_list_string_length_1_5(save_xml):
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -2441,11 +2589,12 @@ def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -2456,11 +2605,12 @@ def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -2471,11 +2621,12 @@ def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -2486,11 +2637,12 @@ def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 10.
@@ -2501,11 +2653,12 @@ def test_list_string_min_length_4_nistxml_sv_iv_list_string_min_length_5_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -2516,11 +2669,12 @@ def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -2531,11 +2685,12 @@ def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -2546,11 +2701,12 @@ def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -2561,11 +2717,12 @@ def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 8.
@@ -2576,11 +2733,12 @@ def test_list_string_min_length_3_nistxml_sv_iv_list_string_min_length_4_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -2591,11 +2749,12 @@ def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -2606,11 +2765,12 @@ def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -2621,11 +2781,12 @@ def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -2636,11 +2797,12 @@ def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 7.
@@ -2651,11 +2813,12 @@ def test_list_string_min_length_2_nistxml_sv_iv_list_string_min_length_3_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -2666,11 +2829,12 @@ def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -2681,11 +2845,12 @@ def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -2696,11 +2861,12 @@ def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -2711,11 +2877,12 @@ def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 6.
@@ -2726,11 +2893,12 @@ def test_list_string_min_length_1_nistxml_sv_iv_list_string_min_length_2_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_1(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -2741,11 +2909,12 @@ def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_1(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_2(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -2756,11 +2925,12 @@ def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_2(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_3(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -2771,11 +2941,12 @@ def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_3(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_4(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -2786,11 +2957,12 @@ def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_4(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_5(save_xml):
     """
     Type list/string is restricted by facet minLength with value 5.
@@ -2801,11 +2973,12 @@ def test_list_string_min_length_nistxml_sv_iv_list_string_min_length_1_5(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -2816,11 +2989,12 @@ def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -2831,11 +3005,12 @@ def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -2846,11 +3021,12 @@ def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -2861,11 +3037,12 @@ def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 10.
@@ -2876,11 +3053,12 @@ def test_list_string_max_length_4_nistxml_sv_iv_list_string_max_length_5_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2891,11 +3069,12 @@ def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2906,11 +3085,12 @@ def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2921,11 +3101,12 @@ def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2936,11 +3117,12 @@ def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 8.
@@ -2951,11 +3133,12 @@ def test_list_string_max_length_3_nistxml_sv_iv_list_string_max_length_4_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2966,11 +3149,12 @@ def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2981,11 +3165,12 @@ def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -2996,11 +3181,12 @@ def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -3011,11 +3197,12 @@ def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 7.
@@ -3026,11 +3213,12 @@ def test_list_string_max_length_2_nistxml_sv_iv_list_string_max_length_3_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -3041,11 +3229,12 @@ def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_1(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -3056,11 +3245,12 @@ def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_2(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -3071,11 +3261,12 @@ def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_3(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -3086,11 +3277,12 @@ def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_4(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 6.
@@ -3101,11 +3293,12 @@ def test_list_string_max_length_1_nistxml_sv_iv_list_string_max_length_2_5(save_
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_1(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -3116,11 +3309,12 @@ def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_1(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_2(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -3131,11 +3325,12 @@ def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_2(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_3(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -3146,11 +3341,12 @@ def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_3(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_4(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -3161,11 +3357,12 @@ def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_4(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_5(save_xml):
     """
     Type list/string is restricted by facet maxLength with value 5.
@@ -3176,11 +3373,12 @@ def test_list_string_max_length_nistxml_sv_iv_list_string_max_length_1_5(save_xm
         instance="nistData/list/string/Schema+Instance/NISTXML-SV-IV-list-string-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListStringMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet whiteSpace with value
@@ -3192,11 +3390,12 @@ def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet whiteSpace with value
@@ -3208,11 +3407,12 @@ def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet whiteSpace with value
@@ -3224,11 +3424,12 @@ def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet whiteSpace with value
@@ -3240,11 +3441,12 @@ def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet whiteSpace with value
@@ -3256,11 +3458,12 @@ def test_list_g_month_white_space_nistxml_sv_iv_list_g_month_white_space_1_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3271,11 +3474,12 @@ def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3286,11 +3490,12 @@ def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3301,11 +3506,12 @@ def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3316,11 +3522,12 @@ def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3331,11 +3538,12 @@ def test_list_g_month_enumeration_4_nistxml_sv_iv_list_g_month_enumeration_5_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3346,11 +3554,12 @@ def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3361,11 +3570,12 @@ def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3376,11 +3586,12 @@ def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3391,11 +3602,12 @@ def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3406,11 +3618,12 @@ def test_list_g_month_enumeration_3_nistxml_sv_iv_list_g_month_enumeration_4_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3421,11 +3634,12 @@ def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3436,11 +3650,12 @@ def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3451,11 +3666,12 @@ def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3466,11 +3682,12 @@ def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3481,11 +3698,12 @@ def test_list_g_month_enumeration_2_nistxml_sv_iv_list_g_month_enumeration_3_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3496,11 +3714,12 @@ def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_1(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3511,11 +3730,12 @@ def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_2(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3526,11 +3746,12 @@ def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_3(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3541,11 +3762,12 @@ def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_4(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3556,11 +3778,12 @@ def test_list_g_month_enumeration_1_nistxml_sv_iv_list_g_month_enumeration_2_5(s
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3571,11 +3794,12 @@ def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3586,11 +3810,12 @@ def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3601,11 +3826,12 @@ def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3616,11 +3842,12 @@ def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet enumeration.
@@ -3631,11 +3858,12 @@ def test_list_g_month_enumeration_nistxml_sv_iv_list_g_month_enumeration_1_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3647,11 +3875,12 @@ def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3663,11 +3892,12 @@ def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3679,11 +3909,12 @@ def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3695,11 +3926,12 @@ def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3711,11 +3943,12 @@ def test_list_g_month_pattern_4_nistxml_sv_iv_list_g_month_pattern_5_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d0
@@ -3727,11 +3960,12 @@ def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d0
@@ -3743,11 +3977,12 @@ def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d0
@@ -3759,11 +3994,12 @@ def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d0
@@ -3775,11 +4011,12 @@ def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d1 --\d0
@@ -3791,11 +4028,12 @@ def test_list_g_month_pattern_3_nistxml_sv_iv_list_g_month_pattern_4_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3807,11 +4045,12 @@ def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3823,11 +4062,12 @@ def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3839,11 +4079,12 @@ def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3855,11 +4096,12 @@ def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --0\d
@@ -3871,11 +4113,12 @@ def test_list_g_month_pattern_2_nistxml_sv_iv_list_g_month_pattern_3_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --1\d
@@ -3887,11 +4130,12 @@ def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_1(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --1\d
@@ -3903,11 +4147,12 @@ def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_2(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --1\d
@@ -3919,11 +4164,12 @@ def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_3(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --1\d
@@ -3935,11 +4181,12 @@ def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_4(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --1\d --1\d
@@ -3951,11 +4198,12 @@ def test_list_g_month_pattern_1_nistxml_sv_iv_list_g_month_pattern_2_5(save_xml)
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_1(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --\d4
@@ -3967,11 +4215,12 @@ def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_2(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --\d4
@@ -3983,11 +4232,12 @@ def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_3(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --\d4
@@ -3999,11 +4249,12 @@ def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_4(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --\d4
@@ -4015,11 +4266,12 @@ def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_5(save_xml):
     r"""
     Type list/gMonth is restricted by facet pattern with value --\d9 --\d4
@@ -4031,11 +4283,12 @@ def test_list_g_month_pattern_nistxml_sv_iv_list_g_month_pattern_1_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -4046,11 +4299,12 @@ def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -4061,11 +4315,12 @@ def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -4076,11 +4331,12 @@ def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -4091,11 +4347,12 @@ def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 10.
@@ -4106,11 +4363,12 @@ def test_list_g_month_length_4_nistxml_sv_iv_list_g_month_length_5_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -4121,11 +4379,12 @@ def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -4136,11 +4395,12 @@ def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -4151,11 +4411,12 @@ def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -4166,11 +4427,12 @@ def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 8.
@@ -4181,11 +4443,12 @@ def test_list_g_month_length_3_nistxml_sv_iv_list_g_month_length_4_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -4196,11 +4459,12 @@ def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -4211,11 +4475,12 @@ def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -4226,11 +4491,12 @@ def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -4241,11 +4507,12 @@ def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 7.
@@ -4256,11 +4523,12 @@ def test_list_g_month_length_2_nistxml_sv_iv_list_g_month_length_3_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -4271,11 +4539,12 @@ def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -4286,11 +4555,12 @@ def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -4301,11 +4571,12 @@ def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -4316,11 +4587,12 @@ def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 6.
@@ -4331,11 +4603,12 @@ def test_list_g_month_length_1_nistxml_sv_iv_list_g_month_length_2_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -4346,11 +4619,12 @@ def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_1(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -4361,11 +4635,12 @@ def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_2(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -4376,11 +4651,12 @@ def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_3(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -4391,11 +4667,12 @@ def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_4(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet length with value 5.
@@ -4406,11 +4683,12 @@ def test_list_g_month_length_nistxml_sv_iv_list_g_month_length_1_5(save_xml):
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -4421,11 +4699,12 @@ def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -4436,11 +4715,12 @@ def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -4451,11 +4731,12 @@ def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -4466,11 +4747,12 @@ def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 10.
@@ -4481,11 +4763,12 @@ def test_list_g_month_min_length_4_nistxml_sv_iv_list_g_month_min_length_5_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -4496,11 +4779,12 @@ def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -4511,11 +4795,12 @@ def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -4526,11 +4811,12 @@ def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -4541,11 +4827,12 @@ def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 8.
@@ -4556,11 +4843,12 @@ def test_list_g_month_min_length_3_nistxml_sv_iv_list_g_month_min_length_4_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -4571,11 +4859,12 @@ def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -4586,11 +4875,12 @@ def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -4601,11 +4891,12 @@ def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -4616,11 +4907,12 @@ def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 7.
@@ -4631,11 +4923,12 @@ def test_list_g_month_min_length_2_nistxml_sv_iv_list_g_month_min_length_3_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -4646,11 +4939,12 @@ def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -4661,11 +4955,12 @@ def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -4676,11 +4971,12 @@ def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -4691,11 +4987,12 @@ def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 6.
@@ -4706,11 +5003,12 @@ def test_list_g_month_min_length_1_nistxml_sv_iv_list_g_month_min_length_2_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -4721,11 +5019,12 @@ def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_1(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -4736,11 +5035,12 @@ def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_2(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -4751,11 +5051,12 @@ def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_3(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -4766,11 +5067,12 @@ def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_4(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet minLength with value 5.
@@ -4781,11 +5083,12 @@ def test_list_g_month_min_length_nistxml_sv_iv_list_g_month_min_length_1_5(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -4796,11 +5099,12 @@ def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -4811,11 +5115,12 @@ def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -4826,11 +5131,12 @@ def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -4841,11 +5147,12 @@ def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 10.
@@ -4856,11 +5163,12 @@ def test_list_g_month_max_length_4_nistxml_sv_iv_list_g_month_max_length_5_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -4871,11 +5179,12 @@ def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -4886,11 +5195,12 @@ def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -4901,11 +5211,12 @@ def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -4916,11 +5227,12 @@ def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 8.
@@ -4931,11 +5243,12 @@ def test_list_g_month_max_length_3_nistxml_sv_iv_list_g_month_max_length_4_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -4946,11 +5259,12 @@ def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -4961,11 +5275,12 @@ def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -4976,11 +5291,12 @@ def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -4991,11 +5307,12 @@ def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 7.
@@ -5006,11 +5323,12 @@ def test_list_g_month_max_length_2_nistxml_sv_iv_list_g_month_max_length_3_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -5021,11 +5339,12 @@ def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_1(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -5036,11 +5355,12 @@ def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_2(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -5051,11 +5371,12 @@ def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_3(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -5066,11 +5387,12 @@ def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_4(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 6.
@@ -5081,11 +5403,12 @@ def test_list_g_month_max_length_1_nistxml_sv_iv_list_g_month_max_length_2_5(sav
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_1(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -5096,11 +5419,12 @@ def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_1(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_2(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -5111,11 +5435,12 @@ def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_2(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_3(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -5126,11 +5451,12 @@ def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_3(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_4(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -5141,11 +5467,12 @@ def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_4(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_5(save_xml):
     """
     Type list/gMonth is restricted by facet maxLength with value 5.
@@ -5156,11 +5483,12 @@ def test_list_g_month_max_length_nistxml_sv_iv_list_g_month_max_length_1_5(save_
         instance="nistData/list/gMonth/Schema+Instance/NISTXML-SV-IV-list-gMonth-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_1(save_xml):
     """
     Type list/gDay is restricted by facet whiteSpace with value collapse.
@@ -5171,11 +5499,12 @@ def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_2(save_xml):
     """
     Type list/gDay is restricted by facet whiteSpace with value collapse.
@@ -5186,11 +5515,12 @@ def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_3(save_xml):
     """
     Type list/gDay is restricted by facet whiteSpace with value collapse.
@@ -5201,11 +5531,12 @@ def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_4(save_xml):
     """
     Type list/gDay is restricted by facet whiteSpace with value collapse.
@@ -5216,11 +5547,12 @@ def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_5(save_xml):
     """
     Type list/gDay is restricted by facet whiteSpace with value collapse.
@@ -5231,11 +5563,12 @@ def test_list_g_day_white_space_nistxml_sv_iv_list_g_day_white_space_1_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5246,11 +5579,12 @@ def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5261,11 +5595,12 @@ def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5276,11 +5611,12 @@ def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5291,11 +5627,12 @@ def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5306,11 +5643,12 @@ def test_list_g_day_enumeration_4_nistxml_sv_iv_list_g_day_enumeration_5_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5321,11 +5659,12 @@ def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5336,11 +5675,12 @@ def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5351,11 +5691,12 @@ def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5366,11 +5707,12 @@ def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5381,11 +5723,12 @@ def test_list_g_day_enumeration_3_nistxml_sv_iv_list_g_day_enumeration_4_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5396,11 +5739,12 @@ def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5411,11 +5755,12 @@ def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5426,11 +5771,12 @@ def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5441,11 +5787,12 @@ def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5456,11 +5803,12 @@ def test_list_g_day_enumeration_2_nistxml_sv_iv_list_g_day_enumeration_3_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5471,11 +5819,12 @@ def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_1(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5486,11 +5835,12 @@ def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_2(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5501,11 +5851,12 @@ def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_3(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5516,11 +5867,12 @@ def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_4(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5531,11 +5883,12 @@ def test_list_g_day_enumeration_1_nistxml_sv_iv_list_g_day_enumeration_2_5(save_
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_1(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5546,11 +5899,12 @@ def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_2(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5561,11 +5915,12 @@ def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_3(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5576,11 +5931,12 @@ def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_4(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5591,11 +5947,12 @@ def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_5(save_xml):
     """
     Type list/gDay is restricted by facet enumeration.
@@ -5606,11 +5963,12 @@ def test_list_g_day_enumeration_nistxml_sv_iv_list_g_day_enumeration_1_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---1\d
@@ -5622,11 +5980,12 @@ def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---1\d
@@ -5638,11 +5997,12 @@ def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---1\d
@@ -5654,11 +6014,12 @@ def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---1\d
@@ -5670,11 +6031,12 @@ def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---1\d
@@ -5686,11 +6048,12 @@ def test_list_g_day_pattern_4_nistxml_sv_iv_list_g_day_pattern_5_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---2\d
@@ -5702,11 +6065,12 @@ def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---2\d
@@ -5718,11 +6082,12 @@ def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---2\d
@@ -5734,11 +6099,12 @@ def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---2\d
@@ -5750,11 +6116,12 @@ def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---2\d
@@ -5766,11 +6133,12 @@ def test_list_g_day_pattern_3_nistxml_sv_iv_list_g_day_pattern_4_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---0\d
@@ -5782,11 +6150,12 @@ def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---0\d
@@ -5798,11 +6167,12 @@ def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---0\d
@@ -5814,11 +6184,12 @@ def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---0\d
@@ -5830,11 +6201,12 @@ def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d5 ---0\d
@@ -5846,11 +6218,12 @@ def test_list_g_day_pattern_2_nistxml_sv_iv_list_g_day_pattern_3_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---\d4
@@ -5862,11 +6235,12 @@ def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---\d4
@@ -5878,11 +6252,12 @@ def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---\d4
@@ -5894,11 +6269,12 @@ def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---\d4
@@ -5910,11 +6286,12 @@ def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---1\d ---\d4
@@ -5926,11 +6303,12 @@ def test_list_g_day_pattern_1_nistxml_sv_iv_list_g_day_pattern_2_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_1(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d7 ---2\d
@@ -5942,11 +6320,12 @@ def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_2(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d7 ---2\d
@@ -5958,11 +6337,12 @@ def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_3(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d7 ---2\d
@@ -5974,11 +6354,12 @@ def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_4(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d7 ---2\d
@@ -5990,11 +6371,12 @@ def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_5(save_xml):
     r"""
     Type list/gDay is restricted by facet pattern with value ---\d7 ---2\d
@@ -6006,11 +6388,12 @@ def test_list_g_day_pattern_nistxml_sv_iv_list_g_day_pattern_1_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6021,11 +6404,12 @@ def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6036,11 +6420,12 @@ def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6051,11 +6436,12 @@ def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6066,11 +6452,12 @@ def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 10.
@@ -6081,11 +6468,12 @@ def test_list_g_day_length_4_nistxml_sv_iv_list_g_day_length_5_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -6096,11 +6484,12 @@ def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -6111,11 +6500,12 @@ def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -6126,11 +6516,12 @@ def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -6141,11 +6532,12 @@ def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 8.
@@ -6156,11 +6548,12 @@ def test_list_g_day_length_3_nistxml_sv_iv_list_g_day_length_4_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -6171,11 +6564,12 @@ def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -6186,11 +6580,12 @@ def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -6201,11 +6596,12 @@ def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -6216,11 +6612,12 @@ def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 7.
@@ -6231,11 +6628,12 @@ def test_list_g_day_length_2_nistxml_sv_iv_list_g_day_length_3_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -6246,11 +6644,12 @@ def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -6261,11 +6660,12 @@ def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -6276,11 +6676,12 @@ def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -6291,11 +6692,12 @@ def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 6.
@@ -6306,11 +6708,12 @@ def test_list_g_day_length_1_nistxml_sv_iv_list_g_day_length_2_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_1(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -6321,11 +6724,12 @@ def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_1(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_2(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -6336,11 +6740,12 @@ def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_2(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_3(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -6351,11 +6756,12 @@ def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_3(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_4(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -6366,11 +6772,12 @@ def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_4(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_5(save_xml):
     """
     Type list/gDay is restricted by facet length with value 5.
@@ -6381,11 +6788,12 @@ def test_list_g_day_length_nistxml_sv_iv_list_g_day_length_1_5(save_xml):
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -6396,11 +6804,12 @@ def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -6411,11 +6820,12 @@ def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -6426,11 +6836,12 @@ def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -6441,11 +6852,12 @@ def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 10.
@@ -6456,11 +6868,12 @@ def test_list_g_day_min_length_4_nistxml_sv_iv_list_g_day_min_length_5_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -6471,11 +6884,12 @@ def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -6486,11 +6900,12 @@ def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -6501,11 +6916,12 @@ def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -6516,11 +6932,12 @@ def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 8.
@@ -6531,11 +6948,12 @@ def test_list_g_day_min_length_3_nistxml_sv_iv_list_g_day_min_length_4_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -6546,11 +6964,12 @@ def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -6561,11 +6980,12 @@ def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -6576,11 +6996,12 @@ def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -6591,11 +7012,12 @@ def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 7.
@@ -6606,11 +7028,12 @@ def test_list_g_day_min_length_2_nistxml_sv_iv_list_g_day_min_length_3_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -6621,11 +7044,12 @@ def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -6636,11 +7060,12 @@ def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -6651,11 +7076,12 @@ def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -6666,11 +7092,12 @@ def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 6.
@@ -6681,11 +7108,12 @@ def test_list_g_day_min_length_1_nistxml_sv_iv_list_g_day_min_length_2_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_1(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -6696,11 +7124,12 @@ def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_1(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_2(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -6711,11 +7140,12 @@ def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_2(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_3(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -6726,11 +7156,12 @@ def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_3(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_4(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -6741,11 +7172,12 @@ def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_4(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_5(save_xml):
     """
     Type list/gDay is restricted by facet minLength with value 5.
@@ -6756,11 +7188,12 @@ def test_list_g_day_min_length_nistxml_sv_iv_list_g_day_min_length_1_5(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -6771,11 +7204,12 @@ def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -6786,11 +7220,12 @@ def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -6801,11 +7236,12 @@ def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -6816,11 +7252,12 @@ def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 10.
@@ -6831,11 +7268,12 @@ def test_list_g_day_max_length_4_nistxml_sv_iv_list_g_day_max_length_5_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -6846,11 +7284,12 @@ def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -6861,11 +7300,12 @@ def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -6876,11 +7316,12 @@ def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -6891,11 +7332,12 @@ def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 8.
@@ -6906,11 +7348,12 @@ def test_list_g_day_max_length_3_nistxml_sv_iv_list_g_day_max_length_4_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -6921,11 +7364,12 @@ def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -6936,11 +7380,12 @@ def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -6951,11 +7396,12 @@ def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -6966,11 +7412,12 @@ def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 7.
@@ -6981,11 +7428,12 @@ def test_list_g_day_max_length_2_nistxml_sv_iv_list_g_day_max_length_3_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -6996,11 +7444,12 @@ def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_1(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7011,11 +7460,12 @@ def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_2(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7026,11 +7476,12 @@ def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_3(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7041,11 +7492,12 @@ def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_4(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 6.
@@ -7056,11 +7508,12 @@ def test_list_g_day_max_length_1_nistxml_sv_iv_list_g_day_max_length_2_5(save_xm
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_1(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -7071,11 +7524,12 @@ def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_1(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_2(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -7086,11 +7540,12 @@ def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_2(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_3(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -7101,11 +7556,12 @@ def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_3(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_4(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -7116,11 +7572,12 @@ def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_4(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_5(save_xml):
     """
     Type list/gDay is restricted by facet maxLength with value 5.
@@ -7131,11 +7588,12 @@ def test_list_g_day_max_length_nistxml_sv_iv_list_g_day_max_length_1_5(save_xml)
         instance="nistData/list/gDay/Schema+Instance/NISTXML-SV-IV-list-gDay-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet whiteSpace with value
@@ -7147,11 +7605,12 @@ def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet whiteSpace with value
@@ -7163,11 +7622,12 @@ def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet whiteSpace with value
@@ -7179,11 +7639,12 @@ def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet whiteSpace with value
@@ -7195,11 +7656,12 @@ def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet whiteSpace with value
@@ -7211,11 +7673,12 @@ def test_list_g_month_day_white_space_nistxml_sv_iv_list_g_month_day_white_space
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumeration_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7226,11 +7689,12 @@ def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumeration_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7241,11 +7705,12 @@ def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumeration_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7256,11 +7721,12 @@ def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumeration_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7271,11 +7737,12 @@ def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumeration_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7286,11 +7753,12 @@ def test_list_g_month_day_enumeration_4_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumeration_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7301,11 +7769,12 @@ def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumeration_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7316,11 +7785,12 @@ def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumeration_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7331,11 +7801,12 @@ def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumeration_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7346,11 +7817,12 @@ def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumeration_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7361,11 +7833,12 @@ def test_list_g_month_day_enumeration_3_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumeration_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7376,11 +7849,12 @@ def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumeration_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7391,11 +7865,12 @@ def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumeration_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7406,11 +7881,12 @@ def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumeration_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7421,11 +7897,12 @@ def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumeration_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7436,11 +7913,12 @@ def test_list_g_month_day_enumeration_2_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumeration_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7451,11 +7929,12 @@ def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumeration_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7466,11 +7945,12 @@ def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumeration_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7481,11 +7961,12 @@ def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumeration_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7496,11 +7977,12 @@ def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumeration_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7511,11 +7993,12 @@ def test_list_g_month_day_enumeration_1_nistxml_sv_iv_list_g_month_day_enumerati
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7526,11 +8009,12 @@ def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7541,11 +8025,12 @@ def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7556,11 +8041,12 @@ def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7571,11 +8057,12 @@ def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet enumeration.
@@ -7586,11 +8073,12 @@ def test_list_g_month_day_enumeration_nistxml_sv_iv_list_g_month_day_enumeration
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7603,11 +8091,12 @@ def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7620,11 +8109,12 @@ def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7637,11 +8127,12 @@ def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7654,11 +8145,12 @@ def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7671,11 +8163,12 @@ def test_list_g_month_day_pattern_4_nistxml_sv_iv_list_g_month_day_pattern_5_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7688,11 +8181,12 @@ def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7705,11 +8199,12 @@ def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7722,11 +8217,12 @@ def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7739,11 +8235,12 @@ def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7756,11 +8253,12 @@ def test_list_g_month_day_pattern_3_nistxml_sv_iv_list_g_month_day_pattern_4_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7773,11 +8271,12 @@ def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7790,11 +8289,12 @@ def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7807,11 +8307,12 @@ def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7824,11 +8325,12 @@ def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7841,11 +8343,12 @@ def test_list_g_month_day_pattern_2_nistxml_sv_iv_list_g_month_day_pattern_3_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7858,11 +8361,12 @@ def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_1(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7875,11 +8379,12 @@ def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_2(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7892,11 +8397,12 @@ def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_3(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7909,11 +8415,12 @@ def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_4(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7926,11 +8433,12 @@ def test_list_g_month_day_pattern_1_nistxml_sv_iv_list_g_month_day_pattern_2_5(s
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_1(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7943,11 +8451,12 @@ def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_2(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7960,11 +8469,12 @@ def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_3(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7977,11 +8487,12 @@ def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_4(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -7994,11 +8505,12 @@ def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_5(save_xml):
     r"""
     Type list/gMonthDay is restricted by facet pattern with value
@@ -8011,11 +8523,12 @@ def test_list_g_month_day_pattern_nistxml_sv_iv_list_g_month_day_pattern_1_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8026,11 +8539,12 @@ def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8041,11 +8555,12 @@ def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8056,11 +8571,12 @@ def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8071,11 +8587,12 @@ def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 10.
@@ -8086,11 +8603,12 @@ def test_list_g_month_day_length_4_nistxml_sv_iv_list_g_month_day_length_5_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8101,11 +8619,12 @@ def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8116,11 +8635,12 @@ def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8131,11 +8651,12 @@ def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8146,11 +8667,12 @@ def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 8.
@@ -8161,11 +8683,12 @@ def test_list_g_month_day_length_3_nistxml_sv_iv_list_g_month_day_length_4_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -8176,11 +8699,12 @@ def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -8191,11 +8715,12 @@ def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -8206,11 +8731,12 @@ def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -8221,11 +8747,12 @@ def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 7.
@@ -8236,11 +8763,12 @@ def test_list_g_month_day_length_2_nistxml_sv_iv_list_g_month_day_length_3_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -8251,11 +8779,12 @@ def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_1(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -8266,11 +8795,12 @@ def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_2(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -8281,11 +8811,12 @@ def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_3(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -8296,11 +8827,12 @@ def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_4(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 6.
@@ -8311,11 +8843,12 @@ def test_list_g_month_day_length_1_nistxml_sv_iv_list_g_month_day_length_2_5(sav
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -8326,11 +8859,12 @@ def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_1(save_
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -8341,11 +8875,12 @@ def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_2(save_
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -8356,11 +8891,12 @@ def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_3(save_
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -8371,11 +8907,12 @@ def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_4(save_
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet length with value 5.
@@ -8386,11 +8923,12 @@ def test_list_g_month_day_length_nistxml_sv_iv_list_g_month_day_length_1_5(save_
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -8401,11 +8939,12 @@ def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -8416,11 +8955,12 @@ def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -8431,11 +8971,12 @@ def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -8446,11 +8987,12 @@ def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 10.
@@ -8461,11 +9003,12 @@ def test_list_g_month_day_min_length_4_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -8476,11 +9019,12 @@ def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -8491,11 +9035,12 @@ def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -8506,11 +9051,12 @@ def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -8521,11 +9067,12 @@ def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 8.
@@ -8536,11 +9083,12 @@ def test_list_g_month_day_min_length_3_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -8551,11 +9099,12 @@ def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -8566,11 +9115,12 @@ def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -8581,11 +9131,12 @@ def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -8596,11 +9147,12 @@ def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 7.
@@ -8611,11 +9163,12 @@ def test_list_g_month_day_min_length_2_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -8626,11 +9179,12 @@ def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -8641,11 +9195,12 @@ def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -8656,11 +9211,12 @@ def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -8671,11 +9227,12 @@ def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 6.
@@ -8686,11 +9243,12 @@ def test_list_g_month_day_min_length_1_nistxml_sv_iv_list_g_month_day_min_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -8701,11 +9259,12 @@ def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -8716,11 +9275,12 @@ def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -8731,11 +9291,12 @@ def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -8746,11 +9307,12 @@ def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet minLength with value 5.
@@ -8761,11 +9323,12 @@ def test_list_g_month_day_min_length_nistxml_sv_iv_list_g_month_day_min_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length_5_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -8776,11 +9339,12 @@ def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length_5_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -8791,11 +9355,12 @@ def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length_5_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -8806,11 +9371,12 @@ def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length_5_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -8821,11 +9387,12 @@ def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length_5_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 10.
@@ -8836,11 +9403,12 @@ def test_list_g_month_day_max_length_4_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length_4_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -8851,11 +9419,12 @@ def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length_4_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -8866,11 +9435,12 @@ def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length_4_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -8881,11 +9451,12 @@ def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length_4_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -8896,11 +9467,12 @@ def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length_4_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 8.
@@ -8911,11 +9483,12 @@ def test_list_g_month_day_max_length_3_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length_3_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -8926,11 +9499,12 @@ def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length_3_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -8941,11 +9515,12 @@ def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length_3_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -8956,11 +9531,12 @@ def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length_3_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -8971,11 +9547,12 @@ def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length_3_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 7.
@@ -8986,11 +9563,12 @@ def test_list_g_month_day_max_length_2_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length_2_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9001,11 +9579,12 @@ def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length_2_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9016,11 +9595,12 @@ def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length_2_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9031,11 +9611,12 @@ def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length_2_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9046,11 +9627,12 @@ def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length_2_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 6.
@@ -9061,11 +9643,12 @@ def test_list_g_month_day_max_length_1_nistxml_sv_iv_list_g_month_day_max_length
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1_1(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9076,11 +9659,12 @@ def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1_2(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9091,11 +9675,12 @@ def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1_3(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9106,11 +9691,12 @@ def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1_4(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9121,11 +9707,12 @@ def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1_5(save_xml):
     """
     Type list/gMonthDay is restricted by facet maxLength with value 5.
@@ -9136,11 +9723,12 @@ def test_list_g_month_day_max_length_nistxml_sv_iv_list_g_month_day_max_length_1
         instance="nistData/list/gMonthDay/Schema+Instance/NISTXML-SV-IV-list-gMonthDay-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGMonthDayMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_1(save_xml):
     """
     Type list/gYear is restricted by facet whiteSpace with value collapse.
@@ -9151,11 +9739,12 @@ def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_2(save_xml):
     """
     Type list/gYear is restricted by facet whiteSpace with value collapse.
@@ -9166,11 +9755,12 @@ def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_3(save_xml):
     """
     Type list/gYear is restricted by facet whiteSpace with value collapse.
@@ -9181,11 +9771,12 @@ def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_4(save_xml):
     """
     Type list/gYear is restricted by facet whiteSpace with value collapse.
@@ -9196,11 +9787,12 @@ def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_5(save_xml):
     """
     Type list/gYear is restricted by facet whiteSpace with value collapse.
@@ -9211,11 +9803,12 @@ def test_list_g_year_white_space_nistxml_sv_iv_list_g_year_white_space_1_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9226,11 +9819,12 @@ def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9241,11 +9835,12 @@ def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9256,11 +9851,12 @@ def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9271,11 +9867,12 @@ def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9286,11 +9883,12 @@ def test_list_g_year_enumeration_4_nistxml_sv_iv_list_g_year_enumeration_5_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9301,11 +9899,12 @@ def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9316,11 +9915,12 @@ def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9331,11 +9931,12 @@ def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9346,11 +9947,12 @@ def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9361,11 +9963,12 @@ def test_list_g_year_enumeration_3_nistxml_sv_iv_list_g_year_enumeration_4_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9376,11 +9979,12 @@ def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9391,11 +9995,12 @@ def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9406,11 +10011,12 @@ def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9421,11 +10027,12 @@ def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9436,11 +10043,12 @@ def test_list_g_year_enumeration_2_nistxml_sv_iv_list_g_year_enumeration_3_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9451,11 +10059,12 @@ def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_1(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9466,11 +10075,12 @@ def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_2(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9481,11 +10091,12 @@ def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_3(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9496,11 +10107,12 @@ def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_4(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9511,11 +10123,12 @@ def test_list_g_year_enumeration_1_nistxml_sv_iv_list_g_year_enumeration_2_5(sav
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_1(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9526,11 +10139,12 @@ def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_2(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9541,11 +10155,12 @@ def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_3(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9556,11 +10171,12 @@ def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_4(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9571,11 +10187,12 @@ def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_5(save_xml):
     """
     Type list/gYear is restricted by facet enumeration.
@@ -9586,11 +10203,12 @@ def test_list_g_year_enumeration_nistxml_sv_iv_list_g_year_enumeration_1_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -9602,11 +10220,12 @@ def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -9618,11 +10237,12 @@ def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -9634,11 +10254,12 @@ def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -9650,11 +10271,12 @@ def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 18\d\d
@@ -9666,11 +10288,12 @@ def test_list_g_year_pattern_4_nistxml_sv_iv_list_g_year_pattern_5_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -9682,11 +10305,12 @@ def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -9698,11 +10322,12 @@ def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -9714,11 +10339,12 @@ def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -9730,11 +10356,12 @@ def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 19\d\d
@@ -9746,11 +10373,12 @@ def test_list_g_year_pattern_3_nistxml_sv_iv_list_g_year_pattern_4_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d93
@@ -9762,11 +10390,12 @@ def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d93
@@ -9778,11 +10407,12 @@ def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d93
@@ -9794,11 +10424,12 @@ def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d93
@@ -9810,11 +10441,12 @@ def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d93
@@ -9826,11 +10458,12 @@ def test_list_g_year_pattern_2_nistxml_sv_iv_list_g_year_pattern_3_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 17\d\d
@@ -9842,11 +10475,12 @@ def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 17\d\d
@@ -9858,11 +10492,12 @@ def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 17\d\d
@@ -9874,11 +10509,12 @@ def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 17\d\d
@@ -9890,11 +10526,12 @@ def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value 17\d\d
@@ -9906,11 +10543,12 @@ def test_list_g_year_pattern_1_nistxml_sv_iv_list_g_year_pattern_2_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_1(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d81
@@ -9922,11 +10560,12 @@ def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_2(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d81
@@ -9938,11 +10577,12 @@ def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_3(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d81
@@ -9954,11 +10594,12 @@ def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_4(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d81
@@ -9970,11 +10611,12 @@ def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_5(save_xml):
     r"""
     Type list/gYear is restricted by facet pattern with value \d\d81
@@ -9986,11 +10628,12 @@ def test_list_g_year_pattern_nistxml_sv_iv_list_g_year_pattern_1_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10001,11 +10644,12 @@ def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10016,11 +10660,12 @@ def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10031,11 +10676,12 @@ def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10046,11 +10692,12 @@ def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 10.
@@ -10061,11 +10708,12 @@ def test_list_g_year_length_4_nistxml_sv_iv_list_g_year_length_5_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10076,11 +10724,12 @@ def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10091,11 +10740,12 @@ def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10106,11 +10756,12 @@ def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10121,11 +10772,12 @@ def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 8.
@@ -10136,11 +10788,12 @@ def test_list_g_year_length_3_nistxml_sv_iv_list_g_year_length_4_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10151,11 +10804,12 @@ def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10166,11 +10820,12 @@ def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10181,11 +10836,12 @@ def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10196,11 +10852,12 @@ def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 7.
@@ -10211,11 +10868,12 @@ def test_list_g_year_length_2_nistxml_sv_iv_list_g_year_length_3_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -10226,11 +10884,12 @@ def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -10241,11 +10900,12 @@ def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -10256,11 +10916,12 @@ def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -10271,11 +10932,12 @@ def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 6.
@@ -10286,11 +10948,12 @@ def test_list_g_year_length_1_nistxml_sv_iv_list_g_year_length_2_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_1(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -10301,11 +10964,12 @@ def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_1(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_2(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -10316,11 +10980,12 @@ def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_2(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_3(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -10331,11 +10996,12 @@ def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_3(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_4(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -10346,11 +11012,12 @@ def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_4(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_5(save_xml):
     """
     Type list/gYear is restricted by facet length with value 5.
@@ -10361,11 +11028,12 @@ def test_list_g_year_length_nistxml_sv_iv_list_g_year_length_1_5(save_xml):
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -10376,11 +11044,12 @@ def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -10391,11 +11060,12 @@ def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -10406,11 +11076,12 @@ def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -10421,11 +11092,12 @@ def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 10.
@@ -10436,11 +11108,12 @@ def test_list_g_year_min_length_4_nistxml_sv_iv_list_g_year_min_length_5_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -10451,11 +11124,12 @@ def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -10466,11 +11140,12 @@ def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -10481,11 +11156,12 @@ def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -10496,11 +11172,12 @@ def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 8.
@@ -10511,11 +11188,12 @@ def test_list_g_year_min_length_3_nistxml_sv_iv_list_g_year_min_length_4_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -10526,11 +11204,12 @@ def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -10541,11 +11220,12 @@ def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -10556,11 +11236,12 @@ def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -10571,11 +11252,12 @@ def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 7.
@@ -10586,11 +11268,12 @@ def test_list_g_year_min_length_2_nistxml_sv_iv_list_g_year_min_length_3_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -10601,11 +11284,12 @@ def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -10616,11 +11300,12 @@ def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -10631,11 +11316,12 @@ def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -10646,11 +11332,12 @@ def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 6.
@@ -10661,11 +11348,12 @@ def test_list_g_year_min_length_1_nistxml_sv_iv_list_g_year_min_length_2_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_1(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -10676,11 +11364,12 @@ def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_1(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_2(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -10691,11 +11380,12 @@ def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_2(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_3(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -10706,11 +11396,12 @@ def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_3(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_4(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -10721,11 +11412,12 @@ def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_4(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_5(save_xml):
     """
     Type list/gYear is restricted by facet minLength with value 5.
@@ -10736,11 +11428,12 @@ def test_list_g_year_min_length_nistxml_sv_iv_list_g_year_min_length_1_5(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -10751,11 +11444,12 @@ def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -10766,11 +11460,12 @@ def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -10781,11 +11476,12 @@ def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -10796,11 +11492,12 @@ def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 10.
@@ -10811,11 +11508,12 @@ def test_list_g_year_max_length_4_nistxml_sv_iv_list_g_year_max_length_5_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -10826,11 +11524,12 @@ def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -10841,11 +11540,12 @@ def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -10856,11 +11556,12 @@ def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -10871,11 +11572,12 @@ def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 8.
@@ -10886,11 +11588,12 @@ def test_list_g_year_max_length_3_nistxml_sv_iv_list_g_year_max_length_4_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -10901,11 +11604,12 @@ def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -10916,11 +11620,12 @@ def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -10931,11 +11636,12 @@ def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -10946,11 +11652,12 @@ def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 7.
@@ -10961,11 +11668,12 @@ def test_list_g_year_max_length_2_nistxml_sv_iv_list_g_year_max_length_3_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -10976,11 +11684,12 @@ def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_1(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -10991,11 +11700,12 @@ def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_2(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11006,11 +11716,12 @@ def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_3(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11021,11 +11732,12 @@ def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_4(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 6.
@@ -11036,11 +11748,12 @@ def test_list_g_year_max_length_1_nistxml_sv_iv_list_g_year_max_length_2_5(save_
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_1(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11051,11 +11764,12 @@ def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_1(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_2(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11066,11 +11780,12 @@ def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_2(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_3(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11081,11 +11796,12 @@ def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_3(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_4(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11096,11 +11812,12 @@ def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_4(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_5(save_xml):
     """
     Type list/gYear is restricted by facet maxLength with value 5.
@@ -11111,11 +11828,12 @@ def test_list_g_year_max_length_nistxml_sv_iv_list_g_year_max_length_1_5(save_xm
         instance="nistData/list/gYear/Schema+Instance/NISTXML-SV-IV-list-gYear-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_space_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet whiteSpace with value
@@ -11127,11 +11845,12 @@ def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_spa
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_space_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet whiteSpace with value
@@ -11143,11 +11862,12 @@ def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_spa
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_space_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet whiteSpace with value
@@ -11159,11 +11879,12 @@ def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_spa
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_space_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet whiteSpace with value
@@ -11175,11 +11896,12 @@ def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_spa
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_space_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet whiteSpace with value
@@ -11191,11 +11913,12 @@ def test_list_g_year_month_white_space_nistxml_sv_iv_list_g_year_month_white_spa
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumeration_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11206,11 +11929,12 @@ def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumeration_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11221,11 +11945,12 @@ def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumeration_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11236,11 +11961,12 @@ def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumeration_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11251,11 +11977,12 @@ def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumeration_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11266,11 +11993,12 @@ def test_list_g_year_month_enumeration_4_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumeration_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11281,11 +12009,12 @@ def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumeration_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11296,11 +12025,12 @@ def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumeration_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11311,11 +12041,12 @@ def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumeration_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11326,11 +12057,12 @@ def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumeration_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11341,11 +12073,12 @@ def test_list_g_year_month_enumeration_3_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumeration_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11356,11 +12089,12 @@ def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumeration_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11371,11 +12105,12 @@ def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumeration_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11386,11 +12121,12 @@ def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumeration_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11401,11 +12137,12 @@ def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumeration_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11416,11 +12153,12 @@ def test_list_g_year_month_enumeration_2_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumeration_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11431,11 +12169,12 @@ def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumeration_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11446,11 +12185,12 @@ def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumeration_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11461,11 +12201,12 @@ def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumeration_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11476,11 +12217,12 @@ def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumeration_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11491,11 +12233,12 @@ def test_list_g_year_month_enumeration_1_nistxml_sv_iv_list_g_year_month_enumera
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumeration_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11506,11 +12249,12 @@ def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumerati
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumeration_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11521,11 +12265,12 @@ def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumerati
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumeration_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11536,11 +12281,12 @@ def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumerati
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumeration_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11551,11 +12297,12 @@ def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumerati
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumeration_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet enumeration.
@@ -11566,11 +12313,12 @@ def test_list_g_year_month_enumeration_nistxml_sv_iv_list_g_year_month_enumerati
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11583,11 +12331,12 @@ def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11600,11 +12349,12 @@ def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11617,11 +12367,12 @@ def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11634,11 +12385,12 @@ def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11651,11 +12403,12 @@ def test_list_g_year_month_pattern_4_nistxml_sv_iv_list_g_year_month_pattern_5_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11667,11 +12420,12 @@ def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11683,11 +12437,12 @@ def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11699,11 +12454,12 @@ def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11715,11 +12471,12 @@ def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11731,11 +12488,12 @@ def test_list_g_year_month_pattern_3_nistxml_sv_iv_list_g_year_month_pattern_4_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11748,11 +12506,12 @@ def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11765,11 +12524,12 @@ def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11782,11 +12542,12 @@ def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11799,11 +12560,12 @@ def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11816,11 +12578,12 @@ def test_list_g_year_month_pattern_2_nistxml_sv_iv_list_g_year_month_pattern_3_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11833,11 +12596,12 @@ def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_1
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11850,11 +12614,12 @@ def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_2
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11867,11 +12632,12 @@ def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_3
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11884,11 +12650,12 @@ def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_4
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11901,11 +12668,12 @@ def test_list_g_year_month_pattern_1_nistxml_sv_iv_list_g_year_month_pattern_2_5
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_1(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11918,11 +12686,12 @@ def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_2(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11935,11 +12704,12 @@ def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_3(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11952,11 +12722,12 @@ def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_4(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11969,11 +12740,12 @@ def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_5(save_xml):
     r"""
     Type list/gYearMonth is restricted by facet pattern with value
@@ -11986,11 +12758,12 @@ def test_list_g_year_month_pattern_nistxml_sv_iv_list_g_year_month_pattern_1_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12001,11 +12774,12 @@ def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12016,11 +12790,12 @@ def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12031,11 +12806,12 @@ def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12046,11 +12822,12 @@ def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 10.
@@ -12061,11 +12838,12 @@ def test_list_g_year_month_length_4_nistxml_sv_iv_list_g_year_month_length_5_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12076,11 +12854,12 @@ def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12091,11 +12870,12 @@ def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12106,11 +12886,12 @@ def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12121,11 +12902,12 @@ def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 8.
@@ -12136,11 +12918,12 @@ def test_list_g_year_month_length_3_nistxml_sv_iv_list_g_year_month_length_4_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12151,11 +12934,12 @@ def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12166,11 +12950,12 @@ def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12181,11 +12966,12 @@ def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12196,11 +12982,12 @@ def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 7.
@@ -12211,11 +12998,12 @@ def test_list_g_year_month_length_2_nistxml_sv_iv_list_g_year_month_length_3_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12226,11 +13014,12 @@ def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_1(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12241,11 +13030,12 @@ def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_2(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12256,11 +13046,12 @@ def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_3(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12271,11 +13062,12 @@ def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_4(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 6.
@@ -12286,11 +13078,12 @@ def test_list_g_year_month_length_1_nistxml_sv_iv_list_g_year_month_length_2_5(s
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -12301,11 +13094,12 @@ def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_1(sav
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -12316,11 +13110,12 @@ def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_2(sav
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -12331,11 +13126,12 @@ def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_3(sav
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -12346,11 +13142,12 @@ def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_4(sav
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet length with value 5.
@@ -12361,11 +13158,12 @@ def test_list_g_year_month_length_nistxml_sv_iv_list_g_year_month_length_1_5(sav
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_length_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -12376,11 +13174,12 @@ def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_length_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -12391,11 +13190,12 @@ def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_length_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -12406,11 +13206,12 @@ def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_length_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -12421,11 +13222,12 @@ def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_length_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 10.
@@ -12436,11 +13238,12 @@ def test_list_g_year_month_min_length_4_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_length_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -12451,11 +13254,12 @@ def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_length_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -12466,11 +13270,12 @@ def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_length_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -12481,11 +13286,12 @@ def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_length_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -12496,11 +13302,12 @@ def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_length_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 8.
@@ -12511,11 +13318,12 @@ def test_list_g_year_month_min_length_3_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_length_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -12526,11 +13334,12 @@ def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_length_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -12541,11 +13350,12 @@ def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_length_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -12556,11 +13366,12 @@ def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_length_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -12571,11 +13382,12 @@ def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_length_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 7.
@@ -12586,11 +13398,12 @@ def test_list_g_year_month_min_length_2_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_length_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -12601,11 +13414,12 @@ def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_length_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -12616,11 +13430,12 @@ def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_length_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -12631,11 +13446,12 @@ def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_length_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -12646,11 +13462,12 @@ def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_length_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 6.
@@ -12661,11 +13478,12 @@ def test_list_g_year_month_min_length_1_nistxml_sv_iv_list_g_year_month_min_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -12676,11 +13494,12 @@ def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -12691,11 +13510,12 @@ def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -12706,11 +13526,12 @@ def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -12721,11 +13542,12 @@ def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet minLength with value 5.
@@ -12736,11 +13558,12 @@ def test_list_g_year_month_min_length_nistxml_sv_iv_list_g_year_month_min_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_length_5_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -12751,11 +13574,12 @@ def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_length_5_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -12766,11 +13590,12 @@ def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_length_5_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -12781,11 +13606,12 @@ def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_length_5_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -12796,11 +13622,12 @@ def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_length_5_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 10.
@@ -12811,11 +13638,12 @@ def test_list_g_year_month_max_length_4_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_length_4_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -12826,11 +13654,12 @@ def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_length_4_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -12841,11 +13670,12 @@ def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_length_4_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -12856,11 +13686,12 @@ def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_length_4_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -12871,11 +13702,12 @@ def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_length_4_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 8.
@@ -12886,11 +13718,12 @@ def test_list_g_year_month_max_length_3_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_length_3_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -12901,11 +13734,12 @@ def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_length_3_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -12916,11 +13750,12 @@ def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_length_3_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -12931,11 +13766,12 @@ def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_length_3_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -12946,11 +13782,12 @@ def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_length_3_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 7.
@@ -12961,11 +13798,12 @@ def test_list_g_year_month_max_length_2_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_length_2_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -12976,11 +13814,12 @@ def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_length_2_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -12991,11 +13830,12 @@ def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_length_2_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13006,11 +13846,12 @@ def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_length_2_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13021,11 +13862,12 @@ def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_length_2_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 6.
@@ -13036,11 +13878,12 @@ def test_list_g_year_month_max_length_1_nistxml_sv_iv_list_g_year_month_max_leng
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length_1_1(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13051,11 +13894,12 @@ def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length_1_2(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13066,11 +13910,12 @@ def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length_1_3(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13081,11 +13926,12 @@ def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length_1_4(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13096,11 +13942,12 @@ def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length_1_5(save_xml):
     """
     Type list/gYearMonth is restricted by facet maxLength with value 5.
@@ -13111,11 +13958,12 @@ def test_list_g_year_month_max_length_nistxml_sv_iv_list_g_year_month_max_length
         instance="nistData/list/gYearMonth/Schema+Instance/NISTXML-SV-IV-list-gYearMonth-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListGYearMonthMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_1(save_xml):
     """
     Type list/date is restricted by facet whiteSpace with value collapse.
@@ -13126,11 +13974,12 @@ def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_2(save_xml):
     """
     Type list/date is restricted by facet whiteSpace with value collapse.
@@ -13141,11 +13990,12 @@ def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_3(save_xml):
     """
     Type list/date is restricted by facet whiteSpace with value collapse.
@@ -13156,11 +14006,12 @@ def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_4(save_xml):
     """
     Type list/date is restricted by facet whiteSpace with value collapse.
@@ -13171,11 +14022,12 @@ def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_5(save_xml):
     """
     Type list/date is restricted by facet whiteSpace with value collapse.
@@ -13186,11 +14038,12 @@ def test_list_date_white_space_nistxml_sv_iv_list_date_white_space_1_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13201,11 +14054,12 @@ def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13216,11 +14070,12 @@ def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13231,11 +14086,12 @@ def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13246,11 +14102,12 @@ def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13261,11 +14118,12 @@ def test_list_date_enumeration_4_nistxml_sv_iv_list_date_enumeration_5_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13276,11 +14134,12 @@ def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13291,11 +14150,12 @@ def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13306,11 +14166,12 @@ def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13321,11 +14182,12 @@ def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13336,11 +14198,12 @@ def test_list_date_enumeration_3_nistxml_sv_iv_list_date_enumeration_4_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13351,11 +14214,12 @@ def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13366,11 +14230,12 @@ def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13381,11 +14246,12 @@ def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13396,11 +14262,12 @@ def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13411,11 +14278,12 @@ def test_list_date_enumeration_2_nistxml_sv_iv_list_date_enumeration_3_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13426,11 +14294,12 @@ def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_1(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13441,11 +14310,12 @@ def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_2(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13456,11 +14326,12 @@ def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_3(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13471,11 +14342,12 @@ def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_4(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13486,11 +14358,12 @@ def test_list_date_enumeration_1_nistxml_sv_iv_list_date_enumeration_2_5(save_xm
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_1(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13501,11 +14374,12 @@ def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_2(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13516,11 +14390,12 @@ def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_3(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13531,11 +14406,12 @@ def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_4(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13546,11 +14422,12 @@ def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_5(save_xml):
     """
     Type list/date is restricted by facet enumeration.
@@ -13561,11 +14438,12 @@ def test_list_date_enumeration_nistxml_sv_iv_list_date_enumeration_1_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13578,11 +14456,12 @@ def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13595,11 +14474,12 @@ def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13612,11 +14492,12 @@ def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13629,11 +14510,12 @@ def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13646,11 +14528,12 @@ def test_list_date_pattern_4_nistxml_sv_iv_list_date_pattern_5_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13663,11 +14546,12 @@ def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13680,11 +14564,12 @@ def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13697,11 +14582,12 @@ def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13714,11 +14600,12 @@ def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13731,11 +14618,12 @@ def test_list_date_pattern_3_nistxml_sv_iv_list_date_pattern_4_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13748,11 +14636,12 @@ def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13765,11 +14654,12 @@ def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13782,11 +14672,12 @@ def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13799,11 +14690,12 @@ def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13816,11 +14708,12 @@ def test_list_date_pattern_2_nistxml_sv_iv_list_date_pattern_3_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13833,11 +14726,12 @@ def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13850,11 +14744,12 @@ def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13867,11 +14762,12 @@ def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13884,11 +14780,12 @@ def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13901,11 +14798,12 @@ def test_list_date_pattern_1_nistxml_sv_iv_list_date_pattern_2_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_1(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13919,11 +14817,12 @@ def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_2(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13937,11 +14836,12 @@ def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_3(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13955,11 +14855,12 @@ def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_4(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13973,11 +14874,12 @@ def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_5(save_xml):
     r"""
     Type list/date is restricted by facet pattern with value
@@ -13991,11 +14893,12 @@ def test_list_date_pattern_nistxml_sv_iv_list_date_pattern_1_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDatePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_1(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14006,11 +14909,12 @@ def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_2(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14021,11 +14925,12 @@ def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_3(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14036,11 +14941,12 @@ def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_4(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14051,11 +14957,12 @@ def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_5(save_xml):
     """
     Type list/date is restricted by facet length with value 10.
@@ -14066,11 +14973,12 @@ def test_list_date_length_4_nistxml_sv_iv_list_date_length_5_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_1(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14081,11 +14989,12 @@ def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_2(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14096,11 +15005,12 @@ def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_3(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14111,11 +15021,12 @@ def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_4(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14126,11 +15037,12 @@ def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_5(save_xml):
     """
     Type list/date is restricted by facet length with value 8.
@@ -14141,11 +15053,12 @@ def test_list_date_length_3_nistxml_sv_iv_list_date_length_4_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_1(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14156,11 +15069,12 @@ def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_2(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14171,11 +15085,12 @@ def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_3(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14186,11 +15101,12 @@ def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_4(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14201,11 +15117,12 @@ def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_5(save_xml):
     """
     Type list/date is restricted by facet length with value 7.
@@ -14216,11 +15133,12 @@ def test_list_date_length_2_nistxml_sv_iv_list_date_length_3_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_1(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14231,11 +15149,12 @@ def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_2(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14246,11 +15165,12 @@ def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_3(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14261,11 +15181,12 @@ def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_4(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14276,11 +15197,12 @@ def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_5(save_xml):
     """
     Type list/date is restricted by facet length with value 6.
@@ -14291,11 +15213,12 @@ def test_list_date_length_1_nistxml_sv_iv_list_date_length_2_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_nistxml_sv_iv_list_date_length_1_1(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14306,11 +15229,12 @@ def test_list_date_length_nistxml_sv_iv_list_date_length_1_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_nistxml_sv_iv_list_date_length_1_2(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14321,11 +15245,12 @@ def test_list_date_length_nistxml_sv_iv_list_date_length_1_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_nistxml_sv_iv_list_date_length_1_3(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14336,11 +15261,12 @@ def test_list_date_length_nistxml_sv_iv_list_date_length_1_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_nistxml_sv_iv_list_date_length_1_4(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14351,11 +15277,12 @@ def test_list_date_length_nistxml_sv_iv_list_date_length_1_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_length_nistxml_sv_iv_list_date_length_1_5(save_xml):
     """
     Type list/date is restricted by facet length with value 5.
@@ -14366,11 +15293,12 @@ def test_list_date_length_nistxml_sv_iv_list_date_length_1_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -14381,11 +15309,12 @@ def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -14396,11 +15325,12 @@ def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -14411,11 +15341,12 @@ def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -14426,11 +15357,12 @@ def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 10.
@@ -14441,11 +15373,12 @@ def test_list_date_min_length_4_nistxml_sv_iv_list_date_min_length_5_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -14456,11 +15389,12 @@ def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -14471,11 +15405,12 @@ def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -14486,11 +15421,12 @@ def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -14501,11 +15437,12 @@ def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 8.
@@ -14516,11 +15453,12 @@ def test_list_date_min_length_3_nistxml_sv_iv_list_date_min_length_4_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -14531,11 +15469,12 @@ def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -14546,11 +15485,12 @@ def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -14561,11 +15501,12 @@ def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -14576,11 +15517,12 @@ def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 7.
@@ -14591,11 +15533,12 @@ def test_list_date_min_length_2_nistxml_sv_iv_list_date_min_length_3_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -14606,11 +15549,12 @@ def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -14621,11 +15565,12 @@ def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -14636,11 +15581,12 @@ def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -14651,11 +15597,12 @@ def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 6.
@@ -14666,11 +15613,12 @@ def test_list_date_min_length_1_nistxml_sv_iv_list_date_min_length_2_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_1(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -14681,11 +15629,12 @@ def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_2(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -14696,11 +15645,12 @@ def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_3(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -14711,11 +15661,12 @@ def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_4(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -14726,11 +15677,12 @@ def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_5(save_xml):
     """
     Type list/date is restricted by facet minLength with value 5.
@@ -14741,11 +15693,12 @@ def test_list_date_min_length_nistxml_sv_iv_list_date_min_length_1_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -14756,11 +15709,12 @@ def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -14771,11 +15725,12 @@ def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -14786,11 +15741,12 @@ def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -14801,11 +15757,12 @@ def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 10.
@@ -14816,11 +15773,12 @@ def test_list_date_max_length_4_nistxml_sv_iv_list_date_max_length_5_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -14831,11 +15789,12 @@ def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -14846,11 +15805,12 @@ def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -14861,11 +15821,12 @@ def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -14876,11 +15837,12 @@ def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 8.
@@ -14891,11 +15853,12 @@ def test_list_date_max_length_3_nistxml_sv_iv_list_date_max_length_4_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -14906,11 +15869,12 @@ def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -14921,11 +15885,12 @@ def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -14936,11 +15901,12 @@ def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -14951,11 +15917,12 @@ def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 7.
@@ -14966,11 +15933,12 @@ def test_list_date_max_length_2_nistxml_sv_iv_list_date_max_length_3_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -14981,11 +15949,12 @@ def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_1(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -14996,11 +15965,12 @@ def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_2(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -15011,11 +15981,12 @@ def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_3(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -15026,11 +15997,12 @@ def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_4(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 6.
@@ -15041,11 +16013,12 @@ def test_list_date_max_length_1_nistxml_sv_iv_list_date_max_length_2_5(save_xml)
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_1(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -15056,11 +16029,12 @@ def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_1(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_2(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -15071,11 +16045,12 @@ def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_2(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_3(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -15086,11 +16061,12 @@ def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_3(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_4(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -15101,11 +16077,12 @@ def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_4(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_5(save_xml):
     """
     Type list/date is restricted by facet maxLength with value 5.
@@ -15116,11 +16093,12 @@ def test_list_date_max_length_nistxml_sv_iv_list_date_max_length_1_5(save_xml):
         instance="nistData/list/date/Schema+Instance/NISTXML-SV-IV-list-date-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_1(save_xml):
     """
     Type list/time is restricted by facet whiteSpace with value collapse.
@@ -15131,11 +16109,12 @@ def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_2(save_xml):
     """
     Type list/time is restricted by facet whiteSpace with value collapse.
@@ -15146,11 +16125,12 @@ def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_3(save_xml):
     """
     Type list/time is restricted by facet whiteSpace with value collapse.
@@ -15161,11 +16141,12 @@ def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_4(save_xml):
     """
     Type list/time is restricted by facet whiteSpace with value collapse.
@@ -15176,11 +16157,12 @@ def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_5(save_xml):
     """
     Type list/time is restricted by facet whiteSpace with value collapse.
@@ -15191,11 +16173,12 @@ def test_list_time_white_space_nistxml_sv_iv_list_time_white_space_1_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15206,11 +16189,12 @@ def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15221,11 +16205,12 @@ def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15236,11 +16221,12 @@ def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15251,11 +16237,12 @@ def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15266,11 +16253,12 @@ def test_list_time_enumeration_4_nistxml_sv_iv_list_time_enumeration_5_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15281,11 +16269,12 @@ def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15296,11 +16285,12 @@ def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15311,11 +16301,12 @@ def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15326,11 +16317,12 @@ def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15341,11 +16333,12 @@ def test_list_time_enumeration_3_nistxml_sv_iv_list_time_enumeration_4_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15356,11 +16349,12 @@ def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15371,11 +16365,12 @@ def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15386,11 +16381,12 @@ def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15401,11 +16397,12 @@ def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15416,11 +16413,12 @@ def test_list_time_enumeration_2_nistxml_sv_iv_list_time_enumeration_3_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15431,11 +16429,12 @@ def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_1(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15446,11 +16445,12 @@ def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_2(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15461,11 +16461,12 @@ def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_3(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15476,11 +16477,12 @@ def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_4(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -15491,6 +16493,6 @@ def test_list_time_enumeration_1_nistxml_sv_iv_list_time_enumeration_2_5(save_xm
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_8000.py
+++ b/tests/test_nist_meta_8000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_1(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -11,11 +14,12 @@ def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_2(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -26,11 +30,12 @@ def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_3(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -41,11 +46,12 @@ def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_4(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -56,11 +62,12 @@ def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_5(save_xml):
     """
     Type list/time is restricted by facet enumeration.
@@ -71,11 +78,12 @@ def test_list_time_enumeration_nistxml_sv_iv_list_time_enumeration_1_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d2:\d8:3\d
@@ -87,11 +95,12 @@ def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d2:\d8:3\d
@@ -103,11 +112,12 @@ def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d2:\d8:3\d
@@ -119,11 +129,12 @@ def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d2:\d8:3\d
@@ -135,11 +146,12 @@ def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d2:\d8:3\d
@@ -151,11 +163,12 @@ def test_list_time_pattern_4_nistxml_sv_iv_list_time_pattern_5_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d8:0\d:0\d
@@ -167,11 +180,12 @@ def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d8:0\d:0\d
@@ -183,11 +197,12 @@ def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d8:0\d:0\d
@@ -199,11 +214,12 @@ def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d8:0\d:0\d
@@ -215,11 +231,12 @@ def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d8:0\d:0\d
@@ -231,11 +248,12 @@ def test_list_time_pattern_3_nistxml_sv_iv_list_time_pattern_4_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d4:4\d:\d8
@@ -248,11 +266,12 @@ def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d4:4\d:\d8
@@ -265,11 +284,12 @@ def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d4:4\d:\d8
@@ -282,11 +302,12 @@ def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d4:4\d:\d8
@@ -299,11 +320,12 @@ def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value \d4:4\d:\d8
@@ -316,11 +338,12 @@ def test_list_time_pattern_2_nistxml_sv_iv_list_time_pattern_3_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -333,11 +356,12 @@ def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -350,11 +374,12 @@ def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -367,11 +392,12 @@ def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -384,11 +410,12 @@ def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 0\d:3\d:\d1
@@ -401,11 +428,12 @@ def test_list_time_pattern_1_nistxml_sv_iv_list_time_pattern_2_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_1(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d3:\d2
@@ -417,11 +445,12 @@ def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_2(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d3:\d2
@@ -433,11 +462,12 @@ def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_3(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d3:\d2
@@ -449,11 +479,12 @@ def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_4(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d3:\d2
@@ -465,11 +496,12 @@ def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_5(save_xml):
     r"""
     Type list/time is restricted by facet pattern with value 1\d:\d3:\d2
@@ -481,11 +513,12 @@ def test_list_time_pattern_nistxml_sv_iv_list_time_pattern_1_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_1(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -496,11 +529,12 @@ def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_2(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -511,11 +545,12 @@ def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_3(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -526,11 +561,12 @@ def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_4(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -541,11 +577,12 @@ def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_5(save_xml):
     """
     Type list/time is restricted by facet length with value 10.
@@ -556,11 +593,12 @@ def test_list_time_length_4_nistxml_sv_iv_list_time_length_5_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_1(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -571,11 +609,12 @@ def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_2(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -586,11 +625,12 @@ def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_3(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -601,11 +641,12 @@ def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_4(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -616,11 +657,12 @@ def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_5(save_xml):
     """
     Type list/time is restricted by facet length with value 8.
@@ -631,11 +673,12 @@ def test_list_time_length_3_nistxml_sv_iv_list_time_length_4_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_1(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -646,11 +689,12 @@ def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_2(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -661,11 +705,12 @@ def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_3(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -676,11 +721,12 @@ def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_4(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -691,11 +737,12 @@ def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_5(save_xml):
     """
     Type list/time is restricted by facet length with value 7.
@@ -706,11 +753,12 @@ def test_list_time_length_2_nistxml_sv_iv_list_time_length_3_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_1(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -721,11 +769,12 @@ def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_2(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -736,11 +785,12 @@ def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_3(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -751,11 +801,12 @@ def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_4(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -766,11 +817,12 @@ def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_5(save_xml):
     """
     Type list/time is restricted by facet length with value 6.
@@ -781,11 +833,12 @@ def test_list_time_length_1_nistxml_sv_iv_list_time_length_2_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_nistxml_sv_iv_list_time_length_1_1(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -796,11 +849,12 @@ def test_list_time_length_nistxml_sv_iv_list_time_length_1_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_nistxml_sv_iv_list_time_length_1_2(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -811,11 +865,12 @@ def test_list_time_length_nistxml_sv_iv_list_time_length_1_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_nistxml_sv_iv_list_time_length_1_3(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -826,11 +881,12 @@ def test_list_time_length_nistxml_sv_iv_list_time_length_1_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_nistxml_sv_iv_list_time_length_1_4(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -841,11 +897,12 @@ def test_list_time_length_nistxml_sv_iv_list_time_length_1_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_length_nistxml_sv_iv_list_time_length_1_5(save_xml):
     """
     Type list/time is restricted by facet length with value 5.
@@ -856,11 +913,12 @@ def test_list_time_length_nistxml_sv_iv_list_time_length_1_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -871,11 +929,12 @@ def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -886,11 +945,12 @@ def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -901,11 +961,12 @@ def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -916,11 +977,12 @@ def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 10.
@@ -931,11 +993,12 @@ def test_list_time_min_length_4_nistxml_sv_iv_list_time_min_length_5_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -946,11 +1009,12 @@ def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -961,11 +1025,12 @@ def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -976,11 +1041,12 @@ def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -991,11 +1057,12 @@ def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 8.
@@ -1006,11 +1073,12 @@ def test_list_time_min_length_3_nistxml_sv_iv_list_time_min_length_4_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1021,11 +1089,12 @@ def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1036,11 +1105,12 @@ def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1051,11 +1121,12 @@ def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1066,11 +1137,12 @@ def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 7.
@@ -1081,11 +1153,12 @@ def test_list_time_min_length_2_nistxml_sv_iv_list_time_min_length_3_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1096,11 +1169,12 @@ def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1111,11 +1185,12 @@ def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1126,11 +1201,12 @@ def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1141,11 +1217,12 @@ def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 6.
@@ -1156,11 +1233,12 @@ def test_list_time_min_length_1_nistxml_sv_iv_list_time_min_length_2_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_1(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1171,11 +1249,12 @@ def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_2(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1186,11 +1265,12 @@ def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_3(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1201,11 +1281,12 @@ def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_4(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1216,11 +1297,12 @@ def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_5(save_xml):
     """
     Type list/time is restricted by facet minLength with value 5.
@@ -1231,11 +1313,12 @@ def test_list_time_min_length_nistxml_sv_iv_list_time_min_length_1_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1246,11 +1329,12 @@ def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1261,11 +1345,12 @@ def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1276,11 +1361,12 @@ def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1291,11 +1377,12 @@ def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 10.
@@ -1306,11 +1393,12 @@ def test_list_time_max_length_4_nistxml_sv_iv_list_time_max_length_5_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -1321,11 +1409,12 @@ def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -1336,11 +1425,12 @@ def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -1351,11 +1441,12 @@ def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -1366,11 +1457,12 @@ def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 8.
@@ -1381,11 +1473,12 @@ def test_list_time_max_length_3_nistxml_sv_iv_list_time_max_length_4_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -1396,11 +1489,12 @@ def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -1411,11 +1505,12 @@ def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -1426,11 +1521,12 @@ def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -1441,11 +1537,12 @@ def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 7.
@@ -1456,11 +1553,12 @@ def test_list_time_max_length_2_nistxml_sv_iv_list_time_max_length_3_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -1471,11 +1569,12 @@ def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_1(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -1486,11 +1585,12 @@ def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_2(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -1501,11 +1601,12 @@ def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_3(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -1516,11 +1617,12 @@ def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_4(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 6.
@@ -1531,11 +1633,12 @@ def test_list_time_max_length_1_nistxml_sv_iv_list_time_max_length_2_5(save_xml)
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_1(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -1546,11 +1649,12 @@ def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_1(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_2(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -1561,11 +1665,12 @@ def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_2(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_3(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -1576,11 +1681,12 @@ def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_3(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_4(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -1591,11 +1697,12 @@ def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_4(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_5(save_xml):
     """
     Type list/time is restricted by facet maxLength with value 5.
@@ -1606,11 +1713,12 @@ def test_list_time_max_length_nistxml_sv_iv_list_time_max_length_1_5(save_xml):
         instance="nistData/list/time/Schema+Instance/NISTXML-SV-IV-list-time-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet whiteSpace with value
@@ -1622,11 +1730,12 @@ def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet whiteSpace with value
@@ -1638,11 +1747,12 @@ def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet whiteSpace with value
@@ -1654,11 +1764,12 @@ def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet whiteSpace with value
@@ -1670,11 +1781,12 @@ def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet whiteSpace with value
@@ -1686,11 +1798,12 @@ def test_list_date_time_white_space_nistxml_sv_iv_list_date_time_white_space_1_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1701,11 +1814,12 @@ def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1716,11 +1830,12 @@ def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1731,11 +1846,12 @@ def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1746,11 +1862,12 @@ def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1761,11 +1878,12 @@ def test_list_date_time_enumeration_4_nistxml_sv_iv_list_date_time_enumeration_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1776,11 +1894,12 @@ def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1791,11 +1910,12 @@ def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1806,11 +1926,12 @@ def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1821,11 +1942,12 @@ def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1836,11 +1958,12 @@ def test_list_date_time_enumeration_3_nistxml_sv_iv_list_date_time_enumeration_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1851,11 +1974,12 @@ def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1866,11 +1990,12 @@ def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1881,11 +2006,12 @@ def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1896,11 +2022,12 @@ def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1911,11 +2038,12 @@ def test_list_date_time_enumeration_2_nistxml_sv_iv_list_date_time_enumeration_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1926,11 +2054,12 @@ def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1941,11 +2070,12 @@ def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1956,11 +2086,12 @@ def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1971,11 +2102,12 @@ def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -1986,11 +2118,12 @@ def test_list_date_time_enumeration_1_nistxml_sv_iv_list_date_time_enumeration_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2001,11 +2134,12 @@ def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2016,11 +2150,12 @@ def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2031,11 +2166,12 @@ def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2046,11 +2182,12 @@ def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet enumeration.
@@ -2061,11 +2198,12 @@ def test_list_date_time_enumeration_nistxml_sv_iv_list_date_time_enumeration_1_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2079,11 +2217,12 @@ def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2097,11 +2236,12 @@ def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2115,11 +2255,12 @@ def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2133,11 +2274,12 @@ def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2151,11 +2293,12 @@ def test_list_date_time_pattern_4_nistxml_sv_iv_list_date_time_pattern_5_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2169,11 +2312,12 @@ def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2187,11 +2331,12 @@ def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2205,11 +2350,12 @@ def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2223,11 +2369,12 @@ def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2241,11 +2388,12 @@ def test_list_date_time_pattern_3_nistxml_sv_iv_list_date_time_pattern_4_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2261,11 +2409,12 @@ def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2281,11 +2430,12 @@ def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2301,11 +2451,12 @@ def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2321,11 +2472,12 @@ def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2341,11 +2493,12 @@ def test_list_date_time_pattern_2_nistxml_sv_iv_list_date_time_pattern_3_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2360,11 +2513,12 @@ def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_1(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2379,11 +2533,12 @@ def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_2(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2398,11 +2553,12 @@ def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_3(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2417,11 +2573,12 @@ def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_4(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2436,11 +2593,12 @@ def test_list_date_time_pattern_1_nistxml_sv_iv_list_date_time_pattern_2_5(save_
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_1(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2455,11 +2613,12 @@ def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_2(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2474,11 +2633,12 @@ def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_3(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2493,11 +2653,12 @@ def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_4(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2512,11 +2673,12 @@ def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_5(save_xml):
     r"""
     Type list/dateTime is restricted by facet pattern with value
@@ -2531,11 +2693,12 @@ def test_list_date_time_pattern_nistxml_sv_iv_list_date_time_pattern_1_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -2546,11 +2709,12 @@ def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -2561,11 +2725,12 @@ def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -2576,11 +2741,12 @@ def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -2591,11 +2757,12 @@ def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 10.
@@ -2606,11 +2773,12 @@ def test_list_date_time_length_4_nistxml_sv_iv_list_date_time_length_5_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -2621,11 +2789,12 @@ def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -2636,11 +2805,12 @@ def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -2651,11 +2821,12 @@ def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -2666,11 +2837,12 @@ def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 8.
@@ -2681,11 +2853,12 @@ def test_list_date_time_length_3_nistxml_sv_iv_list_date_time_length_4_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -2696,11 +2869,12 @@ def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -2711,11 +2885,12 @@ def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -2726,11 +2901,12 @@ def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -2741,11 +2917,12 @@ def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 7.
@@ -2756,11 +2933,12 @@ def test_list_date_time_length_2_nistxml_sv_iv_list_date_time_length_3_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -2771,11 +2949,12 @@ def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_1(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -2786,11 +2965,12 @@ def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_2(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -2801,11 +2981,12 @@ def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_3(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -2816,11 +2997,12 @@ def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_4(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 6.
@@ -2831,11 +3013,12 @@ def test_list_date_time_length_1_nistxml_sv_iv_list_date_time_length_2_5(save_xm
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -2846,11 +3029,12 @@ def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_1(save_xml)
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -2861,11 +3045,12 @@ def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_2(save_xml)
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -2876,11 +3061,12 @@ def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_3(save_xml)
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -2891,11 +3077,12 @@ def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_4(save_xml)
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet length with value 5.
@@ -2906,11 +3093,12 @@ def test_list_date_time_length_nistxml_sv_iv_list_date_time_length_1_5(save_xml)
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -2921,11 +3109,12 @@ def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -2936,11 +3125,12 @@ def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -2951,11 +3141,12 @@ def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -2966,11 +3157,12 @@ def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 10.
@@ -2981,11 +3173,12 @@ def test_list_date_time_min_length_4_nistxml_sv_iv_list_date_time_min_length_5_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -2996,11 +3189,12 @@ def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3011,11 +3205,12 @@ def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3026,11 +3221,12 @@ def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3041,11 +3237,12 @@ def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 8.
@@ -3056,11 +3253,12 @@ def test_list_date_time_min_length_3_nistxml_sv_iv_list_date_time_min_length_4_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3071,11 +3269,12 @@ def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3086,11 +3285,12 @@ def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3101,11 +3301,12 @@ def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3116,11 +3317,12 @@ def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 7.
@@ -3131,11 +3333,12 @@ def test_list_date_time_min_length_2_nistxml_sv_iv_list_date_time_min_length_3_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3146,11 +3349,12 @@ def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3161,11 +3365,12 @@ def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3176,11 +3381,12 @@ def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3191,11 +3397,12 @@ def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 6.
@@ -3206,11 +3413,12 @@ def test_list_date_time_min_length_1_nistxml_sv_iv_list_date_time_min_length_2_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3221,11 +3429,12 @@ def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_1(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3236,11 +3445,12 @@ def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_2(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3251,11 +3461,12 @@ def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_3(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3266,11 +3477,12 @@ def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_4(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet minLength with value 5.
@@ -3281,11 +3493,12 @@ def test_list_date_time_min_length_nistxml_sv_iv_list_date_time_min_length_1_5(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3296,11 +3509,12 @@ def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3311,11 +3525,12 @@ def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3326,11 +3541,12 @@ def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3341,11 +3557,12 @@ def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 10.
@@ -3356,11 +3573,12 @@ def test_list_date_time_max_length_4_nistxml_sv_iv_list_date_time_max_length_5_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3371,11 +3589,12 @@ def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3386,11 +3605,12 @@ def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3401,11 +3621,12 @@ def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3416,11 +3637,12 @@ def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 8.
@@ -3431,11 +3653,12 @@ def test_list_date_time_max_length_3_nistxml_sv_iv_list_date_time_max_length_4_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -3446,11 +3669,12 @@ def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -3461,11 +3685,12 @@ def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -3476,11 +3701,12 @@ def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -3491,11 +3717,12 @@ def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 7.
@@ -3506,11 +3733,12 @@ def test_list_date_time_max_length_2_nistxml_sv_iv_list_date_time_max_length_3_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -3521,11 +3749,12 @@ def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_1
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -3536,11 +3765,12 @@ def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_2
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -3551,11 +3781,12 @@ def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_3
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -3566,11 +3797,12 @@ def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_4
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 6.
@@ -3581,11 +3813,12 @@ def test_list_date_time_max_length_1_nistxml_sv_iv_list_date_time_max_length_2_5
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_1(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -3596,11 +3829,12 @@ def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_1(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_2(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -3611,11 +3845,12 @@ def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_2(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_3(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -3626,11 +3861,12 @@ def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_3(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_4(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -3641,11 +3877,12 @@ def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_4(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_5(save_xml):
     """
     Type list/dateTime is restricted by facet maxLength with value 5.
@@ -3656,11 +3893,12 @@ def test_list_date_time_max_length_nistxml_sv_iv_list_date_time_max_length_1_5(s
         instance="nistData/list/dateTime/Schema+Instance/NISTXML-SV-IV-list-dateTime-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDateTimeMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_1(save_xml):
     """
     Type list/duration is restricted by facet whiteSpace with value
@@ -3672,11 +3910,12 @@ def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_2(save_xml):
     """
     Type list/duration is restricted by facet whiteSpace with value
@@ -3688,11 +3927,12 @@ def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_3(save_xml):
     """
     Type list/duration is restricted by facet whiteSpace with value
@@ -3704,11 +3944,12 @@ def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_4(save_xml):
     """
     Type list/duration is restricted by facet whiteSpace with value
@@ -3720,11 +3961,12 @@ def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_5(save_xml):
     """
     Type list/duration is restricted by facet whiteSpace with value
@@ -3736,11 +3978,12 @@ def test_list_duration_white_space_nistxml_sv_iv_list_duration_white_space_1_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3751,11 +3994,12 @@ def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3766,11 +4010,12 @@ def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3781,11 +4026,12 @@ def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3796,11 +4042,12 @@ def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3811,11 +4058,12 @@ def test_list_duration_enumeration_4_nistxml_sv_iv_list_duration_enumeration_5_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3826,11 +4074,12 @@ def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3841,11 +4090,12 @@ def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3856,11 +4106,12 @@ def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3871,11 +4122,12 @@ def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3886,11 +4138,12 @@ def test_list_duration_enumeration_3_nistxml_sv_iv_list_duration_enumeration_4_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3901,11 +4154,12 @@ def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3916,11 +4170,12 @@ def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3931,11 +4186,12 @@ def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3946,11 +4202,12 @@ def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3961,11 +4218,12 @@ def test_list_duration_enumeration_2_nistxml_sv_iv_list_duration_enumeration_3_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3976,11 +4234,12 @@ def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_1
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -3991,11 +4250,12 @@ def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_2
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4006,11 +4266,12 @@ def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_3
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4021,11 +4282,12 @@ def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_4
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4036,11 +4298,12 @@ def test_list_duration_enumeration_1_nistxml_sv_iv_list_duration_enumeration_2_5
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_1(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4051,11 +4314,12 @@ def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_2(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4066,11 +4330,12 @@ def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_3(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4081,11 +4346,12 @@ def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_4(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4096,11 +4362,12 @@ def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_5(save_xml):
     """
     Type list/duration is restricted by facet enumeration.
@@ -4111,11 +4378,12 @@ def test_list_duration_enumeration_nistxml_sv_iv_list_duration_enumeration_1_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4129,11 +4397,12 @@ def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4147,11 +4416,12 @@ def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4165,11 +4435,12 @@ def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4183,11 +4454,12 @@ def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4201,11 +4473,12 @@ def test_list_duration_pattern_4_nistxml_sv_iv_list_duration_pattern_5_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4220,11 +4493,12 @@ def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4239,11 +4513,12 @@ def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4258,11 +4533,12 @@ def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4277,11 +4553,12 @@ def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4296,11 +4573,12 @@ def test_list_duration_pattern_3_nistxml_sv_iv_list_duration_pattern_4_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4316,11 +4594,12 @@ def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4336,11 +4615,12 @@ def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4356,11 +4636,12 @@ def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4376,11 +4657,12 @@ def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4396,11 +4678,12 @@ def test_list_duration_pattern_2_nistxml_sv_iv_list_duration_pattern_3_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4416,11 +4699,12 @@ def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_1(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4436,11 +4720,12 @@ def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_2(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4456,11 +4741,12 @@ def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_3(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4476,11 +4762,12 @@ def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_4(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4496,11 +4783,12 @@ def test_list_duration_pattern_1_nistxml_sv_iv_list_duration_pattern_2_5(save_xm
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_1(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4515,11 +4803,12 @@ def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_2(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4534,11 +4823,12 @@ def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_3(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4553,11 +4843,12 @@ def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_4(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4572,11 +4863,12 @@ def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_5(save_xml):
     r"""
     Type list/duration is restricted by facet pattern with value
@@ -4591,11 +4883,12 @@ def test_list_duration_pattern_nistxml_sv_iv_list_duration_pattern_1_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -4606,11 +4899,12 @@ def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -4621,11 +4915,12 @@ def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -4636,11 +4931,12 @@ def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -4651,11 +4947,12 @@ def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 10.
@@ -4666,11 +4963,12 @@ def test_list_duration_length_4_nistxml_sv_iv_list_duration_length_5_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -4681,11 +4979,12 @@ def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -4696,11 +4995,12 @@ def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -4711,11 +5011,12 @@ def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -4726,11 +5027,12 @@ def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 8.
@@ -4741,11 +5043,12 @@ def test_list_duration_length_3_nistxml_sv_iv_list_duration_length_4_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -4756,11 +5059,12 @@ def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -4771,11 +5075,12 @@ def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -4786,11 +5091,12 @@ def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -4801,11 +5107,12 @@ def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 7.
@@ -4816,11 +5123,12 @@ def test_list_duration_length_2_nistxml_sv_iv_list_duration_length_3_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -4831,11 +5139,12 @@ def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_1(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -4846,11 +5155,12 @@ def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_2(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -4861,11 +5171,12 @@ def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_3(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -4876,11 +5187,12 @@ def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_4(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 6.
@@ -4891,11 +5203,12 @@ def test_list_duration_length_1_nistxml_sv_iv_list_duration_length_2_5(save_xml)
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_1(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -4906,11 +5219,12 @@ def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_1(save_xml):
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_2(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -4921,11 +5235,12 @@ def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_2(save_xml):
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_3(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -4936,11 +5251,12 @@ def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_3(save_xml):
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_4(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -4951,11 +5267,12 @@ def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_4(save_xml):
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_5(save_xml):
     """
     Type list/duration is restricted by facet length with value 5.
@@ -4966,11 +5283,12 @@ def test_list_duration_length_nistxml_sv_iv_list_duration_length_1_5(save_xml):
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -4981,11 +5299,12 @@ def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -4996,11 +5315,12 @@ def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5011,11 +5331,12 @@ def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5026,11 +5347,12 @@ def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 10.
@@ -5041,11 +5363,12 @@ def test_list_duration_min_length_4_nistxml_sv_iv_list_duration_min_length_5_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5056,11 +5379,12 @@ def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5071,11 +5395,12 @@ def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5086,11 +5411,12 @@ def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5101,11 +5427,12 @@ def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 8.
@@ -5116,11 +5443,12 @@ def test_list_duration_min_length_3_nistxml_sv_iv_list_duration_min_length_4_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5131,11 +5459,12 @@ def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5146,11 +5475,12 @@ def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5161,11 +5491,12 @@ def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5176,11 +5507,12 @@ def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 7.
@@ -5191,11 +5523,12 @@ def test_list_duration_min_length_2_nistxml_sv_iv_list_duration_min_length_3_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5206,11 +5539,12 @@ def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5221,11 +5555,12 @@ def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5236,11 +5571,12 @@ def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5251,11 +5587,12 @@ def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 6.
@@ -5266,11 +5603,12 @@ def test_list_duration_min_length_1_nistxml_sv_iv_list_duration_min_length_2_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_1(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5281,11 +5619,12 @@ def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_1(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_2(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5296,11 +5635,12 @@ def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_2(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_3(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5311,11 +5651,12 @@ def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_3(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_4(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5326,11 +5667,12 @@ def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_4(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_5(save_xml):
     """
     Type list/duration is restricted by facet minLength with value 5.
@@ -5341,11 +5683,12 @@ def test_list_duration_min_length_nistxml_sv_iv_list_duration_min_length_1_5(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5356,11 +5699,12 @@ def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5371,11 +5715,12 @@ def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5386,11 +5731,12 @@ def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5401,11 +5747,12 @@ def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 10.
@@ -5416,11 +5763,12 @@ def test_list_duration_max_length_4_nistxml_sv_iv_list_duration_max_length_5_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5431,11 +5779,12 @@ def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5446,11 +5795,12 @@ def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5461,11 +5811,12 @@ def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5476,11 +5827,12 @@ def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 8.
@@ -5491,11 +5843,12 @@ def test_list_duration_max_length_3_nistxml_sv_iv_list_duration_max_length_4_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -5506,11 +5859,12 @@ def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -5521,11 +5875,12 @@ def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -5536,11 +5891,12 @@ def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -5551,11 +5907,12 @@ def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 7.
@@ -5566,11 +5923,12 @@ def test_list_duration_max_length_2_nistxml_sv_iv_list_duration_max_length_3_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -5581,11 +5939,12 @@ def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_1(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -5596,11 +5955,12 @@ def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_2(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -5611,11 +5971,12 @@ def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_3(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -5626,11 +5987,12 @@ def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_4(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 6.
@@ -5641,11 +6003,12 @@ def test_list_duration_max_length_1_nistxml_sv_iv_list_duration_max_length_2_5(s
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_1(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -5656,11 +6019,12 @@ def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_1(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_2(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -5671,11 +6035,12 @@ def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_2(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_3(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -5686,11 +6051,12 @@ def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_3(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_4(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -5701,11 +6067,12 @@ def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_4(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_5(save_xml):
     """
     Type list/duration is restricted by facet maxLength with value 5.
@@ -5716,11 +6083,12 @@ def test_list_duration_max_length_nistxml_sv_iv_list_duration_max_length_1_5(sav
         instance="nistData/list/duration/Schema+Instance/NISTXML-SV-IV-list-duration-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDurationMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_1(save_xml):
     """
     Type list/float is restricted by facet whiteSpace with value collapse.
@@ -5731,11 +6099,12 @@ def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_2(save_xml):
     """
     Type list/float is restricted by facet whiteSpace with value collapse.
@@ -5746,11 +6115,12 @@ def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_3(save_xml):
     """
     Type list/float is restricted by facet whiteSpace with value collapse.
@@ -5761,11 +6131,12 @@ def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_4(save_xml):
     """
     Type list/float is restricted by facet whiteSpace with value collapse.
@@ -5776,11 +6147,12 @@ def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_5(save_xml):
     """
     Type list/float is restricted by facet whiteSpace with value collapse.
@@ -5791,11 +6163,12 @@ def test_list_float_white_space_nistxml_sv_iv_list_float_white_space_1_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5806,11 +6179,12 @@ def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5821,11 +6195,12 @@ def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5836,11 +6211,12 @@ def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5851,11 +6227,12 @@ def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5866,11 +6243,12 @@ def test_list_float_enumeration_4_nistxml_sv_iv_list_float_enumeration_5_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5881,11 +6259,12 @@ def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5896,11 +6275,12 @@ def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5911,11 +6291,12 @@ def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5926,11 +6307,12 @@ def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5941,11 +6323,12 @@ def test_list_float_enumeration_3_nistxml_sv_iv_list_float_enumeration_4_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5956,11 +6339,12 @@ def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5971,11 +6355,12 @@ def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -5986,11 +6371,12 @@ def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6001,11 +6387,12 @@ def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6016,11 +6403,12 @@ def test_list_float_enumeration_2_nistxml_sv_iv_list_float_enumeration_3_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6031,11 +6419,12 @@ def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_1(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6046,11 +6435,12 @@ def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_2(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6061,11 +6451,12 @@ def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_3(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6076,11 +6467,12 @@ def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_4(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6091,11 +6483,12 @@ def test_list_float_enumeration_1_nistxml_sv_iv_list_float_enumeration_2_5(save_
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_1(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6106,11 +6499,12 @@ def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_2(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6121,11 +6515,12 @@ def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_3(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6136,11 +6531,12 @@ def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_4(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6151,11 +6547,12 @@ def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_5(save_xml):
     """
     Type list/float is restricted by facet enumeration.
@@ -6166,11 +6563,12 @@ def test_list_float_enumeration_nistxml_sv_iv_list_float_enumeration_1_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6184,11 +6582,12 @@ def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6202,11 +6601,12 @@ def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6220,11 +6620,12 @@ def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6238,11 +6639,12 @@ def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6256,11 +6658,12 @@ def test_list_float_pattern_4_nistxml_sv_iv_list_float_pattern_5_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6273,11 +6676,12 @@ def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6290,11 +6694,12 @@ def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6307,11 +6712,12 @@ def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6324,11 +6730,12 @@ def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6341,11 +6748,12 @@ def test_list_float_pattern_3_nistxml_sv_iv_list_float_pattern_4_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6358,11 +6766,12 @@ def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6375,11 +6784,12 @@ def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6392,11 +6802,12 @@ def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6409,11 +6820,12 @@ def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6426,11 +6838,12 @@ def test_list_float_pattern_2_nistxml_sv_iv_list_float_pattern_3_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6444,11 +6857,12 @@ def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6462,11 +6876,12 @@ def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6480,11 +6895,12 @@ def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6498,11 +6914,12 @@ def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6516,11 +6933,12 @@ def test_list_float_pattern_1_nistxml_sv_iv_list_float_pattern_2_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_1(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6533,11 +6951,12 @@ def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_2(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6550,11 +6969,12 @@ def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_3(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6567,11 +6987,12 @@ def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_4(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6584,11 +7005,12 @@ def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_5(save_xml):
     r"""
     Type list/float is restricted by facet pattern with value
@@ -6601,11 +7023,12 @@ def test_list_float_pattern_nistxml_sv_iv_list_float_pattern_1_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_1(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -6616,11 +7039,12 @@ def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_2(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -6631,11 +7055,12 @@ def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_3(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -6646,11 +7071,12 @@ def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_4(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -6661,11 +7087,12 @@ def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_5(save_xml):
     """
     Type list/float is restricted by facet length with value 10.
@@ -6676,11 +7103,12 @@ def test_list_float_length_4_nistxml_sv_iv_list_float_length_5_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_1(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -6691,11 +7119,12 @@ def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_2(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -6706,11 +7135,12 @@ def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_3(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -6721,11 +7151,12 @@ def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_4(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -6736,11 +7167,12 @@ def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_5(save_xml):
     """
     Type list/float is restricted by facet length with value 8.
@@ -6751,11 +7183,12 @@ def test_list_float_length_3_nistxml_sv_iv_list_float_length_4_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_1(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -6766,11 +7199,12 @@ def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_2(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -6781,11 +7215,12 @@ def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_3(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -6796,11 +7231,12 @@ def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_4(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -6811,11 +7247,12 @@ def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_5(save_xml):
     """
     Type list/float is restricted by facet length with value 7.
@@ -6826,11 +7263,12 @@ def test_list_float_length_2_nistxml_sv_iv_list_float_length_3_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_1(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -6841,11 +7279,12 @@ def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_2(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -6856,11 +7295,12 @@ def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_3(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -6871,11 +7311,12 @@ def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_4(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -6886,11 +7327,12 @@ def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_5(save_xml):
     """
     Type list/float is restricted by facet length with value 6.
@@ -6901,11 +7343,12 @@ def test_list_float_length_1_nistxml_sv_iv_list_float_length_2_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_nistxml_sv_iv_list_float_length_1_1(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -6916,11 +7359,12 @@ def test_list_float_length_nistxml_sv_iv_list_float_length_1_1(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_nistxml_sv_iv_list_float_length_1_2(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -6931,11 +7375,12 @@ def test_list_float_length_nistxml_sv_iv_list_float_length_1_2(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_nistxml_sv_iv_list_float_length_1_3(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -6946,11 +7391,12 @@ def test_list_float_length_nistxml_sv_iv_list_float_length_1_3(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_nistxml_sv_iv_list_float_length_1_4(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -6961,11 +7407,12 @@ def test_list_float_length_nistxml_sv_iv_list_float_length_1_4(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_length_nistxml_sv_iv_list_float_length_1_5(save_xml):
     """
     Type list/float is restricted by facet length with value 5.
@@ -6976,11 +7423,12 @@ def test_list_float_length_nistxml_sv_iv_list_float_length_1_5(save_xml):
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -6991,11 +7439,12 @@ def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7006,11 +7455,12 @@ def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7021,11 +7471,12 @@ def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7036,11 +7487,12 @@ def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 10.
@@ -7051,11 +7503,12 @@ def test_list_float_min_length_4_nistxml_sv_iv_list_float_min_length_5_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7066,11 +7519,12 @@ def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7081,11 +7535,12 @@ def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7096,11 +7551,12 @@ def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7111,11 +7567,12 @@ def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 8.
@@ -7126,11 +7583,12 @@ def test_list_float_min_length_3_nistxml_sv_iv_list_float_min_length_4_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7141,11 +7599,12 @@ def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7156,11 +7615,12 @@ def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7171,11 +7631,12 @@ def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7186,11 +7647,12 @@ def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 7.
@@ -7201,11 +7663,12 @@ def test_list_float_min_length_2_nistxml_sv_iv_list_float_min_length_3_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7216,11 +7679,12 @@ def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7231,11 +7695,12 @@ def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7246,11 +7711,12 @@ def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7261,11 +7727,12 @@ def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 6.
@@ -7276,11 +7743,12 @@ def test_list_float_min_length_1_nistxml_sv_iv_list_float_min_length_2_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_1(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7291,11 +7759,12 @@ def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_1(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_2(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7306,11 +7775,12 @@ def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_2(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_3(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7321,11 +7791,12 @@ def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_3(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_4(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7336,11 +7807,12 @@ def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_4(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_5(save_xml):
     """
     Type list/float is restricted by facet minLength with value 5.
@@ -7351,11 +7823,12 @@ def test_list_float_min_length_nistxml_sv_iv_list_float_min_length_1_5(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7366,11 +7839,12 @@ def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7381,11 +7855,12 @@ def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7396,11 +7871,12 @@ def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7411,11 +7887,12 @@ def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 10.
@@ -7426,11 +7903,12 @@ def test_list_float_max_length_4_nistxml_sv_iv_list_float_max_length_5_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7441,11 +7919,12 @@ def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7456,11 +7935,12 @@ def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7471,11 +7951,12 @@ def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7486,11 +7967,12 @@ def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 8.
@@ -7501,11 +7983,12 @@ def test_list_float_max_length_3_nistxml_sv_iv_list_float_max_length_4_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7516,11 +7999,12 @@ def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7531,11 +8015,12 @@ def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7546,11 +8031,12 @@ def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7561,11 +8047,12 @@ def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 7.
@@ -7576,11 +8063,12 @@ def test_list_float_max_length_2_nistxml_sv_iv_list_float_max_length_3_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -7591,11 +8079,12 @@ def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_1(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -7606,11 +8095,12 @@ def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_2(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -7621,11 +8111,12 @@ def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_3(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -7636,11 +8127,12 @@ def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_4(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 6.
@@ -7651,11 +8143,12 @@ def test_list_float_max_length_1_nistxml_sv_iv_list_float_max_length_2_5(save_xm
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_1(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -7666,11 +8159,12 @@ def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_1(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_2(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -7681,11 +8175,12 @@ def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_2(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_3(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -7696,11 +8191,12 @@ def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_3(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_4(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -7711,11 +8207,12 @@ def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_4(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_5(save_xml):
     """
     Type list/float is restricted by facet maxLength with value 5.
@@ -7726,11 +8223,12 @@ def test_list_float_max_length_nistxml_sv_iv_list_float_max_length_1_5(save_xml)
         instance="nistData/list/float/Schema+Instance/NISTXML-SV-IV-list-float-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListFloatMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_1(save_xml):
     """
     Type list/double is restricted by facet whiteSpace with value
@@ -7742,11 +8240,12 @@ def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_2(save_xml):
     """
     Type list/double is restricted by facet whiteSpace with value
@@ -7758,11 +8257,12 @@ def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_3(save_xml):
     """
     Type list/double is restricted by facet whiteSpace with value
@@ -7774,11 +8274,12 @@ def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_4(save_xml):
     """
     Type list/double is restricted by facet whiteSpace with value
@@ -7790,11 +8291,12 @@ def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_5(save_xml):
     """
     Type list/double is restricted by facet whiteSpace with value
@@ -7806,11 +8308,12 @@ def test_list_double_white_space_nistxml_sv_iv_list_double_white_space_1_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7821,11 +8324,12 @@ def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7836,11 +8340,12 @@ def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7851,11 +8356,12 @@ def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7866,11 +8372,12 @@ def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7881,11 +8388,12 @@ def test_list_double_enumeration_4_nistxml_sv_iv_list_double_enumeration_5_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7896,11 +8404,12 @@ def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7911,11 +8420,12 @@ def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7926,11 +8436,12 @@ def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7941,11 +8452,12 @@ def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7956,11 +8468,12 @@ def test_list_double_enumeration_3_nistxml_sv_iv_list_double_enumeration_4_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7971,11 +8484,12 @@ def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -7986,11 +8500,12 @@ def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8001,11 +8516,12 @@ def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8016,11 +8532,12 @@ def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8031,11 +8548,12 @@ def test_list_double_enumeration_2_nistxml_sv_iv_list_double_enumeration_3_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8046,11 +8564,12 @@ def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_1(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8061,11 +8580,12 @@ def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_2(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8076,11 +8596,12 @@ def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_3(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8091,11 +8612,12 @@ def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_4(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8106,11 +8628,12 @@ def test_list_double_enumeration_1_nistxml_sv_iv_list_double_enumeration_2_5(sav
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_1(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8121,11 +8644,12 @@ def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_2(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8136,11 +8660,12 @@ def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_3(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8151,11 +8676,12 @@ def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_4(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8166,11 +8692,12 @@ def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_5(save_xml):
     """
     Type list/double is restricted by facet enumeration.
@@ -8181,11 +8708,12 @@ def test_list_double_enumeration_nistxml_sv_iv_list_double_enumeration_1_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8199,11 +8727,12 @@ def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8217,11 +8746,12 @@ def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8235,11 +8765,12 @@ def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8253,11 +8784,12 @@ def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8271,11 +8803,12 @@ def test_list_double_pattern_4_nistxml_sv_iv_list_double_pattern_5_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8289,11 +8822,12 @@ def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8307,11 +8841,12 @@ def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8325,11 +8860,12 @@ def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8343,11 +8879,12 @@ def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8361,11 +8898,12 @@ def test_list_double_pattern_3_nistxml_sv_iv_list_double_pattern_4_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8378,11 +8916,12 @@ def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8395,11 +8934,12 @@ def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8412,11 +8952,12 @@ def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8429,11 +8970,12 @@ def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8446,11 +8988,12 @@ def test_list_double_pattern_2_nistxml_sv_iv_list_double_pattern_3_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8464,11 +9007,12 @@ def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8482,11 +9026,12 @@ def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8500,11 +9045,12 @@ def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8518,11 +9064,12 @@ def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8536,11 +9083,12 @@ def test_list_double_pattern_1_nistxml_sv_iv_list_double_pattern_2_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_1(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8553,11 +9101,12 @@ def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_2(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8570,11 +9119,12 @@ def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_3(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8587,11 +9137,12 @@ def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_4(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8604,11 +9155,12 @@ def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_5(save_xml):
     r"""
     Type list/double is restricted by facet pattern with value
@@ -8621,11 +9173,12 @@ def test_list_double_pattern_nistxml_sv_iv_list_double_pattern_1_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoublePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_1(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -8636,11 +9189,12 @@ def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_2(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -8651,11 +9205,12 @@ def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_3(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -8666,11 +9221,12 @@ def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_4(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -8681,11 +9237,12 @@ def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_5(save_xml):
     """
     Type list/double is restricted by facet length with value 10.
@@ -8696,11 +9253,12 @@ def test_list_double_length_4_nistxml_sv_iv_list_double_length_5_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_1(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -8711,11 +9269,12 @@ def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_2(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -8726,11 +9285,12 @@ def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_3(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -8741,11 +9301,12 @@ def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_4(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -8756,11 +9317,12 @@ def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_5(save_xml):
     """
     Type list/double is restricted by facet length with value 8.
@@ -8771,11 +9333,12 @@ def test_list_double_length_3_nistxml_sv_iv_list_double_length_4_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_1(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -8786,11 +9349,12 @@ def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_2(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -8801,11 +9365,12 @@ def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_3(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -8816,11 +9381,12 @@ def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_4(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -8831,11 +9397,12 @@ def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_5(save_xml):
     """
     Type list/double is restricted by facet length with value 7.
@@ -8846,11 +9413,12 @@ def test_list_double_length_2_nistxml_sv_iv_list_double_length_3_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_1(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -8861,11 +9429,12 @@ def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_2(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -8876,11 +9445,12 @@ def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_3(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -8891,11 +9461,12 @@ def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_4(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -8906,11 +9477,12 @@ def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_5(save_xml):
     """
     Type list/double is restricted by facet length with value 6.
@@ -8921,11 +9493,12 @@ def test_list_double_length_1_nistxml_sv_iv_list_double_length_2_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_nistxml_sv_iv_list_double_length_1_1(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -8936,11 +9509,12 @@ def test_list_double_length_nistxml_sv_iv_list_double_length_1_1(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_nistxml_sv_iv_list_double_length_1_2(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -8951,11 +9525,12 @@ def test_list_double_length_nistxml_sv_iv_list_double_length_1_2(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_nistxml_sv_iv_list_double_length_1_3(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -8966,11 +9541,12 @@ def test_list_double_length_nistxml_sv_iv_list_double_length_1_3(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_nistxml_sv_iv_list_double_length_1_4(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -8981,11 +9557,12 @@ def test_list_double_length_nistxml_sv_iv_list_double_length_1_4(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_length_nistxml_sv_iv_list_double_length_1_5(save_xml):
     """
     Type list/double is restricted by facet length with value 5.
@@ -8996,11 +9573,12 @@ def test_list_double_length_nistxml_sv_iv_list_double_length_1_5(save_xml):
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9011,11 +9589,12 @@ def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9026,11 +9605,12 @@ def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9041,11 +9621,12 @@ def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9056,11 +9637,12 @@ def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 10.
@@ -9071,11 +9653,12 @@ def test_list_double_min_length_4_nistxml_sv_iv_list_double_min_length_5_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9086,11 +9669,12 @@ def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9101,11 +9685,12 @@ def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9116,11 +9701,12 @@ def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9131,11 +9717,12 @@ def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 8.
@@ -9146,11 +9733,12 @@ def test_list_double_min_length_3_nistxml_sv_iv_list_double_min_length_4_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9161,11 +9749,12 @@ def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9176,11 +9765,12 @@ def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9191,11 +9781,12 @@ def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9206,11 +9797,12 @@ def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 7.
@@ -9221,11 +9813,12 @@ def test_list_double_min_length_2_nistxml_sv_iv_list_double_min_length_3_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9236,11 +9829,12 @@ def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9251,11 +9845,12 @@ def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9266,11 +9861,12 @@ def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9281,11 +9877,12 @@ def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 6.
@@ -9296,11 +9893,12 @@ def test_list_double_min_length_1_nistxml_sv_iv_list_double_min_length_2_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_1(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9311,11 +9909,12 @@ def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_1(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_2(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9326,11 +9925,12 @@ def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_2(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_3(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9341,11 +9941,12 @@ def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_3(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_4(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9356,11 +9957,12 @@ def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_4(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_5(save_xml):
     """
     Type list/double is restricted by facet minLength with value 5.
@@ -9371,11 +9973,12 @@ def test_list_double_min_length_nistxml_sv_iv_list_double_min_length_1_5(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9386,11 +9989,12 @@ def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9401,11 +10005,12 @@ def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9416,11 +10021,12 @@ def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9431,11 +10037,12 @@ def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 10.
@@ -9446,11 +10053,12 @@ def test_list_double_max_length_4_nistxml_sv_iv_list_double_max_length_5_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9461,11 +10069,12 @@ def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9476,11 +10085,12 @@ def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9491,11 +10101,12 @@ def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9506,11 +10117,12 @@ def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 8.
@@ -9521,11 +10133,12 @@ def test_list_double_max_length_3_nistxml_sv_iv_list_double_max_length_4_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9536,11 +10149,12 @@ def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9551,11 +10165,12 @@ def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9566,11 +10181,12 @@ def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9581,11 +10197,12 @@ def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 7.
@@ -9596,11 +10213,12 @@ def test_list_double_max_length_2_nistxml_sv_iv_list_double_max_length_3_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9611,11 +10229,12 @@ def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_1(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9626,11 +10245,12 @@ def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_2(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9641,11 +10261,12 @@ def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_3(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9656,11 +10277,12 @@ def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_4(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 6.
@@ -9671,11 +10293,12 @@ def test_list_double_max_length_1_nistxml_sv_iv_list_double_max_length_2_5(save_
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_1(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -9686,11 +10309,12 @@ def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_1(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_2(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -9701,11 +10325,12 @@ def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_2(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_3(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -9716,11 +10341,12 @@ def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_3(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_4(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -9731,11 +10357,12 @@ def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_4(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_5(save_xml):
     """
     Type list/double is restricted by facet maxLength with value 5.
@@ -9746,11 +10373,12 @@ def test_list_double_max_length_nistxml_sv_iv_list_double_max_length_1_5(save_xm
         instance="nistData/list/double/Schema+Instance/NISTXML-SV-IV-list-double-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListDoubleMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_white_space_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet whiteSpace with value
@@ -9762,11 +10390,12 @@ def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_w
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_white_space_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet whiteSpace with value
@@ -9778,11 +10407,12 @@ def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_w
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_white_space_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet whiteSpace with value
@@ -9794,11 +10424,12 @@ def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_w
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_white_space_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet whiteSpace with value
@@ -9810,11 +10441,12 @@ def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_w
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_white_space_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet whiteSpace with value
@@ -9826,11 +10458,12 @@ def test_list_positive_integer_white_space_nistxml_sv_iv_list_positive_integer_w
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer_enumeration_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9841,11 +10474,12 @@ def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer_enumeration_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9856,11 +10490,12 @@ def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer_enumeration_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9871,11 +10506,12 @@ def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer_enumeration_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9886,11 +10522,12 @@ def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer_enumeration_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9901,11 +10538,12 @@ def test_list_positive_integer_enumeration_4_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer_enumeration_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9916,11 +10554,12 @@ def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer_enumeration_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9931,11 +10570,12 @@ def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer_enumeration_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9946,11 +10586,12 @@ def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer_enumeration_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9961,11 +10602,12 @@ def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer_enumeration_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9976,11 +10618,12 @@ def test_list_positive_integer_enumeration_3_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer_enumeration_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -9991,11 +10634,12 @@ def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer_enumeration_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10006,11 +10650,12 @@ def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer_enumeration_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10021,11 +10666,12 @@ def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer_enumeration_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10036,11 +10682,12 @@ def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer_enumeration_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10051,11 +10698,12 @@ def test_list_positive_integer_enumeration_2_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer_enumeration_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10066,11 +10714,12 @@ def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer_enumeration_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10081,11 +10730,12 @@ def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer_enumeration_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10096,11 +10746,12 @@ def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer_enumeration_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10111,11 +10762,12 @@ def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer_enumeration_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10126,11 +10778,12 @@ def test_list_positive_integer_enumeration_1_nistxml_sv_iv_list_positive_integer
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_enumeration_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10141,11 +10794,12 @@ def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_e
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_enumeration_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10156,11 +10810,12 @@ def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_e
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_enumeration_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10171,11 +10826,12 @@ def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_e
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_enumeration_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10186,11 +10842,12 @@ def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_e
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_enumeration_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet enumeration.
@@ -10201,11 +10858,12 @@ def test_list_positive_integer_enumeration_nistxml_sv_iv_list_positive_integer_e
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pattern_5_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10217,11 +10875,12 @@ def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pattern_5_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10233,11 +10892,12 @@ def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pattern_5_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10249,11 +10909,12 @@ def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pattern_5_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10265,11 +10926,12 @@ def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pattern_5_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10281,11 +10943,12 @@ def test_list_positive_integer_pattern_4_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pattern_4_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10297,11 +10960,12 @@ def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pattern_4_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10313,11 +10977,12 @@ def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pattern_4_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10329,11 +10994,12 @@ def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pattern_4_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10345,11 +11011,12 @@ def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pattern_4_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10361,11 +11028,12 @@ def test_list_positive_integer_pattern_3_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pattern_3_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10377,11 +11045,12 @@ def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pattern_3_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10393,11 +11062,12 @@ def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pattern_3_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10409,11 +11079,12 @@ def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pattern_3_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10425,11 +11096,12 @@ def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pattern_3_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10441,11 +11113,12 @@ def test_list_positive_integer_pattern_2_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pattern_2_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10457,11 +11130,12 @@ def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pattern_2_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10473,11 +11147,12 @@ def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pattern_2_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10489,11 +11164,12 @@ def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pattern_2_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10505,11 +11181,12 @@ def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pattern_2_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10521,11 +11198,12 @@ def test_list_positive_integer_pattern_1_nistxml_sv_iv_list_positive_integer_pat
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_pattern_1_1(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10537,11 +11215,12 @@ def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_patte
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_pattern_1_2(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10553,11 +11232,12 @@ def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_patte
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_pattern_1_3(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10569,11 +11249,12 @@ def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_patte
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_pattern_1_4(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10585,11 +11266,12 @@ def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_patte
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_pattern_1_5(save_xml):
     r"""
     Type list/positiveInteger is restricted by facet pattern with value
@@ -10601,11 +11283,12 @@ def test_list_positive_integer_pattern_nistxml_sv_iv_list_positive_integer_patte
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_length_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10616,11 +11299,12 @@ def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_length_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10631,11 +11315,12 @@ def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_length_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10646,11 +11331,12 @@ def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_length_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10661,11 +11347,12 @@ def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_length_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 10.
@@ -10676,11 +11363,12 @@ def test_list_positive_integer_length_4_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_length_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10691,11 +11379,12 @@ def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_length_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10706,11 +11395,12 @@ def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_length_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10721,11 +11411,12 @@ def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_length_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10736,11 +11427,12 @@ def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_length_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 8.
@@ -10751,11 +11443,12 @@ def test_list_positive_integer_length_3_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_length_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -10766,11 +11459,12 @@ def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_length_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -10781,11 +11475,12 @@ def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_length_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -10796,11 +11491,12 @@ def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_length_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -10811,11 +11507,12 @@ def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_length_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 7.
@@ -10826,11 +11523,12 @@ def test_list_positive_integer_length_2_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_length_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -10841,11 +11539,12 @@ def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_length_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -10856,11 +11555,12 @@ def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_length_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -10871,11 +11571,12 @@ def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_length_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -10886,11 +11587,12 @@ def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_length_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 6.
@@ -10901,11 +11603,12 @@ def test_list_positive_integer_length_1_nistxml_sv_iv_list_positive_integer_leng
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -10916,11 +11619,12 @@ def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -10931,11 +11635,12 @@ def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -10946,11 +11651,12 @@ def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -10961,11 +11667,12 @@ def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet length with value 5.
@@ -10976,11 +11683,12 @@ def test_list_positive_integer_length_nistxml_sv_iv_list_positive_integer_length
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_min_length_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -10992,11 +11700,12 @@ def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_min_length_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11008,11 +11717,12 @@ def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_min_length_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11024,11 +11734,12 @@ def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_min_length_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11040,11 +11751,12 @@ def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_min_length_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11056,11 +11768,12 @@ def test_list_positive_integer_min_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_min_length_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11072,11 +11785,12 @@ def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_min_length_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11088,11 +11802,12 @@ def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_min_length_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11104,11 +11819,12 @@ def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_min_length_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11120,11 +11836,12 @@ def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_min_length_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11136,11 +11853,12 @@ def test_list_positive_integer_min_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_min_length_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11152,11 +11870,12 @@ def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_min_length_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11168,11 +11887,12 @@ def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_min_length_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11184,11 +11904,12 @@ def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_min_length_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11200,11 +11921,12 @@ def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_min_length_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11216,11 +11938,12 @@ def test_list_positive_integer_min_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_min_length_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11232,11 +11955,12 @@ def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_min_length_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11248,11 +11972,12 @@ def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_min_length_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11264,11 +11989,12 @@ def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_min_length_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11280,11 +12006,12 @@ def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_min_length_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11296,11 +12023,12 @@ def test_list_positive_integer_min_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_min_length_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11312,11 +12040,12 @@ def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_mi
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_min_length_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11328,11 +12057,12 @@ def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_mi
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_min_length_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11344,11 +12074,12 @@ def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_mi
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_min_length_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11360,11 +12091,12 @@ def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_mi
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_min_length_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet minLength with value
@@ -11376,11 +12108,12 @@ def test_list_positive_integer_min_length_nistxml_sv_iv_list_positive_integer_mi
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_max_length_5_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11392,11 +12125,12 @@ def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_max_length_5_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11408,11 +12142,12 @@ def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_max_length_5_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11424,11 +12159,12 @@ def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_max_length_5_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11440,11 +12176,12 @@ def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_max_length_5_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11456,11 +12193,12 @@ def test_list_positive_integer_max_length_4_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_max_length_4_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11472,11 +12210,12 @@ def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_max_length_4_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11488,11 +12227,12 @@ def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_max_length_4_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11504,11 +12244,12 @@ def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_max_length_4_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11520,11 +12261,12 @@ def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_max_length_4_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11536,11 +12278,12 @@ def test_list_positive_integer_max_length_3_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_max_length_3_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11552,11 +12295,12 @@ def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_max_length_3_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11568,11 +12312,12 @@ def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_max_length_3_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11584,11 +12329,12 @@ def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_max_length_3_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11600,11 +12346,12 @@ def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_max_length_3_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11616,11 +12363,12 @@ def test_list_positive_integer_max_length_2_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_max_length_2_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11632,11 +12380,12 @@ def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_max_length_2_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11648,11 +12397,12 @@ def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_max_length_2_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11664,11 +12414,12 @@ def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_max_length_2_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11680,11 +12431,12 @@ def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_max_length_2_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11696,11 +12448,12 @@ def test_list_positive_integer_max_length_1_nistxml_sv_iv_list_positive_integer_
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_max_length_1_1(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11712,11 +12465,12 @@ def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_ma
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_max_length_1_2(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11728,11 +12482,12 @@ def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_ma
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_max_length_1_3(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11744,11 +12499,12 @@ def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_ma
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_max_length_1_4(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11760,11 +12516,12 @@ def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_ma
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_max_length_1_5(save_xml):
     """
     Type list/positiveInteger is restricted by facet maxLength with value
@@ -11776,11 +12533,12 @@ def test_list_positive_integer_max_length_nistxml_sv_iv_list_positive_integer_ma
         instance="nistData/list/positiveInteger/Schema+Instance/NISTXML-SV-IV-list-positiveInteger-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListPositiveIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_space_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet whiteSpace with value
@@ -11792,11 +12550,12 @@ def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_space_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet whiteSpace with value
@@ -11808,11 +12567,12 @@ def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_space_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet whiteSpace with value
@@ -11824,11 +12584,12 @@ def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_space_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet whiteSpace with value
@@ -11840,11 +12601,12 @@ def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_space_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet whiteSpace with value
@@ -11856,11 +12618,12 @@ def test_list_unsigned_byte_white_space_nistxml_sv_iv_list_unsigned_byte_white_s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enumeration_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11871,11 +12634,12 @@ def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enumeration_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11886,11 +12650,12 @@ def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enumeration_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11901,11 +12666,12 @@ def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enumeration_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11916,11 +12682,12 @@ def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enumeration_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11931,11 +12698,12 @@ def test_list_unsigned_byte_enumeration_4_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enumeration_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11946,11 +12714,12 @@ def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enumeration_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11961,11 +12730,12 @@ def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enumeration_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11976,11 +12746,12 @@ def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enumeration_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -11991,11 +12762,12 @@ def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enumeration_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12006,11 +12778,12 @@ def test_list_unsigned_byte_enumeration_3_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enumeration_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12021,11 +12794,12 @@ def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enumeration_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12036,11 +12810,12 @@ def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enumeration_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12051,11 +12826,12 @@ def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enumeration_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12066,11 +12842,12 @@ def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enumeration_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12081,11 +12858,12 @@ def test_list_unsigned_byte_enumeration_2_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enumeration_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12096,11 +12874,12 @@ def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enumeration_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12111,11 +12890,12 @@ def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enumeration_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12126,11 +12906,12 @@ def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enumeration_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12141,11 +12922,12 @@ def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enumeration_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12156,11 +12938,12 @@ def test_list_unsigned_byte_enumeration_1_nistxml_sv_iv_list_unsigned_byte_enume
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumeration_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12171,11 +12954,12 @@ def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumera
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumeration_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12186,11 +12970,12 @@ def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumera
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumeration_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12201,11 +12986,12 @@ def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumera
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumeration_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12216,11 +13002,12 @@ def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumera
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumeration_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet enumeration.
@@ -12231,11 +13018,12 @@ def test_list_unsigned_byte_enumeration_nistxml_sv_iv_list_unsigned_byte_enumera
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12247,11 +13035,12 @@ def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12263,11 +13052,12 @@ def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12279,11 +13069,12 @@ def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12295,11 +13086,12 @@ def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12311,11 +13103,12 @@ def test_list_unsigned_byte_pattern_4_nistxml_sv_iv_list_unsigned_byte_pattern_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12327,11 +13120,12 @@ def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12343,11 +13137,12 @@ def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12359,11 +13154,12 @@ def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12375,11 +13171,12 @@ def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12391,11 +13188,12 @@ def test_list_unsigned_byte_pattern_3_nistxml_sv_iv_list_unsigned_byte_pattern_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12407,11 +13205,12 @@ def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12423,11 +13222,12 @@ def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12439,11 +13239,12 @@ def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12455,11 +13256,12 @@ def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12471,11 +13273,12 @@ def test_list_unsigned_byte_pattern_2_nistxml_sv_iv_list_unsigned_byte_pattern_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12487,11 +13290,12 @@ def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12503,11 +13307,12 @@ def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12519,11 +13324,12 @@ def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12535,11 +13341,12 @@ def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12551,11 +13358,12 @@ def test_list_unsigned_byte_pattern_1_nistxml_sv_iv_list_unsigned_byte_pattern_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_1(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12567,11 +13375,12 @@ def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_2(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12583,11 +13392,12 @@ def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_3(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12599,11 +13409,12 @@ def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_4(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12615,11 +13426,12 @@ def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_5(save_xml):
     r"""
     Type list/unsignedByte is restricted by facet pattern with value \d{1}
@@ -12631,11 +13443,12 @@ def test_list_unsigned_byte_pattern_nistxml_sv_iv_list_unsigned_byte_pattern_1_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12646,11 +13459,12 @@ def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12661,11 +13475,12 @@ def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12676,11 +13491,12 @@ def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12691,11 +13507,12 @@ def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 10.
@@ -12706,11 +13523,12 @@ def test_list_unsigned_byte_length_4_nistxml_sv_iv_list_unsigned_byte_length_5_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12721,11 +13539,12 @@ def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12736,11 +13555,12 @@ def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12751,11 +13571,12 @@ def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12766,11 +13587,12 @@ def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 8.
@@ -12781,11 +13603,12 @@ def test_list_unsigned_byte_length_3_nistxml_sv_iv_list_unsigned_byte_length_4_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -12796,11 +13619,12 @@ def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -12811,11 +13635,12 @@ def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -12826,11 +13651,12 @@ def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -12841,11 +13667,12 @@ def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 7.
@@ -12856,11 +13683,12 @@ def test_list_unsigned_byte_length_2_nistxml_sv_iv_list_unsigned_byte_length_3_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -12871,11 +13699,12 @@ def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_1
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -12886,11 +13715,12 @@ def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_2
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -12901,11 +13731,12 @@ def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_3
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -12916,11 +13747,12 @@ def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_4
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 6.
@@ -12931,11 +13763,12 @@ def test_list_unsigned_byte_length_1_nistxml_sv_iv_list_unsigned_byte_length_2_5
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -12946,11 +13779,12 @@ def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_1(s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -12961,11 +13795,12 @@ def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_2(s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -12976,11 +13811,12 @@ def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_3(s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -12991,11 +13827,12 @@ def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_4(s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet length with value 5.
@@ -13006,11 +13843,12 @@ def test_list_unsigned_byte_length_nistxml_sv_iv_list_unsigned_byte_length_1_5(s
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_length_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13021,11 +13859,12 @@ def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_length_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13036,11 +13875,12 @@ def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_length_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13051,11 +13891,12 @@ def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_length_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13066,11 +13907,12 @@ def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_length_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 10.
@@ -13081,11 +13923,12 @@ def test_list_unsigned_byte_min_length_4_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_length_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13096,11 +13939,12 @@ def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_length_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13111,11 +13955,12 @@ def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_length_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13126,11 +13971,12 @@ def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_length_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13141,11 +13987,12 @@ def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_length_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 8.
@@ -13156,11 +14003,12 @@ def test_list_unsigned_byte_min_length_3_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_length_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13171,11 +14019,12 @@ def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_length_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13186,11 +14035,12 @@ def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_length_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13201,11 +14051,12 @@ def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_length_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13216,11 +14067,12 @@ def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_length_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 7.
@@ -13231,11 +14083,12 @@ def test_list_unsigned_byte_min_length_2_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_length_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13246,11 +14099,12 @@ def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_length_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13261,11 +14115,12 @@ def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_length_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13276,11 +14131,12 @@ def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_length_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13291,11 +14147,12 @@ def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_length_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 6.
@@ -13306,11 +14163,12 @@ def test_list_unsigned_byte_min_length_1_nistxml_sv_iv_list_unsigned_byte_min_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_length_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13321,11 +14179,12 @@ def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_length_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13336,11 +14195,12 @@ def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_length_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13351,11 +14211,12 @@ def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_length_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13366,11 +14227,12 @@ def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_length_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet minLength with value 5.
@@ -13381,11 +14243,12 @@ def test_list_unsigned_byte_min_length_nistxml_sv_iv_list_unsigned_byte_min_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_length_5_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13396,11 +14259,12 @@ def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_length_5_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13411,11 +14275,12 @@ def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_length_5_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13426,11 +14291,12 @@ def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_length_5_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13441,11 +14307,12 @@ def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_length_5_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 10.
@@ -13456,11 +14323,12 @@ def test_list_unsigned_byte_max_length_4_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_length_4_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13471,11 +14339,12 @@ def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_length_4_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13486,11 +14355,12 @@ def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_length_4_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13501,11 +14371,12 @@ def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_length_4_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13516,11 +14387,12 @@ def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_length_4_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 8.
@@ -13531,11 +14403,12 @@ def test_list_unsigned_byte_max_length_3_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_length_3_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13546,11 +14419,12 @@ def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_length_3_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13561,11 +14435,12 @@ def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_length_3_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13576,11 +14451,12 @@ def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_length_3_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13591,11 +14467,12 @@ def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_length_3_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 7.
@@ -13606,11 +14483,12 @@ def test_list_unsigned_byte_max_length_2_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_length_2_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13621,11 +14499,12 @@ def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_length_2_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13636,11 +14515,12 @@ def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_length_2_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13651,11 +14531,12 @@ def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_length_2_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13666,11 +14547,12 @@ def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_length_2_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 6.
@@ -13681,11 +14563,12 @@ def test_list_unsigned_byte_max_length_1_nistxml_sv_iv_list_unsigned_byte_max_le
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_length_1_1(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13696,11 +14579,12 @@ def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_length_1_2(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13711,11 +14595,12 @@ def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_length_1_3(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13726,11 +14611,12 @@ def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_length_1_4(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13741,11 +14627,12 @@ def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_length_1_5(save_xml):
     """
     Type list/unsignedByte is restricted by facet maxLength with value 5.
@@ -13756,11 +14643,12 @@ def test_list_unsigned_byte_max_length_nistxml_sv_iv_list_unsigned_byte_max_leng
         instance="nistData/list/unsignedByte/Schema+Instance/NISTXML-SV-IV-list-unsignedByte-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white_space_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet whiteSpace with value
@@ -13772,11 +14660,12 @@ def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white_space_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet whiteSpace with value
@@ -13788,11 +14677,12 @@ def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white_space_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet whiteSpace with value
@@ -13804,11 +14694,12 @@ def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white_space_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet whiteSpace with value
@@ -13820,11 +14711,12 @@ def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white_space_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet whiteSpace with value
@@ -13836,11 +14728,12 @@ def test_list_unsigned_short_white_space_nistxml_sv_iv_list_unsigned_short_white
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enumeration_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13851,11 +14744,12 @@ def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enumeration_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13866,11 +14760,12 @@ def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enumeration_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13881,11 +14776,12 @@ def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enumeration_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13896,11 +14792,12 @@ def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enumeration_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13911,11 +14808,12 @@ def test_list_unsigned_short_enumeration_4_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enumeration_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13926,11 +14824,12 @@ def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enumeration_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13941,11 +14840,12 @@ def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enumeration_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13956,11 +14856,12 @@ def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enumeration_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13971,11 +14872,12 @@ def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enumeration_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -13986,11 +14888,12 @@ def test_list_unsigned_short_enumeration_3_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enumeration_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14001,11 +14904,12 @@ def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enumeration_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14016,11 +14920,12 @@ def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enumeration_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14031,11 +14936,12 @@ def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enumeration_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14046,11 +14952,12 @@ def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enumeration_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14061,11 +14968,12 @@ def test_list_unsigned_short_enumeration_2_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enumeration_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14076,11 +14984,12 @@ def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enumeration_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14091,11 +15000,12 @@ def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enumeration_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14106,11 +15016,12 @@ def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enumeration_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14121,11 +15032,12 @@ def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enumeration_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14136,11 +15048,12 @@ def test_list_unsigned_short_enumeration_1_nistxml_sv_iv_list_unsigned_short_enu
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enumeration_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14151,11 +15064,12 @@ def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enume
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enumeration_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14166,11 +15080,12 @@ def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enume
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enumeration_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14181,11 +15096,12 @@ def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enume
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enumeration_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14196,11 +15112,12 @@ def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enume
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enumeration_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet enumeration.
@@ -14211,11 +15128,12 @@ def test_list_unsigned_short_enumeration_nistxml_sv_iv_list_unsigned_short_enume
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern_5_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14227,11 +15145,12 @@ def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern_5_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14243,11 +15162,12 @@ def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern_5_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14259,11 +15179,12 @@ def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern_5_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14275,11 +15196,12 @@ def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern_5_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14291,11 +15213,12 @@ def test_list_unsigned_short_pattern_4_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern_4_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14307,11 +15230,12 @@ def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern_4_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14323,11 +15247,12 @@ def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern_4_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14339,11 +15264,12 @@ def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern_4_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14355,11 +15281,12 @@ def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern_4_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14371,11 +15298,12 @@ def test_list_unsigned_short_pattern_3_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern_3_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14387,11 +15315,12 @@ def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern_3_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14403,11 +15332,12 @@ def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern_3_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14419,11 +15349,12 @@ def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern_3_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14435,11 +15366,12 @@ def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern_3_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14451,11 +15383,12 @@ def test_list_unsigned_short_pattern_2_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern_2_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14467,11 +15400,12 @@ def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern_2_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14483,11 +15417,12 @@ def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern_2_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14499,11 +15434,12 @@ def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern_2_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14515,11 +15451,12 @@ def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern_2_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14531,11 +15468,12 @@ def test_list_unsigned_short_pattern_1_nistxml_sv_iv_list_unsigned_short_pattern
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1_1(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14547,11 +15485,12 @@ def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1_2(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14563,11 +15502,12 @@ def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1_3(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14579,11 +15519,12 @@ def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1_4(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14595,11 +15536,12 @@ def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1_5(save_xml):
     r"""
     Type list/unsignedShort is restricted by facet pattern with value
@@ -14611,11 +15553,12 @@ def test_list_unsigned_short_pattern_nistxml_sv_iv_list_unsigned_short_pattern_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14626,11 +15569,12 @@ def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14641,11 +15585,12 @@ def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14656,11 +15601,12 @@ def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14671,11 +15617,12 @@ def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 10.
@@ -14686,11 +15633,12 @@ def test_list_unsigned_short_length_4_nistxml_sv_iv_list_unsigned_short_length_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14701,11 +15649,12 @@ def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14716,11 +15665,12 @@ def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14731,11 +15681,12 @@ def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14746,11 +15697,12 @@ def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 8.
@@ -14761,11 +15713,12 @@ def test_list_unsigned_short_length_3_nistxml_sv_iv_list_unsigned_short_length_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14776,11 +15729,12 @@ def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14791,11 +15745,12 @@ def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14806,11 +15761,12 @@ def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14821,11 +15777,12 @@ def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 7.
@@ -14836,11 +15793,12 @@ def test_list_unsigned_short_length_2_nistxml_sv_iv_list_unsigned_short_length_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14851,11 +15809,12 @@ def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14866,11 +15825,12 @@ def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14881,11 +15841,12 @@ def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14896,11 +15857,12 @@ def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 6.
@@ -14911,11 +15873,12 @@ def test_list_unsigned_short_length_1_nistxml_sv_iv_list_unsigned_short_length_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -14926,11 +15889,12 @@ def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_1
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -14941,11 +15905,12 @@ def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_2
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -14956,11 +15921,12 @@ def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_3
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -14971,11 +15937,12 @@ def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_4
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet length with value 5.
@@ -14986,11 +15953,12 @@ def test_list_unsigned_short_length_nistxml_sv_iv_list_unsigned_short_length_1_5
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_length_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15002,11 +15970,12 @@ def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_length_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15018,11 +15987,12 @@ def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_length_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15034,11 +16004,12 @@ def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_length_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15050,11 +16021,12 @@ def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_length_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value
@@ -15066,11 +16038,12 @@ def test_list_unsigned_short_min_length_4_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_length_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15081,11 +16054,12 @@ def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_length_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15096,11 +16070,12 @@ def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_length_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15111,11 +16086,12 @@ def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_length_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15126,11 +16102,12 @@ def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_length_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 8.
@@ -15141,11 +16118,12 @@ def test_list_unsigned_short_min_length_3_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_length_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15156,11 +16134,12 @@ def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_length_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15171,11 +16150,12 @@ def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_length_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15186,11 +16166,12 @@ def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_length_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15201,11 +16182,12 @@ def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_length_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 7.
@@ -15216,11 +16198,12 @@ def test_list_unsigned_short_min_length_2_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_length_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15231,11 +16214,12 @@ def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_length_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15246,11 +16230,12 @@ def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_length_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15261,11 +16246,12 @@ def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_length_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15276,11 +16262,12 @@ def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_length_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 6.
@@ -15291,11 +16278,12 @@ def test_list_unsigned_short_min_length_1_nistxml_sv_iv_list_unsigned_short_min_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_length_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15306,11 +16294,12 @@ def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_length_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15321,11 +16310,12 @@ def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_length_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15336,11 +16326,12 @@ def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_length_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15351,11 +16342,12 @@ def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_length_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet minLength with value 5.
@@ -15366,11 +16358,12 @@ def test_list_unsigned_short_min_length_nistxml_sv_iv_list_unsigned_short_min_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_length_5_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -15382,11 +16375,12 @@ def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_length_5_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -15398,11 +16392,12 @@ def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_length_5_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -15414,11 +16409,12 @@ def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_length_5_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -15430,11 +16426,12 @@ def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_length_5_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value
@@ -15446,11 +16443,12 @@ def test_list_unsigned_short_max_length_4_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_length_4_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -15461,11 +16459,12 @@ def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_length_4_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -15476,11 +16475,12 @@ def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_length_4_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -15491,11 +16491,12 @@ def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_length_4_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -15506,11 +16507,12 @@ def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_length_4_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 8.
@@ -15521,6 +16523,6 @@ def test_list_unsigned_short_max_length_3_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_nist_meta_9000.py
+++ b/tests/test_nist_meta_9000.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_length_3_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -11,11 +14,12 @@ def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_length_3_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -26,11 +30,12 @@ def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_length_3_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -41,11 +46,12 @@ def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_length_3_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -56,11 +62,12 @@ def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_length_3_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 7.
@@ -71,11 +78,12 @@ def test_list_unsigned_short_max_length_2_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_length_2_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -86,11 +94,12 @@ def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_length_2_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -101,11 +110,12 @@ def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_length_2_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -116,11 +126,12 @@ def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_length_2_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -131,11 +142,12 @@ def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_length_2_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 6.
@@ -146,11 +158,12 @@ def test_list_unsigned_short_max_length_1_nistxml_sv_iv_list_unsigned_short_max_
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_length_1_1(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -161,11 +174,12 @@ def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_length_1_2(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -176,11 +190,12 @@ def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_length_1_3(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -191,11 +206,12 @@ def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_length_1_4(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -206,11 +222,12 @@ def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_length_1_5(save_xml):
     """
     Type list/unsignedShort is restricted by facet maxLength with value 5.
@@ -221,11 +238,12 @@ def test_list_unsigned_short_max_length_nistxml_sv_iv_list_unsigned_short_max_le
         instance="nistData/list/unsignedShort/Schema+Instance/NISTXML-SV-IV-list-unsignedShort-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_space_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet whiteSpace with value
@@ -237,11 +255,12 @@ def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_spa
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_space_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet whiteSpace with value
@@ -253,11 +272,12 @@ def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_spa
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_space_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet whiteSpace with value
@@ -269,11 +289,12 @@ def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_spa
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_space_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet whiteSpace with value
@@ -285,11 +306,12 @@ def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_spa
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_space_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet whiteSpace with value
@@ -301,11 +323,12 @@ def test_list_unsigned_int_white_space_nistxml_sv_iv_list_unsigned_int_white_spa
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumeration_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -316,11 +339,12 @@ def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumeration_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -331,11 +355,12 @@ def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumeration_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -346,11 +371,12 @@ def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumeration_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -361,11 +387,12 @@ def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumeration_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -376,11 +403,12 @@ def test_list_unsigned_int_enumeration_4_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumeration_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -391,11 +419,12 @@ def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumeration_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -406,11 +435,12 @@ def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumeration_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -421,11 +451,12 @@ def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumeration_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -436,11 +467,12 @@ def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumeration_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -451,11 +483,12 @@ def test_list_unsigned_int_enumeration_3_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumeration_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -466,11 +499,12 @@ def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumeration_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -481,11 +515,12 @@ def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumeration_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -496,11 +531,12 @@ def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumeration_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -511,11 +547,12 @@ def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumeration_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -526,11 +563,12 @@ def test_list_unsigned_int_enumeration_2_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumeration_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -541,11 +579,12 @@ def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumeration_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -556,11 +595,12 @@ def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumeration_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -571,11 +611,12 @@ def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumeration_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -586,11 +627,12 @@ def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumeration_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -601,11 +643,12 @@ def test_list_unsigned_int_enumeration_1_nistxml_sv_iv_list_unsigned_int_enumera
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumeration_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -616,11 +659,12 @@ def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumerati
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumeration_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -631,11 +675,12 @@ def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumerati
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumeration_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -646,11 +691,12 @@ def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumerati
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumeration_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -661,11 +707,12 @@ def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumerati
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumeration_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet enumeration.
@@ -676,11 +723,12 @@ def test_list_unsigned_int_enumeration_nistxml_sv_iv_list_unsigned_int_enumerati
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -692,11 +740,12 @@ def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -708,11 +757,12 @@ def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -724,11 +774,12 @@ def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -740,11 +791,12 @@ def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -756,11 +808,12 @@ def test_list_unsigned_int_pattern_4_nistxml_sv_iv_list_unsigned_int_pattern_5_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -772,11 +825,12 @@ def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -788,11 +842,12 @@ def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -804,11 +859,12 @@ def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -820,11 +876,12 @@ def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -836,11 +893,12 @@ def test_list_unsigned_int_pattern_3_nistxml_sv_iv_list_unsigned_int_pattern_4_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -852,11 +910,12 @@ def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -868,11 +927,12 @@ def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -884,11 +944,12 @@ def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -900,11 +961,12 @@ def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -916,11 +978,12 @@ def test_list_unsigned_int_pattern_2_nistxml_sv_iv_list_unsigned_int_pattern_3_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -932,11 +995,12 @@ def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_1
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -948,11 +1012,12 @@ def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_2
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -964,11 +1029,12 @@ def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_3
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -980,11 +1046,12 @@ def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_4
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -996,11 +1063,12 @@ def test_list_unsigned_int_pattern_1_nistxml_sv_iv_list_unsigned_int_pattern_2_5
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_1(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1012,11 +1080,12 @@ def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_2(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1028,11 +1097,12 @@ def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_3(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1044,11 +1114,12 @@ def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_4(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1060,11 +1131,12 @@ def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_5(save_xml):
     r"""
     Type list/unsignedInt is restricted by facet pattern with value \d{1}
@@ -1076,11 +1148,12 @@ def test_list_unsigned_int_pattern_nistxml_sv_iv_list_unsigned_int_pattern_1_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1091,11 +1164,12 @@ def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1106,11 +1180,12 @@ def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1121,11 +1196,12 @@ def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1136,11 +1212,12 @@ def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 10.
@@ -1151,11 +1228,12 @@ def test_list_unsigned_int_length_4_nistxml_sv_iv_list_unsigned_int_length_5_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1166,11 +1244,12 @@ def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1181,11 +1260,12 @@ def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1196,11 +1276,12 @@ def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1211,11 +1292,12 @@ def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 8.
@@ -1226,11 +1308,12 @@ def test_list_unsigned_int_length_3_nistxml_sv_iv_list_unsigned_int_length_4_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1241,11 +1324,12 @@ def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1256,11 +1340,12 @@ def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1271,11 +1356,12 @@ def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1286,11 +1372,12 @@ def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 7.
@@ -1301,11 +1388,12 @@ def test_list_unsigned_int_length_2_nistxml_sv_iv_list_unsigned_int_length_3_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1316,11 +1404,12 @@ def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_1(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1331,11 +1420,12 @@ def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_2(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1346,11 +1436,12 @@ def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_3(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1361,11 +1452,12 @@ def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_4(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 6.
@@ -1376,11 +1468,12 @@ def test_list_unsigned_int_length_1_nistxml_sv_iv_list_unsigned_int_length_2_5(s
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1391,11 +1484,12 @@ def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_1(sav
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1406,11 +1500,12 @@ def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_2(sav
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1421,11 +1516,12 @@ def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_3(sav
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1436,11 +1532,12 @@ def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_4(sav
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet length with value 5.
@@ -1451,11 +1548,12 @@ def test_list_unsigned_int_length_nistxml_sv_iv_list_unsigned_int_length_1_5(sav
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_length_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1466,11 +1564,12 @@ def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_length_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1481,11 +1580,12 @@ def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_length_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1496,11 +1596,12 @@ def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_length_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1511,11 +1612,12 @@ def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_length_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 10.
@@ -1526,11 +1628,12 @@ def test_list_unsigned_int_min_length_4_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_length_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1541,11 +1644,12 @@ def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_length_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1556,11 +1660,12 @@ def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_length_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1571,11 +1676,12 @@ def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_length_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1586,11 +1692,12 @@ def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_length_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 8.
@@ -1601,11 +1708,12 @@ def test_list_unsigned_int_min_length_3_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_length_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1616,11 +1724,12 @@ def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_length_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1631,11 +1740,12 @@ def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_length_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1646,11 +1756,12 @@ def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_length_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1661,11 +1772,12 @@ def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_length_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 7.
@@ -1676,11 +1788,12 @@ def test_list_unsigned_int_min_length_2_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_length_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1691,11 +1804,12 @@ def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_length_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1706,11 +1820,12 @@ def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_length_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1721,11 +1836,12 @@ def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_length_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1736,11 +1852,12 @@ def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_length_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 6.
@@ -1751,11 +1868,12 @@ def test_list_unsigned_int_min_length_1_nistxml_sv_iv_list_unsigned_int_min_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1766,11 +1884,12 @@ def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1781,11 +1900,12 @@ def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1796,11 +1916,12 @@ def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1811,11 +1932,12 @@ def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet minLength with value 5.
@@ -1826,11 +1948,12 @@ def test_list_unsigned_int_min_length_nistxml_sv_iv_list_unsigned_int_min_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_length_5_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1841,11 +1964,12 @@ def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_length_5_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1856,11 +1980,12 @@ def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_length_5_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1871,11 +1996,12 @@ def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_length_5_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1886,11 +2012,12 @@ def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_length_5_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 10.
@@ -1901,11 +2028,12 @@ def test_list_unsigned_int_max_length_4_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_length_4_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -1916,11 +2044,12 @@ def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_length_4_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -1931,11 +2060,12 @@ def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_length_4_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -1946,11 +2076,12 @@ def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_length_4_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -1961,11 +2092,12 @@ def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_length_4_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 8.
@@ -1976,11 +2108,12 @@ def test_list_unsigned_int_max_length_3_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_length_3_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -1991,11 +2124,12 @@ def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_length_3_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2006,11 +2140,12 @@ def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_length_3_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2021,11 +2156,12 @@ def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_length_3_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2036,11 +2172,12 @@ def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_length_3_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 7.
@@ -2051,11 +2188,12 @@ def test_list_unsigned_int_max_length_2_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_length_2_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2066,11 +2204,12 @@ def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_length_2_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2081,11 +2220,12 @@ def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_length_2_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2096,11 +2236,12 @@ def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_length_2_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2111,11 +2252,12 @@ def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_length_2_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 6.
@@ -2126,11 +2268,12 @@ def test_list_unsigned_int_max_length_1_nistxml_sv_iv_list_unsigned_int_max_leng
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length_1_1(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2141,11 +2284,12 @@ def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length_1_2(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2156,11 +2300,12 @@ def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length_1_3(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2171,11 +2316,12 @@ def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length_1_4(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2186,11 +2332,12 @@ def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length_1_5(save_xml):
     """
     Type list/unsignedInt is restricted by facet maxLength with value 5.
@@ -2201,11 +2348,12 @@ def test_list_unsigned_int_max_length_nistxml_sv_iv_list_unsigned_int_max_length
         instance="nistData/list/unsignedInt/Schema+Instance/NISTXML-SV-IV-list-unsignedInt-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_space_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet whiteSpace with value
@@ -2217,11 +2365,12 @@ def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_space_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet whiteSpace with value
@@ -2233,11 +2382,12 @@ def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_space_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet whiteSpace with value
@@ -2249,11 +2399,12 @@ def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_space_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet whiteSpace with value
@@ -2265,11 +2416,12 @@ def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_space_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet whiteSpace with value
@@ -2281,11 +2433,12 @@ def test_list_unsigned_long_white_space_nistxml_sv_iv_list_unsigned_long_white_s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enumeration_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2296,11 +2449,12 @@ def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enumeration_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2311,11 +2465,12 @@ def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enumeration_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2326,11 +2481,12 @@ def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enumeration_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2341,11 +2497,12 @@ def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enumeration_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2356,11 +2513,12 @@ def test_list_unsigned_long_enumeration_4_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enumeration_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2371,11 +2529,12 @@ def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enumeration_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2386,11 +2545,12 @@ def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enumeration_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2401,11 +2561,12 @@ def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enumeration_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2416,11 +2577,12 @@ def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enumeration_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2431,11 +2593,12 @@ def test_list_unsigned_long_enumeration_3_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enumeration_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2446,11 +2609,12 @@ def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enumeration_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2461,11 +2625,12 @@ def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enumeration_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2476,11 +2641,12 @@ def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enumeration_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2491,11 +2657,12 @@ def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enumeration_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2506,11 +2673,12 @@ def test_list_unsigned_long_enumeration_2_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enumeration_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2521,11 +2689,12 @@ def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enumeration_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2536,11 +2705,12 @@ def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enumeration_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2551,11 +2721,12 @@ def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enumeration_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2566,11 +2737,12 @@ def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enumeration_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2581,11 +2753,12 @@ def test_list_unsigned_long_enumeration_1_nistxml_sv_iv_list_unsigned_long_enume
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumeration_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2596,11 +2769,12 @@ def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumera
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumeration_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2611,11 +2785,12 @@ def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumera
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumeration_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2626,11 +2801,12 @@ def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumera
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumeration_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2641,11 +2817,12 @@ def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumera
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumeration_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet enumeration.
@@ -2656,11 +2833,12 @@ def test_list_unsigned_long_enumeration_nistxml_sv_iv_list_unsigned_long_enumera
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2672,11 +2850,12 @@ def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2688,11 +2867,12 @@ def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2704,11 +2884,12 @@ def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2720,11 +2901,12 @@ def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2736,11 +2918,12 @@ def test_list_unsigned_long_pattern_4_nistxml_sv_iv_list_unsigned_long_pattern_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2752,11 +2935,12 @@ def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2768,11 +2952,12 @@ def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2784,11 +2969,12 @@ def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2800,11 +2986,12 @@ def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2816,11 +3003,12 @@ def test_list_unsigned_long_pattern_3_nistxml_sv_iv_list_unsigned_long_pattern_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2832,11 +3020,12 @@ def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2848,11 +3037,12 @@ def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2864,11 +3054,12 @@ def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2880,11 +3071,12 @@ def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2896,11 +3088,12 @@ def test_list_unsigned_long_pattern_2_nistxml_sv_iv_list_unsigned_long_pattern_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2912,11 +3105,12 @@ def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2928,11 +3122,12 @@ def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2944,11 +3139,12 @@ def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2960,11 +3156,12 @@ def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2976,11 +3173,12 @@ def test_list_unsigned_long_pattern_1_nistxml_sv_iv_list_unsigned_long_pattern_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_1(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -2992,11 +3190,12 @@ def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_2(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3008,11 +3207,12 @@ def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_3(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3024,11 +3224,12 @@ def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_4(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3040,11 +3241,12 @@ def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_5(save_xml):
     r"""
     Type list/unsignedLong is restricted by facet pattern with value \d{1}
@@ -3056,11 +3258,12 @@ def test_list_unsigned_long_pattern_nistxml_sv_iv_list_unsigned_long_pattern_1_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3071,11 +3274,12 @@ def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3086,11 +3290,12 @@ def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3101,11 +3306,12 @@ def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3116,11 +3322,12 @@ def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 10.
@@ -3131,11 +3338,12 @@ def test_list_unsigned_long_length_4_nistxml_sv_iv_list_unsigned_long_length_5_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3146,11 +3354,12 @@ def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3161,11 +3370,12 @@ def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3176,11 +3386,12 @@ def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3191,11 +3402,12 @@ def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 8.
@@ -3206,11 +3418,12 @@ def test_list_unsigned_long_length_3_nistxml_sv_iv_list_unsigned_long_length_4_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3221,11 +3434,12 @@ def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3236,11 +3450,12 @@ def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3251,11 +3466,12 @@ def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3266,11 +3482,12 @@ def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 7.
@@ -3281,11 +3498,12 @@ def test_list_unsigned_long_length_2_nistxml_sv_iv_list_unsigned_long_length_3_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3296,11 +3514,12 @@ def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_1
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3311,11 +3530,12 @@ def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_2
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3326,11 +3546,12 @@ def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_3
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3341,11 +3562,12 @@ def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_4
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 6.
@@ -3356,11 +3578,12 @@ def test_list_unsigned_long_length_1_nistxml_sv_iv_list_unsigned_long_length_2_5
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3371,11 +3594,12 @@ def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_1(s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3386,11 +3610,12 @@ def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_2(s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3401,11 +3626,12 @@ def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_3(s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3416,11 +3642,12 @@ def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_4(s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet length with value 5.
@@ -3431,11 +3658,12 @@ def test_list_unsigned_long_length_nistxml_sv_iv_list_unsigned_long_length_1_5(s
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_length_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3446,11 +3674,12 @@ def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_length_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3461,11 +3690,12 @@ def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_length_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3476,11 +3706,12 @@ def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_length_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3491,11 +3722,12 @@ def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_length_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 10.
@@ -3506,11 +3738,12 @@ def test_list_unsigned_long_min_length_4_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_length_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3521,11 +3754,12 @@ def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_length_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3536,11 +3770,12 @@ def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_length_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3551,11 +3786,12 @@ def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_length_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3566,11 +3802,12 @@ def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_length_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 8.
@@ -3581,11 +3818,12 @@ def test_list_unsigned_long_min_length_3_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_length_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3596,11 +3834,12 @@ def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_length_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3611,11 +3850,12 @@ def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_length_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3626,11 +3866,12 @@ def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_length_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3641,11 +3882,12 @@ def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_length_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 7.
@@ -3656,11 +3898,12 @@ def test_list_unsigned_long_min_length_2_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_length_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3671,11 +3914,12 @@ def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_length_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3686,11 +3930,12 @@ def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_length_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3701,11 +3946,12 @@ def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_length_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3716,11 +3962,12 @@ def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_length_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 6.
@@ -3731,11 +3978,12 @@ def test_list_unsigned_long_min_length_1_nistxml_sv_iv_list_unsigned_long_min_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_length_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3746,11 +3994,12 @@ def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_length_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3761,11 +4010,12 @@ def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_length_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3776,11 +4026,12 @@ def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_length_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3791,11 +4042,12 @@ def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_length_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet minLength with value 5.
@@ -3806,11 +4058,12 @@ def test_list_unsigned_long_min_length_nistxml_sv_iv_list_unsigned_long_min_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_length_5_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3821,11 +4074,12 @@ def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_length_5_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3836,11 +4090,12 @@ def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_length_5_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3851,11 +4106,12 @@ def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_length_5_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3866,11 +4122,12 @@ def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_length_5_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 10.
@@ -3881,11 +4138,12 @@ def test_list_unsigned_long_max_length_4_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_length_4_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3896,11 +4154,12 @@ def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_length_4_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3911,11 +4170,12 @@ def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_length_4_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3926,11 +4186,12 @@ def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_length_4_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3941,11 +4202,12 @@ def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_length_4_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 8.
@@ -3956,11 +4218,12 @@ def test_list_unsigned_long_max_length_3_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_length_3_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -3971,11 +4234,12 @@ def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_length_3_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -3986,11 +4250,12 @@ def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_length_3_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -4001,11 +4266,12 @@ def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_length_3_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -4016,11 +4282,12 @@ def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_length_3_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 7.
@@ -4031,11 +4298,12 @@ def test_list_unsigned_long_max_length_2_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_length_2_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4046,11 +4314,12 @@ def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_length_2_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4061,11 +4330,12 @@ def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_length_2_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4076,11 +4346,12 @@ def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_length_2_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4091,11 +4362,12 @@ def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_length_2_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 6.
@@ -4106,11 +4378,12 @@ def test_list_unsigned_long_max_length_1_nistxml_sv_iv_list_unsigned_long_max_le
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_length_1_1(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4121,11 +4394,12 @@ def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_length_1_2(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4136,11 +4410,12 @@ def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_length_1_3(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4151,11 +4426,12 @@ def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_length_1_4(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4166,11 +4442,12 @@ def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_length_1_5(save_xml):
     """
     Type list/unsignedLong is restricted by facet maxLength with value 5.
@@ -4181,11 +4458,12 @@ def test_list_unsigned_long_max_length_nistxml_sv_iv_list_unsigned_long_max_leng
         instance="nistData/list/unsignedLong/Schema+Instance/NISTXML-SV-IV-list-unsignedLong-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListUnsignedLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_integer_white_space_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet whiteSpace with
@@ -4197,11 +4475,12 @@ def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_integer_white_space_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet whiteSpace with
@@ -4213,11 +4492,12 @@ def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_integer_white_space_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet whiteSpace with
@@ -4229,11 +4509,12 @@ def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_integer_white_space_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet whiteSpace with
@@ -4245,11 +4526,12 @@ def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_integer_white_space_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet whiteSpace with
@@ -4261,11 +4543,12 @@ def test_list_non_negative_integer_white_space_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative_integer_enumeration_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4276,11 +4559,12 @@ def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative_integer_enumeration_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4291,11 +4575,12 @@ def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative_integer_enumeration_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4306,11 +4591,12 @@ def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative_integer_enumeration_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4321,11 +4607,12 @@ def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative_integer_enumeration_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4336,11 +4623,12 @@ def test_list_non_negative_integer_enumeration_4_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative_integer_enumeration_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4351,11 +4639,12 @@ def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative_integer_enumeration_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4366,11 +4655,12 @@ def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative_integer_enumeration_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4381,11 +4671,12 @@ def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative_integer_enumeration_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4396,11 +4687,12 @@ def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative_integer_enumeration_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4411,11 +4703,12 @@ def test_list_non_negative_integer_enumeration_3_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative_integer_enumeration_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4426,11 +4719,12 @@ def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative_integer_enumeration_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4441,11 +4735,12 @@ def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative_integer_enumeration_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4456,11 +4751,12 @@ def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative_integer_enumeration_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4471,11 +4767,12 @@ def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative_integer_enumeration_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4486,11 +4783,12 @@ def test_list_non_negative_integer_enumeration_2_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative_integer_enumeration_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4501,11 +4799,12 @@ def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative_integer_enumeration_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4516,11 +4815,12 @@ def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative_integer_enumeration_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4531,11 +4831,12 @@ def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative_integer_enumeration_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4546,11 +4847,12 @@ def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative_integer_enumeration_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4561,11 +4863,12 @@ def test_list_non_negative_integer_enumeration_1_nistxml_sv_iv_list_non_negative
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_integer_enumeration_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4576,11 +4879,12 @@ def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_integer_enumeration_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4591,11 +4895,12 @@ def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_integer_enumeration_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4606,11 +4911,12 @@ def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_integer_enumeration_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4621,11 +4927,12 @@ def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_integer_enumeration_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet enumeration.
@@ -4636,11 +4943,12 @@ def test_list_non_negative_integer_enumeration_nistxml_sv_iv_list_non_negative_i
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_integer_pattern_5_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4652,11 +4960,12 @@ def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_integer_pattern_5_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4668,11 +4977,12 @@ def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_integer_pattern_5_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4684,11 +4994,12 @@ def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_integer_pattern_5_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4700,11 +5011,12 @@ def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_integer_pattern_5_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4716,11 +5028,12 @@ def test_list_non_negative_integer_pattern_4_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_integer_pattern_4_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4732,11 +5045,12 @@ def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_integer_pattern_4_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4748,11 +5062,12 @@ def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_integer_pattern_4_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4764,11 +5079,12 @@ def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_integer_pattern_4_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4780,11 +5096,12 @@ def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_integer_pattern_4_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4796,11 +5113,12 @@ def test_list_non_negative_integer_pattern_3_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_integer_pattern_3_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4812,11 +5130,12 @@ def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_integer_pattern_3_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4828,11 +5147,12 @@ def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_integer_pattern_3_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4844,11 +5164,12 @@ def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_integer_pattern_3_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4860,11 +5181,12 @@ def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_integer_pattern_3_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4876,11 +5198,12 @@ def test_list_non_negative_integer_pattern_2_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_integer_pattern_2_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4892,11 +5215,12 @@ def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_integer_pattern_2_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4908,11 +5232,12 @@ def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_integer_pattern_2_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4924,11 +5249,12 @@ def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_integer_pattern_2_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4940,11 +5266,12 @@ def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_integer_pattern_2_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4956,11 +5283,12 @@ def test_list_non_negative_integer_pattern_1_nistxml_sv_iv_list_non_negative_int
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integer_pattern_1_1(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4972,11 +5300,12 @@ def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integ
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integer_pattern_1_2(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -4988,11 +5317,12 @@ def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integ
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integer_pattern_1_3(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -5004,11 +5334,12 @@ def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integ
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integer_pattern_1_4(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -5020,11 +5351,12 @@ def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integ
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integer_pattern_1_5(save_xml):
     r"""
     Type list/nonNegativeInteger is restricted by facet pattern with value
@@ -5036,11 +5368,12 @@ def test_list_non_negative_integer_pattern_nistxml_sv_iv_list_non_negative_integ
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_integer_length_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5052,11 +5385,12 @@ def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_integer_length_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5068,11 +5402,12 @@ def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_integer_length_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5084,11 +5419,12 @@ def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_integer_length_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5100,11 +5436,12 @@ def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_integer_length_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5116,11 +5453,12 @@ def test_list_non_negative_integer_length_4_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_integer_length_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5132,11 +5470,12 @@ def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_integer_length_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5148,11 +5487,12 @@ def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_integer_length_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5164,11 +5504,12 @@ def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_integer_length_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5180,11 +5521,12 @@ def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_integer_length_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5196,11 +5538,12 @@ def test_list_non_negative_integer_length_3_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_integer_length_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5212,11 +5555,12 @@ def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_integer_length_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5228,11 +5572,12 @@ def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_integer_length_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5244,11 +5589,12 @@ def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_integer_length_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5260,11 +5606,12 @@ def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_integer_length_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5276,11 +5623,12 @@ def test_list_non_negative_integer_length_2_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_integer_length_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5292,11 +5640,12 @@ def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_integer_length_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5308,11 +5657,12 @@ def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_integer_length_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5324,11 +5674,12 @@ def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_integer_length_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5340,11 +5691,12 @@ def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_integer_length_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5356,11 +5708,12 @@ def test_list_non_negative_integer_length_1_nistxml_sv_iv_list_non_negative_inte
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_integer_length_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5372,11 +5725,12 @@ def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_intege
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_integer_length_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5388,11 +5742,12 @@ def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_intege
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_integer_length_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5404,11 +5759,12 @@ def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_intege
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_integer_length_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5420,11 +5776,12 @@ def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_intege
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_integer_length_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet length with value
@@ -5436,11 +5793,12 @@ def test_list_non_negative_integer_length_nistxml_sv_iv_list_non_negative_intege
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_integer_min_length_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5452,11 +5810,12 @@ def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_integer_min_length_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5468,11 +5827,12 @@ def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_integer_min_length_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5484,11 +5844,12 @@ def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_integer_min_length_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5500,11 +5861,12 @@ def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_integer_min_length_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5516,11 +5878,12 @@ def test_list_non_negative_integer_min_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_integer_min_length_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5532,11 +5895,12 @@ def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_integer_min_length_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5548,11 +5912,12 @@ def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_integer_min_length_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5564,11 +5929,12 @@ def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_integer_min_length_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5580,11 +5946,12 @@ def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_integer_min_length_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5596,11 +5963,12 @@ def test_list_non_negative_integer_min_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_integer_min_length_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5612,11 +5980,12 @@ def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_integer_min_length_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5628,11 +5997,12 @@ def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_integer_min_length_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5644,11 +6014,12 @@ def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_integer_min_length_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5660,11 +6031,12 @@ def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_integer_min_length_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5676,11 +6048,12 @@ def test_list_non_negative_integer_min_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_integer_min_length_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5692,11 +6065,12 @@ def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_integer_min_length_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5708,11 +6082,12 @@ def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_integer_min_length_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5724,11 +6099,12 @@ def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_integer_min_length_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5740,11 +6116,12 @@ def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_integer_min_length_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5756,11 +6133,12 @@ def test_list_non_negative_integer_min_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_integer_min_length_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5772,11 +6150,12 @@ def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_integer_min_length_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5788,11 +6167,12 @@ def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_integer_min_length_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5804,11 +6184,12 @@ def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_integer_min_length_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5820,11 +6201,12 @@ def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_integer_min_length_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet minLength with
@@ -5836,11 +6218,12 @@ def test_list_non_negative_integer_min_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_integer_max_length_5_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5852,11 +6235,12 @@ def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_integer_max_length_5_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5868,11 +6252,12 @@ def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_integer_max_length_5_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5884,11 +6269,12 @@ def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_integer_max_length_5_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5900,11 +6286,12 @@ def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_integer_max_length_5_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5916,11 +6303,12 @@ def test_list_non_negative_integer_max_length_4_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_integer_max_length_4_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5932,11 +6320,12 @@ def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_integer_max_length_4_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5948,11 +6337,12 @@ def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_integer_max_length_4_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5964,11 +6354,12 @@ def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_integer_max_length_4_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5980,11 +6371,12 @@ def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_integer_max_length_4_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -5996,11 +6388,12 @@ def test_list_non_negative_integer_max_length_3_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_integer_max_length_3_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6012,11 +6405,12 @@ def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_integer_max_length_3_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6028,11 +6422,12 @@ def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_integer_max_length_3_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6044,11 +6439,12 @@ def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_integer_max_length_3_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6060,11 +6456,12 @@ def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_integer_max_length_3_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6076,11 +6473,12 @@ def test_list_non_negative_integer_max_length_2_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_integer_max_length_2_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6092,11 +6490,12 @@ def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_integer_max_length_2_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6108,11 +6507,12 @@ def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_integer_max_length_2_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6124,11 +6524,12 @@ def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_integer_max_length_2_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6140,11 +6541,12 @@ def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_integer_max_length_2_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6156,11 +6558,12 @@ def test_list_non_negative_integer_max_length_1_nistxml_sv_iv_list_non_negative_
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_integer_max_length_1_1(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6172,11 +6575,12 @@ def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_integer_max_length_1_2(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6188,11 +6592,12 @@ def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_integer_max_length_1_3(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6204,11 +6609,12 @@ def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_integer_max_length_1_4(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6220,11 +6626,12 @@ def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_integer_max_length_1_5(save_xml):
     """
     Type list/nonNegativeInteger is restricted by facet maxLength with
@@ -6236,11 +6643,12 @@ def test_list_non_negative_integer_max_length_nistxml_sv_iv_list_non_negative_in
         instance="nistData/list/nonNegativeInteger/Schema+Instance/NISTXML-SV-IV-list-nonNegativeInteger-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNonNegativeIntegerMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_1(save_xml):
     """
     Type list/byte is restricted by facet whiteSpace with value collapse.
@@ -6251,11 +6659,12 @@ def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_2(save_xml):
     """
     Type list/byte is restricted by facet whiteSpace with value collapse.
@@ -6266,11 +6675,12 @@ def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_3(save_xml):
     """
     Type list/byte is restricted by facet whiteSpace with value collapse.
@@ -6281,11 +6691,12 @@ def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_4(save_xml):
     """
     Type list/byte is restricted by facet whiteSpace with value collapse.
@@ -6296,11 +6707,12 @@ def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_5(save_xml):
     """
     Type list/byte is restricted by facet whiteSpace with value collapse.
@@ -6311,11 +6723,12 @@ def test_list_byte_white_space_nistxml_sv_iv_list_byte_white_space_1_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6326,11 +6739,12 @@ def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6341,11 +6755,12 @@ def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6356,11 +6771,12 @@ def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6371,11 +6787,12 @@ def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6386,11 +6803,12 @@ def test_list_byte_enumeration_4_nistxml_sv_iv_list_byte_enumeration_5_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6401,11 +6819,12 @@ def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6416,11 +6835,12 @@ def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6431,11 +6851,12 @@ def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6446,11 +6867,12 @@ def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6461,11 +6883,12 @@ def test_list_byte_enumeration_3_nistxml_sv_iv_list_byte_enumeration_4_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6476,11 +6899,12 @@ def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6491,11 +6915,12 @@ def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6506,11 +6931,12 @@ def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6521,11 +6947,12 @@ def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6536,11 +6963,12 @@ def test_list_byte_enumeration_2_nistxml_sv_iv_list_byte_enumeration_3_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6551,11 +6979,12 @@ def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_1(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6566,11 +6995,12 @@ def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_2(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6581,11 +7011,12 @@ def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_3(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6596,11 +7027,12 @@ def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_4(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6611,11 +7043,12 @@ def test_list_byte_enumeration_1_nistxml_sv_iv_list_byte_enumeration_2_5(save_xm
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_1(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6626,11 +7059,12 @@ def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_2(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6641,11 +7075,12 @@ def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_3(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6656,11 +7091,12 @@ def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_4(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6671,11 +7107,12 @@ def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_5(save_xml):
     """
     Type list/byte is restricted by facet enumeration.
@@ -6686,11 +7123,12 @@ def test_list_byte_enumeration_nistxml_sv_iv_list_byte_enumeration_1_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6702,11 +7140,12 @@ def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6718,11 +7157,12 @@ def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6734,11 +7174,12 @@ def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6750,11 +7191,12 @@ def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6766,11 +7208,12 @@ def test_list_byte_pattern_4_nistxml_sv_iv_list_byte_pattern_5_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6782,11 +7225,12 @@ def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6798,11 +7242,12 @@ def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6814,11 +7259,12 @@ def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6830,11 +7276,12 @@ def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6846,11 +7293,12 @@ def test_list_byte_pattern_3_nistxml_sv_iv_list_byte_pattern_4_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6862,11 +7310,12 @@ def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6878,11 +7327,12 @@ def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6894,11 +7344,12 @@ def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6910,11 +7361,12 @@ def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6926,11 +7378,12 @@ def test_list_byte_pattern_2_nistxml_sv_iv_list_byte_pattern_3_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6942,11 +7395,12 @@ def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6958,11 +7412,12 @@ def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6974,11 +7429,12 @@ def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -6990,11 +7446,12 @@ def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -7006,11 +7463,12 @@ def test_list_byte_pattern_1_nistxml_sv_iv_list_byte_pattern_2_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_1(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -7022,11 +7480,12 @@ def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_2(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -7038,11 +7497,12 @@ def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_3(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -7054,11 +7514,12 @@ def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_4(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -7070,11 +7531,12 @@ def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_5(save_xml):
     r"""
     Type list/byte is restricted by facet pattern with value \-\d{3}
@@ -7086,11 +7548,12 @@ def test_list_byte_pattern_nistxml_sv_iv_list_byte_pattern_1_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListBytePattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -7101,11 +7564,12 @@ def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -7116,11 +7580,12 @@ def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -7131,11 +7596,12 @@ def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -7146,11 +7612,12 @@ def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 10.
@@ -7161,11 +7628,12 @@ def test_list_byte_length_4_nistxml_sv_iv_list_byte_length_5_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7176,11 +7644,12 @@ def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7191,11 +7660,12 @@ def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7206,11 +7676,12 @@ def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7221,11 +7692,12 @@ def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 8.
@@ -7236,11 +7708,12 @@ def test_list_byte_length_3_nistxml_sv_iv_list_byte_length_4_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7251,11 +7724,12 @@ def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7266,11 +7740,12 @@ def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7281,11 +7756,12 @@ def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7296,11 +7772,12 @@ def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 7.
@@ -7311,11 +7788,12 @@ def test_list_byte_length_2_nistxml_sv_iv_list_byte_length_3_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7326,11 +7804,12 @@ def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7341,11 +7820,12 @@ def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7356,11 +7836,12 @@ def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7371,11 +7852,12 @@ def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 6.
@@ -7386,11 +7868,12 @@ def test_list_byte_length_1_nistxml_sv_iv_list_byte_length_2_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_1(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7401,11 +7884,12 @@ def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_2(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7416,11 +7900,12 @@ def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_3(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7431,11 +7916,12 @@ def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_4(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7446,11 +7932,12 @@ def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_5(save_xml):
     """
     Type list/byte is restricted by facet length with value 5.
@@ -7461,11 +7948,12 @@ def test_list_byte_length_nistxml_sv_iv_list_byte_length_1_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7476,11 +7964,12 @@ def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7491,11 +7980,12 @@ def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7506,11 +7996,12 @@ def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7521,11 +8012,12 @@ def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 10.
@@ -7536,11 +8028,12 @@ def test_list_byte_min_length_4_nistxml_sv_iv_list_byte_min_length_5_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7551,11 +8044,12 @@ def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7566,11 +8060,12 @@ def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7581,11 +8076,12 @@ def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7596,11 +8092,12 @@ def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 8.
@@ -7611,11 +8108,12 @@ def test_list_byte_min_length_3_nistxml_sv_iv_list_byte_min_length_4_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7626,11 +8124,12 @@ def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7641,11 +8140,12 @@ def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7656,11 +8156,12 @@ def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7671,11 +8172,12 @@ def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 7.
@@ -7686,11 +8188,12 @@ def test_list_byte_min_length_2_nistxml_sv_iv_list_byte_min_length_3_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7701,11 +8204,12 @@ def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7716,11 +8220,12 @@ def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7731,11 +8236,12 @@ def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7746,11 +8252,12 @@ def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 6.
@@ -7761,11 +8268,12 @@ def test_list_byte_min_length_1_nistxml_sv_iv_list_byte_min_length_2_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_1(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7776,11 +8284,12 @@ def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_2(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7791,11 +8300,12 @@ def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_3(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7806,11 +8316,12 @@ def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_4(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7821,11 +8332,12 @@ def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_5(save_xml):
     """
     Type list/byte is restricted by facet minLength with value 5.
@@ -7836,11 +8348,12 @@ def test_list_byte_min_length_nistxml_sv_iv_list_byte_min_length_1_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7851,11 +8364,12 @@ def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7866,11 +8380,12 @@ def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7881,11 +8396,12 @@ def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7896,11 +8412,12 @@ def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 10.
@@ -7911,11 +8428,12 @@ def test_list_byte_max_length_4_nistxml_sv_iv_list_byte_max_length_5_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7926,11 +8444,12 @@ def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7941,11 +8460,12 @@ def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7956,11 +8476,12 @@ def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7971,11 +8492,12 @@ def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 8.
@@ -7986,11 +8508,12 @@ def test_list_byte_max_length_3_nistxml_sv_iv_list_byte_max_length_4_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -8001,11 +8524,12 @@ def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -8016,11 +8540,12 @@ def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -8031,11 +8556,12 @@ def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -8046,11 +8572,12 @@ def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 7.
@@ -8061,11 +8588,12 @@ def test_list_byte_max_length_2_nistxml_sv_iv_list_byte_max_length_3_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -8076,11 +8604,12 @@ def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_1(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -8091,11 +8620,12 @@ def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_2(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -8106,11 +8636,12 @@ def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_3(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -8121,11 +8652,12 @@ def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_4(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 6.
@@ -8136,11 +8668,12 @@ def test_list_byte_max_length_1_nistxml_sv_iv_list_byte_max_length_2_5(save_xml)
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_1(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8151,11 +8684,12 @@ def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_1(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_2(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8166,11 +8700,12 @@ def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_2(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_3(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8181,11 +8716,12 @@ def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_3(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_4(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8196,11 +8732,12 @@ def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_4(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_5(save_xml):
     """
     Type list/byte is restricted by facet maxLength with value 5.
@@ -8211,11 +8748,12 @@ def test_list_byte_max_length_nistxml_sv_iv_list_byte_max_length_1_5(save_xml):
         instance="nistData/list/byte/Schema+Instance/NISTXML-SV-IV-list-byte-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListByteMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_1(save_xml):
     """
     Type list/short is restricted by facet whiteSpace with value collapse.
@@ -8226,11 +8764,12 @@ def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_2(save_xml):
     """
     Type list/short is restricted by facet whiteSpace with value collapse.
@@ -8241,11 +8780,12 @@ def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_3(save_xml):
     """
     Type list/short is restricted by facet whiteSpace with value collapse.
@@ -8256,11 +8796,12 @@ def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_4(save_xml):
     """
     Type list/short is restricted by facet whiteSpace with value collapse.
@@ -8271,11 +8812,12 @@ def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_5(save_xml):
     """
     Type list/short is restricted by facet whiteSpace with value collapse.
@@ -8286,11 +8828,12 @@ def test_list_short_white_space_nistxml_sv_iv_list_short_white_space_1_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8301,11 +8844,12 @@ def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8316,11 +8860,12 @@ def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8331,11 +8876,12 @@ def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8346,11 +8892,12 @@ def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8361,11 +8908,12 @@ def test_list_short_enumeration_4_nistxml_sv_iv_list_short_enumeration_5_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8376,11 +8924,12 @@ def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8391,11 +8940,12 @@ def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8406,11 +8956,12 @@ def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8421,11 +8972,12 @@ def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8436,11 +8988,12 @@ def test_list_short_enumeration_3_nistxml_sv_iv_list_short_enumeration_4_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8451,11 +9004,12 @@ def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8466,11 +9020,12 @@ def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8481,11 +9036,12 @@ def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8496,11 +9052,12 @@ def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8511,11 +9068,12 @@ def test_list_short_enumeration_2_nistxml_sv_iv_list_short_enumeration_3_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8526,11 +9084,12 @@ def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_1(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8541,11 +9100,12 @@ def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_2(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8556,11 +9116,12 @@ def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_3(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8571,11 +9132,12 @@ def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_4(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8586,11 +9148,12 @@ def test_list_short_enumeration_1_nistxml_sv_iv_list_short_enumeration_2_5(save_
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_1(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8601,11 +9164,12 @@ def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_2(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8616,11 +9180,12 @@ def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_3(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8631,11 +9196,12 @@ def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_4(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8646,11 +9212,12 @@ def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_5(save_xml):
     """
     Type list/short is restricted by facet enumeration.
@@ -8661,11 +9228,12 @@ def test_list_short_enumeration_nistxml_sv_iv_list_short_enumeration_1_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8677,11 +9245,12 @@ def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8693,11 +9262,12 @@ def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8709,11 +9279,12 @@ def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8725,11 +9296,12 @@ def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8741,11 +9313,12 @@ def test_list_short_pattern_4_nistxml_sv_iv_list_short_pattern_5_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8757,11 +9330,12 @@ def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8773,11 +9347,12 @@ def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8789,11 +9364,12 @@ def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8805,11 +9381,12 @@ def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8821,11 +9398,12 @@ def test_list_short_pattern_3_nistxml_sv_iv_list_short_pattern_4_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8837,11 +9415,12 @@ def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8853,11 +9432,12 @@ def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8869,11 +9449,12 @@ def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8885,11 +9466,12 @@ def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8901,11 +9483,12 @@ def test_list_short_pattern_2_nistxml_sv_iv_list_short_pattern_3_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8917,11 +9500,12 @@ def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8933,11 +9517,12 @@ def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8949,11 +9534,12 @@ def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8965,11 +9551,12 @@ def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8981,11 +9568,12 @@ def test_list_short_pattern_1_nistxml_sv_iv_list_short_pattern_2_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_1(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -8997,11 +9585,12 @@ def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_2(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -9013,11 +9602,12 @@ def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_3(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -9029,11 +9619,12 @@ def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_4(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -9045,11 +9636,12 @@ def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_5(save_xml):
     r"""
     Type list/short is restricted by facet pattern with value \-\d{5}
@@ -9061,11 +9653,12 @@ def test_list_short_pattern_nistxml_sv_iv_list_short_pattern_1_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_1(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -9076,11 +9669,12 @@ def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_2(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -9091,11 +9685,12 @@ def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_3(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -9106,11 +9701,12 @@ def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_4(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -9121,11 +9717,12 @@ def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_5(save_xml):
     """
     Type list/short is restricted by facet length with value 10.
@@ -9136,11 +9733,12 @@ def test_list_short_length_4_nistxml_sv_iv_list_short_length_5_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_1(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -9151,11 +9749,12 @@ def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_2(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -9166,11 +9765,12 @@ def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_3(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -9181,11 +9781,12 @@ def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_4(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -9196,11 +9797,12 @@ def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_5(save_xml):
     """
     Type list/short is restricted by facet length with value 8.
@@ -9211,11 +9813,12 @@ def test_list_short_length_3_nistxml_sv_iv_list_short_length_4_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_1(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9226,11 +9829,12 @@ def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_2(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9241,11 +9845,12 @@ def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_3(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9256,11 +9861,12 @@ def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_4(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9271,11 +9877,12 @@ def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_5(save_xml):
     """
     Type list/short is restricted by facet length with value 7.
@@ -9286,11 +9893,12 @@ def test_list_short_length_2_nistxml_sv_iv_list_short_length_3_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_1(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9301,11 +9909,12 @@ def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_2(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9316,11 +9925,12 @@ def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_3(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9331,11 +9941,12 @@ def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_4(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9346,11 +9957,12 @@ def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_5(save_xml):
     """
     Type list/short is restricted by facet length with value 6.
@@ -9361,11 +9973,12 @@ def test_list_short_length_1_nistxml_sv_iv_list_short_length_2_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_nistxml_sv_iv_list_short_length_1_1(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9376,11 +9989,12 @@ def test_list_short_length_nistxml_sv_iv_list_short_length_1_1(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_nistxml_sv_iv_list_short_length_1_2(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9391,11 +10005,12 @@ def test_list_short_length_nistxml_sv_iv_list_short_length_1_2(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_nistxml_sv_iv_list_short_length_1_3(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9406,11 +10021,12 @@ def test_list_short_length_nistxml_sv_iv_list_short_length_1_3(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_nistxml_sv_iv_list_short_length_1_4(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9421,11 +10037,12 @@ def test_list_short_length_nistxml_sv_iv_list_short_length_1_4(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_length_nistxml_sv_iv_list_short_length_1_5(save_xml):
     """
     Type list/short is restricted by facet length with value 5.
@@ -9436,11 +10053,12 @@ def test_list_short_length_nistxml_sv_iv_list_short_length_1_5(save_xml):
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9451,11 +10069,12 @@ def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9466,11 +10085,12 @@ def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9481,11 +10101,12 @@ def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9496,11 +10117,12 @@ def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 10.
@@ -9511,11 +10133,12 @@ def test_list_short_min_length_4_nistxml_sv_iv_list_short_min_length_5_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9526,11 +10149,12 @@ def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9541,11 +10165,12 @@ def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9556,11 +10181,12 @@ def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9571,11 +10197,12 @@ def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 8.
@@ -9586,11 +10213,12 @@ def test_list_short_min_length_3_nistxml_sv_iv_list_short_min_length_4_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9601,11 +10229,12 @@ def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9616,11 +10245,12 @@ def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9631,11 +10261,12 @@ def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9646,11 +10277,12 @@ def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 7.
@@ -9661,11 +10293,12 @@ def test_list_short_min_length_2_nistxml_sv_iv_list_short_min_length_3_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9676,11 +10309,12 @@ def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9691,11 +10325,12 @@ def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9706,11 +10341,12 @@ def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9721,11 +10357,12 @@ def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 6.
@@ -9736,11 +10373,12 @@ def test_list_short_min_length_1_nistxml_sv_iv_list_short_min_length_2_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_1(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9751,11 +10389,12 @@ def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_1(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_2(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9766,11 +10405,12 @@ def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_2(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_3(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9781,11 +10421,12 @@ def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_3(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_4(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9796,11 +10437,12 @@ def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_4(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_5(save_xml):
     """
     Type list/short is restricted by facet minLength with value 5.
@@ -9811,11 +10453,12 @@ def test_list_short_min_length_nistxml_sv_iv_list_short_min_length_1_5(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9826,11 +10469,12 @@ def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9841,11 +10485,12 @@ def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9856,11 +10501,12 @@ def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9871,11 +10517,12 @@ def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 10.
@@ -9886,11 +10533,12 @@ def test_list_short_max_length_4_nistxml_sv_iv_list_short_max_length_5_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9901,11 +10549,12 @@ def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9916,11 +10565,12 @@ def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9931,11 +10581,12 @@ def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9946,11 +10597,12 @@ def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 8.
@@ -9961,11 +10613,12 @@ def test_list_short_max_length_3_nistxml_sv_iv_list_short_max_length_4_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9976,11 +10629,12 @@ def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -9991,11 +10645,12 @@ def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -10006,11 +10661,12 @@ def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -10021,11 +10677,12 @@ def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 7.
@@ -10036,11 +10693,12 @@ def test_list_short_max_length_2_nistxml_sv_iv_list_short_max_length_3_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -10051,11 +10709,12 @@ def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_1(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -10066,11 +10725,12 @@ def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_2(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -10081,11 +10741,12 @@ def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_3(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -10096,11 +10757,12 @@ def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_4(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 6.
@@ -10111,11 +10773,12 @@ def test_list_short_max_length_1_nistxml_sv_iv_list_short_max_length_2_5(save_xm
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_1(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -10126,11 +10789,12 @@ def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_1(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_2(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -10141,11 +10805,12 @@ def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_2(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_3(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -10156,11 +10821,12 @@ def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_3(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_4(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -10171,11 +10837,12 @@ def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_4(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_5(save_xml):
     """
     Type list/short is restricted by facet maxLength with value 5.
@@ -10186,11 +10853,12 @@ def test_list_short_max_length_nistxml_sv_iv_list_short_max_length_1_5(save_xml)
         instance="nistData/list/short/Schema+Instance/NISTXML-SV-IV-list-short-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListShortMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_1(save_xml):
     """
     Type list/int is restricted by facet whiteSpace with value collapse.
@@ -10201,11 +10869,12 @@ def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_2(save_xml):
     """
     Type list/int is restricted by facet whiteSpace with value collapse.
@@ -10216,11 +10885,12 @@ def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_3(save_xml):
     """
     Type list/int is restricted by facet whiteSpace with value collapse.
@@ -10231,11 +10901,12 @@ def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_4(save_xml):
     """
     Type list/int is restricted by facet whiteSpace with value collapse.
@@ -10246,11 +10917,12 @@ def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_5(save_xml):
     """
     Type list/int is restricted by facet whiteSpace with value collapse.
@@ -10261,11 +10933,12 @@ def test_list_int_white_space_nistxml_sv_iv_list_int_white_space_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10276,11 +10949,12 @@ def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10291,11 +10965,12 @@ def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10306,11 +10981,12 @@ def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10321,11 +10997,12 @@ def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10336,11 +11013,12 @@ def test_list_int_enumeration_4_nistxml_sv_iv_list_int_enumeration_5_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10351,11 +11029,12 @@ def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10366,11 +11045,12 @@ def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10381,11 +11061,12 @@ def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10396,11 +11077,12 @@ def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10411,11 +11093,12 @@ def test_list_int_enumeration_3_nistxml_sv_iv_list_int_enumeration_4_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10426,11 +11109,12 @@ def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10441,11 +11125,12 @@ def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10456,11 +11141,12 @@ def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10471,11 +11157,12 @@ def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10486,11 +11173,12 @@ def test_list_int_enumeration_2_nistxml_sv_iv_list_int_enumeration_3_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10501,11 +11189,12 @@ def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_1(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10516,11 +11205,12 @@ def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_2(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10531,11 +11221,12 @@ def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_3(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10546,11 +11237,12 @@ def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_4(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10561,11 +11253,12 @@ def test_list_int_enumeration_1_nistxml_sv_iv_list_int_enumeration_2_5(save_xml)
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_1(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10576,11 +11269,12 @@ def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_2(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10591,11 +11285,12 @@ def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_3(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10606,11 +11301,12 @@ def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_4(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10621,11 +11317,12 @@ def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_5(save_xml):
     """
     Type list/int is restricted by facet enumeration.
@@ -10636,11 +11333,12 @@ def test_list_int_enumeration_nistxml_sv_iv_list_int_enumeration_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10652,11 +11350,12 @@ def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10668,11 +11367,12 @@ def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10684,11 +11384,12 @@ def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10700,11 +11401,12 @@ def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10716,11 +11418,12 @@ def test_list_int_pattern_4_nistxml_sv_iv_list_int_pattern_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10732,11 +11435,12 @@ def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10748,11 +11452,12 @@ def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10764,11 +11469,12 @@ def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10780,11 +11486,12 @@ def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10796,11 +11503,12 @@ def test_list_int_pattern_3_nistxml_sv_iv_list_int_pattern_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10812,11 +11520,12 @@ def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10828,11 +11537,12 @@ def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10844,11 +11554,12 @@ def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10860,11 +11571,12 @@ def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10876,11 +11588,12 @@ def test_list_int_pattern_2_nistxml_sv_iv_list_int_pattern_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10892,11 +11605,12 @@ def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10908,11 +11622,12 @@ def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10924,11 +11639,12 @@ def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10940,11 +11656,12 @@ def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10956,11 +11673,12 @@ def test_list_int_pattern_1_nistxml_sv_iv_list_int_pattern_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_1(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10972,11 +11690,12 @@ def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_2(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -10988,11 +11707,12 @@ def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_3(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -11004,11 +11724,12 @@ def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_4(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -11020,11 +11741,12 @@ def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_5(save_xml):
     r"""
     Type list/int is restricted by facet pattern with value \-\d{10}
@@ -11036,11 +11758,12 @@ def test_list_int_pattern_nistxml_sv_iv_list_int_pattern_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_1(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -11051,11 +11774,12 @@ def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_2(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -11066,11 +11790,12 @@ def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_3(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -11081,11 +11806,12 @@ def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_4(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -11096,11 +11822,12 @@ def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_5(save_xml):
     """
     Type list/int is restricted by facet length with value 10.
@@ -11111,11 +11838,12 @@ def test_list_int_length_4_nistxml_sv_iv_list_int_length_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_1(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -11126,11 +11854,12 @@ def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_2(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -11141,11 +11870,12 @@ def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_3(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -11156,11 +11886,12 @@ def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_4(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -11171,11 +11902,12 @@ def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_5(save_xml):
     """
     Type list/int is restricted by facet length with value 8.
@@ -11186,11 +11918,12 @@ def test_list_int_length_3_nistxml_sv_iv_list_int_length_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_1(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -11201,11 +11934,12 @@ def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_2(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -11216,11 +11950,12 @@ def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_3(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -11231,11 +11966,12 @@ def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_4(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -11246,11 +11982,12 @@ def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_5(save_xml):
     """
     Type list/int is restricted by facet length with value 7.
@@ -11261,11 +11998,12 @@ def test_list_int_length_2_nistxml_sv_iv_list_int_length_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_1(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11276,11 +12014,12 @@ def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_2(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11291,11 +12030,12 @@ def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_3(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11306,11 +12046,12 @@ def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_4(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11321,11 +12062,12 @@ def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_5(save_xml):
     """
     Type list/int is restricted by facet length with value 6.
@@ -11336,11 +12078,12 @@ def test_list_int_length_1_nistxml_sv_iv_list_int_length_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_nistxml_sv_iv_list_int_length_1_1(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11351,11 +12094,12 @@ def test_list_int_length_nistxml_sv_iv_list_int_length_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_nistxml_sv_iv_list_int_length_1_2(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11366,11 +12110,12 @@ def test_list_int_length_nistxml_sv_iv_list_int_length_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_nistxml_sv_iv_list_int_length_1_3(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11381,11 +12126,12 @@ def test_list_int_length_nistxml_sv_iv_list_int_length_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_nistxml_sv_iv_list_int_length_1_4(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11396,11 +12142,12 @@ def test_list_int_length_nistxml_sv_iv_list_int_length_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_length_nistxml_sv_iv_list_int_length_1_5(save_xml):
     """
     Type list/int is restricted by facet length with value 5.
@@ -11411,11 +12158,12 @@ def test_list_int_length_nistxml_sv_iv_list_int_length_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11426,11 +12174,12 @@ def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11441,11 +12190,12 @@ def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11456,11 +12206,12 @@ def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11471,11 +12222,12 @@ def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 10.
@@ -11486,11 +12238,12 @@ def test_list_int_min_length_4_nistxml_sv_iv_list_int_min_length_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11501,11 +12254,12 @@ def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11516,11 +12270,12 @@ def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11531,11 +12286,12 @@ def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11546,11 +12302,12 @@ def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 8.
@@ -11561,11 +12318,12 @@ def test_list_int_min_length_3_nistxml_sv_iv_list_int_min_length_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11576,11 +12334,12 @@ def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11591,11 +12350,12 @@ def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11606,11 +12366,12 @@ def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11621,11 +12382,12 @@ def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 7.
@@ -11636,11 +12398,12 @@ def test_list_int_min_length_2_nistxml_sv_iv_list_int_min_length_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11651,11 +12414,12 @@ def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11666,11 +12430,12 @@ def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11681,11 +12446,12 @@ def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11696,11 +12462,12 @@ def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 6.
@@ -11711,11 +12478,12 @@ def test_list_int_min_length_1_nistxml_sv_iv_list_int_min_length_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_1(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11726,11 +12494,12 @@ def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_2(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11741,11 +12510,12 @@ def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_3(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11756,11 +12526,12 @@ def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_4(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11771,11 +12542,12 @@ def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_5(save_xml):
     """
     Type list/int is restricted by facet minLength with value 5.
@@ -11786,11 +12558,12 @@ def test_list_int_min_length_nistxml_sv_iv_list_int_min_length_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11801,11 +12574,12 @@ def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11816,11 +12590,12 @@ def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11831,11 +12606,12 @@ def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11846,11 +12622,12 @@ def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 10.
@@ -11861,11 +12638,12 @@ def test_list_int_max_length_4_nistxml_sv_iv_list_int_max_length_5_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11876,11 +12654,12 @@ def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11891,11 +12670,12 @@ def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11906,11 +12686,12 @@ def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11921,11 +12702,12 @@ def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 8.
@@ -11936,11 +12718,12 @@ def test_list_int_max_length_3_nistxml_sv_iv_list_int_max_length_4_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11951,11 +12734,12 @@ def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11966,11 +12750,12 @@ def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11981,11 +12766,12 @@ def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -11996,11 +12782,12 @@ def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 7.
@@ -12011,11 +12798,12 @@ def test_list_int_max_length_2_nistxml_sv_iv_list_int_max_length_3_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -12026,11 +12814,12 @@ def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -12041,11 +12830,12 @@ def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -12056,11 +12846,12 @@ def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -12071,11 +12862,12 @@ def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 6.
@@ -12086,11 +12878,12 @@ def test_list_int_max_length_1_nistxml_sv_iv_list_int_max_length_2_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_1(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -12101,11 +12894,12 @@ def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_1(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_2(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -12116,11 +12910,12 @@ def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_2(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_3(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -12131,11 +12926,12 @@ def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_3(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_4(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -12146,11 +12942,12 @@ def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_4(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_5(save_xml):
     """
     Type list/int is restricted by facet maxLength with value 5.
@@ -12161,11 +12958,12 @@ def test_list_int_max_length_nistxml_sv_iv_list_int_max_length_1_5(save_xml):
         instance="nistData/list/int/Schema+Instance/NISTXML-SV-IV-list-int-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListIntMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_1(save_xml):
     """
     Type list/long is restricted by facet whiteSpace with value collapse.
@@ -12176,11 +12974,12 @@ def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_2(save_xml):
     """
     Type list/long is restricted by facet whiteSpace with value collapse.
@@ -12191,11 +12990,12 @@ def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_3(save_xml):
     """
     Type list/long is restricted by facet whiteSpace with value collapse.
@@ -12206,11 +13006,12 @@ def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_4(save_xml):
     """
     Type list/long is restricted by facet whiteSpace with value collapse.
@@ -12221,11 +13022,12 @@ def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_5(save_xml):
     """
     Type list/long is restricted by facet whiteSpace with value collapse.
@@ -12236,11 +13038,12 @@ def test_list_long_white_space_nistxml_sv_iv_list_long_white_space_1_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12251,11 +13054,12 @@ def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12266,11 +13070,12 @@ def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12281,11 +13086,12 @@ def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12296,11 +13102,12 @@ def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12311,11 +13118,12 @@ def test_list_long_enumeration_4_nistxml_sv_iv_list_long_enumeration_5_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12326,11 +13134,12 @@ def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12341,11 +13150,12 @@ def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12356,11 +13166,12 @@ def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12371,11 +13182,12 @@ def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12386,11 +13198,12 @@ def test_list_long_enumeration_3_nistxml_sv_iv_list_long_enumeration_4_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12401,11 +13214,12 @@ def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12416,11 +13230,12 @@ def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12431,11 +13246,12 @@ def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12446,11 +13262,12 @@ def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12461,11 +13278,12 @@ def test_list_long_enumeration_2_nistxml_sv_iv_list_long_enumeration_3_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12476,11 +13294,12 @@ def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_1(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12491,11 +13310,12 @@ def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_2(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12506,11 +13326,12 @@ def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_3(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12521,11 +13342,12 @@ def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_4(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12536,11 +13358,12 @@ def test_list_long_enumeration_1_nistxml_sv_iv_list_long_enumeration_2_5(save_xm
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_1(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12551,11 +13374,12 @@ def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_2(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12566,11 +13390,12 @@ def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_3(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12581,11 +13406,12 @@ def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_4(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12596,11 +13422,12 @@ def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_5(save_xml):
     """
     Type list/long is restricted by facet enumeration.
@@ -12611,11 +13438,12 @@ def test_list_long_enumeration_nistxml_sv_iv_list_long_enumeration_1_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12627,11 +13455,12 @@ def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12643,11 +13472,12 @@ def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12659,11 +13489,12 @@ def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12675,11 +13506,12 @@ def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12691,11 +13523,12 @@ def test_list_long_pattern_4_nistxml_sv_iv_list_long_pattern_5_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12707,11 +13540,12 @@ def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12723,11 +13557,12 @@ def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12739,11 +13574,12 @@ def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12755,11 +13591,12 @@ def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12771,11 +13608,12 @@ def test_list_long_pattern_3_nistxml_sv_iv_list_long_pattern_4_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12787,11 +13625,12 @@ def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12803,11 +13642,12 @@ def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12819,11 +13659,12 @@ def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12835,11 +13676,12 @@ def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12851,11 +13693,12 @@ def test_list_long_pattern_2_nistxml_sv_iv_list_long_pattern_3_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12867,11 +13710,12 @@ def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12883,11 +13727,12 @@ def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12899,11 +13744,12 @@ def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12915,11 +13761,12 @@ def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12931,11 +13778,12 @@ def test_list_long_pattern_1_nistxml_sv_iv_list_long_pattern_2_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_1(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12947,11 +13795,12 @@ def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_2(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12963,11 +13812,12 @@ def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_3(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12979,11 +13829,12 @@ def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_4(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -12995,11 +13846,12 @@ def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_5(save_xml):
     r"""
     Type list/long is restricted by facet pattern with value \-\d{18}
@@ -13011,11 +13863,12 @@ def test_list_long_pattern_nistxml_sv_iv_list_long_pattern_1_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_1(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -13026,11 +13879,12 @@ def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_2(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -13041,11 +13895,12 @@ def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_3(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -13056,11 +13911,12 @@ def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_4(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -13071,11 +13927,12 @@ def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_5(save_xml):
     """
     Type list/long is restricted by facet length with value 10.
@@ -13086,11 +13943,12 @@ def test_list_long_length_4_nistxml_sv_iv_list_long_length_5_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_1(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -13101,11 +13959,12 @@ def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_2(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -13116,11 +13975,12 @@ def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_3(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -13131,11 +13991,12 @@ def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_4(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -13146,11 +14007,12 @@ def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_5(save_xml):
     """
     Type list/long is restricted by facet length with value 8.
@@ -13161,11 +14023,12 @@ def test_list_long_length_3_nistxml_sv_iv_list_long_length_4_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_1(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -13176,11 +14039,12 @@ def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_2(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -13191,11 +14055,12 @@ def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_3(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -13206,11 +14071,12 @@ def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_4(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -13221,11 +14087,12 @@ def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_5(save_xml):
     """
     Type list/long is restricted by facet length with value 7.
@@ -13236,11 +14103,12 @@ def test_list_long_length_2_nistxml_sv_iv_list_long_length_3_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_1(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -13251,11 +14119,12 @@ def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_2(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -13266,11 +14135,12 @@ def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_3(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -13281,11 +14151,12 @@ def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_4(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -13296,11 +14167,12 @@ def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_5(save_xml):
     """
     Type list/long is restricted by facet length with value 6.
@@ -13311,11 +14183,12 @@ def test_list_long_length_1_nistxml_sv_iv_list_long_length_2_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_nistxml_sv_iv_list_long_length_1_1(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -13326,11 +14199,12 @@ def test_list_long_length_nistxml_sv_iv_list_long_length_1_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_nistxml_sv_iv_list_long_length_1_2(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -13341,11 +14215,12 @@ def test_list_long_length_nistxml_sv_iv_list_long_length_1_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_nistxml_sv_iv_list_long_length_1_3(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -13356,11 +14231,12 @@ def test_list_long_length_nistxml_sv_iv_list_long_length_1_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_nistxml_sv_iv_list_long_length_1_4(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -13371,11 +14247,12 @@ def test_list_long_length_nistxml_sv_iv_list_long_length_1_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_length_nistxml_sv_iv_list_long_length_1_5(save_xml):
     """
     Type list/long is restricted by facet length with value 5.
@@ -13386,11 +14263,12 @@ def test_list_long_length_nistxml_sv_iv_list_long_length_1_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-length-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13401,11 +14279,12 @@ def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13416,11 +14295,12 @@ def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13431,11 +14311,12 @@ def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13446,11 +14327,12 @@ def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 10.
@@ -13461,11 +14343,12 @@ def test_list_long_min_length_4_nistxml_sv_iv_list_long_min_length_5_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13476,11 +14359,12 @@ def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13491,11 +14375,12 @@ def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13506,11 +14391,12 @@ def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13521,11 +14407,12 @@ def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 8.
@@ -13536,11 +14423,12 @@ def test_list_long_min_length_3_nistxml_sv_iv_list_long_min_length_4_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13551,11 +14439,12 @@ def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13566,11 +14455,12 @@ def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13581,11 +14471,12 @@ def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13596,11 +14487,12 @@ def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 7.
@@ -13611,11 +14503,12 @@ def test_list_long_min_length_2_nistxml_sv_iv_list_long_min_length_3_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13626,11 +14519,12 @@ def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13641,11 +14535,12 @@ def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13656,11 +14551,12 @@ def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13671,11 +14567,12 @@ def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 6.
@@ -13686,11 +14583,12 @@ def test_list_long_min_length_1_nistxml_sv_iv_list_long_min_length_2_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_1(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13701,11 +14599,12 @@ def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_2(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13716,11 +14615,12 @@ def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_3(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13731,11 +14631,12 @@ def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_4(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13746,11 +14647,12 @@ def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_5(save_xml):
     """
     Type list/long is restricted by facet minLength with value 5.
@@ -13761,11 +14663,12 @@ def test_list_long_min_length_nistxml_sv_iv_list_long_min_length_1_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-minLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMinLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13776,11 +14679,12 @@ def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13791,11 +14695,12 @@ def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13806,11 +14711,12 @@ def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13821,11 +14727,12 @@ def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 10.
@@ -13836,11 +14743,12 @@ def test_list_long_max_length_4_nistxml_sv_iv_list_long_max_length_5_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13851,11 +14759,12 @@ def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13866,11 +14775,12 @@ def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13881,11 +14791,12 @@ def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13896,11 +14807,12 @@ def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 8.
@@ -13911,11 +14823,12 @@ def test_list_long_max_length_3_nistxml_sv_iv_list_long_max_length_4_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13926,11 +14839,12 @@ def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13941,11 +14855,12 @@ def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13956,11 +14871,12 @@ def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13971,11 +14887,12 @@ def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 7.
@@ -13986,11 +14903,12 @@ def test_list_long_max_length_2_nistxml_sv_iv_list_long_max_length_3_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -14001,11 +14919,12 @@ def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_1(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -14016,11 +14935,12 @@ def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_2(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -14031,11 +14951,12 @@ def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_3(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -14046,11 +14967,12 @@ def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_4(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 6.
@@ -14061,11 +14983,12 @@ def test_list_long_max_length_1_nistxml_sv_iv_list_long_max_length_2_5(save_xml)
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_1(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -14076,11 +14999,12 @@ def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_1(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_2(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -14091,11 +15015,12 @@ def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_2(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_3(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -14106,11 +15031,12 @@ def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_3(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_4(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -14121,11 +15047,12 @@ def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_4(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_5(save_xml):
     """
     Type list/long is restricted by facet maxLength with value 5.
@@ -14136,11 +15063,12 @@ def test_list_long_max_length_nistxml_sv_iv_list_long_max_length_1_5(save_xml):
         instance="nistData/list/long/Schema+Instance/NISTXML-SV-IV-list-long-maxLength-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListLongMaxLength1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_white_space_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet whiteSpace with value
@@ -14152,11 +15080,12 @@ def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_w
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-whiteSpace-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_white_space_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet whiteSpace with value
@@ -14168,11 +15097,12 @@ def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_w
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-whiteSpace-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_white_space_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet whiteSpace with value
@@ -14184,11 +15114,12 @@ def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_w
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-whiteSpace-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_white_space_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet whiteSpace with value
@@ -14200,11 +15131,12 @@ def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_w
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-whiteSpace-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_white_space_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet whiteSpace with value
@@ -14216,11 +15148,12 @@ def test_list_negative_integer_white_space_nistxml_sv_iv_list_negative_integer_w
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-whiteSpace-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerWhiteSpace1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer_enumeration_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14231,11 +15164,12 @@ def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer_enumeration_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14246,11 +15180,12 @@ def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer_enumeration_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14261,11 +15196,12 @@ def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer_enumeration_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14276,11 +15212,12 @@ def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer_enumeration_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14291,11 +15228,12 @@ def test_list_negative_integer_enumeration_4_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer_enumeration_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14306,11 +15244,12 @@ def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer_enumeration_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14321,11 +15260,12 @@ def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer_enumeration_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14336,11 +15276,12 @@ def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer_enumeration_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14351,11 +15292,12 @@ def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer_enumeration_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14366,11 +15308,12 @@ def test_list_negative_integer_enumeration_3_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer_enumeration_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14381,11 +15324,12 @@ def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer_enumeration_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14396,11 +15340,12 @@ def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer_enumeration_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14411,11 +15356,12 @@ def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer_enumeration_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14426,11 +15372,12 @@ def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer_enumeration_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14441,11 +15388,12 @@ def test_list_negative_integer_enumeration_2_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer_enumeration_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14456,11 +15404,12 @@ def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer_enumeration_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14471,11 +15420,12 @@ def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer_enumeration_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14486,11 +15436,12 @@ def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer_enumeration_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14501,11 +15452,12 @@ def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer_enumeration_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14516,11 +15468,12 @@ def test_list_negative_integer_enumeration_1_nistxml_sv_iv_list_negative_integer
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_enumeration_1_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14531,11 +15484,12 @@ def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_e
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_enumeration_1_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14546,11 +15500,12 @@ def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_e
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_enumeration_1_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14561,11 +15516,12 @@ def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_e
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_enumeration_1_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14576,11 +15532,12 @@ def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_e
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_enumeration_1_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet enumeration.
@@ -14591,11 +15548,12 @@ def test_list_negative_integer_enumeration_nistxml_sv_iv_list_negative_integer_e
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-enumeration-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerEnumeration1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pattern_5_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14607,11 +15565,12 @@ def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pattern_5_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14623,11 +15582,12 @@ def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pattern_5_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14639,11 +15599,12 @@ def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pattern_5_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14655,11 +15616,12 @@ def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pattern_5_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14671,11 +15633,12 @@ def test_list_negative_integer_pattern_4_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pattern_4_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14687,11 +15650,12 @@ def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pattern_4_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14703,11 +15667,12 @@ def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pattern_4_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14719,11 +15684,12 @@ def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pattern_4_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14735,11 +15701,12 @@ def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pattern_4_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14751,11 +15718,12 @@ def test_list_negative_integer_pattern_3_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pattern_3_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14767,11 +15735,12 @@ def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pattern_3_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14783,11 +15752,12 @@ def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pattern_3_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14799,11 +15769,12 @@ def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pattern_3_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14815,11 +15786,12 @@ def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pattern_3_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14831,11 +15803,12 @@ def test_list_negative_integer_pattern_2_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pattern_2_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14848,11 +15821,12 @@ def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pattern_2_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14865,11 +15839,12 @@ def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pattern_2_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14882,11 +15857,12 @@ def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pattern_2_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14899,11 +15875,12 @@ def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pattern_2_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14916,11 +15893,12 @@ def test_list_negative_integer_pattern_1_nistxml_sv_iv_list_negative_integer_pat
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_pattern_1_1(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14932,11 +15910,12 @@ def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_patte
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-1-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_pattern_1_2(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14948,11 +15927,12 @@ def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_patte
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-1-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_pattern_1_3(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14964,11 +15944,12 @@ def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_patte
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-1-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_pattern_1_4(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14980,11 +15961,12 @@ def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_patte
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-1-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_pattern_1_5(save_xml):
     r"""
     Type list/negativeInteger is restricted by facet pattern with value
@@ -14996,11 +15978,12 @@ def test_list_negative_integer_pattern_nistxml_sv_iv_list_negative_integer_patte
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-pattern-1-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerPattern1",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_length_5_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -15011,11 +15994,12 @@ def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-5-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_length_5_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -15026,11 +16010,12 @@ def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-5-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_length_5_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -15041,11 +16026,12 @@ def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-5-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_length_5_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -15056,11 +16042,12 @@ def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-5-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_length_5_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 10.
@@ -15071,11 +16058,12 @@ def test_list_negative_integer_length_4_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-5-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength5",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_length_4_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -15086,11 +16074,12 @@ def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-4-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_length_4_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -15101,11 +16090,12 @@ def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-4-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_length_4_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -15116,11 +16106,12 @@ def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-4-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_length_4_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -15131,11 +16122,12 @@ def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-4-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_length_4_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 8.
@@ -15146,11 +16138,12 @@ def test_list_negative_integer_length_3_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-4-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength4",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_length_3_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -15161,11 +16154,12 @@ def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-3-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_length_3_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -15176,11 +16170,12 @@ def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-3-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_length_3_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -15191,11 +16186,12 @@ def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-3-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_length_3_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -15206,11 +16202,12 @@ def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-3-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_length_3_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 7.
@@ -15221,11 +16218,12 @@ def test_list_negative_integer_length_2_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-3-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength3",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_length_2_1(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -15236,11 +16234,12 @@ def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-2-1.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_length_2_2(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -15251,11 +16250,12 @@ def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-2-2.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_length_2_3(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -15266,11 +16266,12 @@ def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-2-3.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_length_2_4(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -15281,11 +16282,12 @@ def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-2-4.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_length_2_5(save_xml):
     """
     Type list/negativeInteger is restricted by facet length with value 6.
@@ -15296,6 +16298,6 @@ def test_list_negative_integer_length_1_nistxml_sv_iv_list_negative_integer_leng
         instance="nistData/list/negativeInteger/Schema+Instance/NISTXML-SV-IV-list-negativeInteger-length-2-5.xml",
         instance_is_valid=True,
         class_name="NistschemaSvIvListNegativeIntegerLength2",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_saxon_meta_856.py
+++ b/tests/test_saxon_meta_856.py
@@ -3378,7 +3378,6 @@ def test_cta0018_cta0018_v01(save_xml):
 
 
 @pytest.mark.schema11
-@pytest.mark.xfail
 def test_cta0017_cta0017_v01(save_xml):
     """
     Type alternative using a simple type XPath expression can only access
@@ -5807,7 +5806,6 @@ def test_missing003_missing003_n1_xml(save_xml):
     )
 
 
-@pytest.mark.xfail
 def test_missing002_missing001_v1_xml(save_xml):
     """
     Element declaration with missing substitution group head Error only if
@@ -5824,7 +5822,6 @@ def test_missing002_missing001_v1_xml(save_xml):
     )
 
 
-@pytest.mark.xfail
 def test_missing002_missing001_n1_xml(save_xml):
     """
     Element declaration with missing substitution group head Error only if
@@ -13719,7 +13716,6 @@ def test_xv005_xv005_n02_xml(save_xml):
 
 
 @pytest.mark.schema11
-@pytest.mark.xfail
 def test_xv004_xv004_v01_xml(save_xml):
     """
     Use newly-allowed name characters in schema component names Non-BMP

--- a/tests/test_saxon_meta_856.py
+++ b/tests/test_saxon_meta_856.py
@@ -3332,6 +3332,7 @@ def test_cta0018_cta0018_v01(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_cta0017_cta0017_v01(save_xml):
     """
     Type alternative using a simple type XPath expression can only access
@@ -5739,6 +5740,7 @@ def test_missing003_missing003_n1_xml(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_missing002_missing001_v1_xml(save_xml):
     """
     Element declaration with missing substitution group head Error only if
@@ -5755,6 +5757,7 @@ def test_missing002_missing001_v1_xml(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_missing002_missing001_n1_xml(save_xml):
     """
     Element declaration with missing substitution group head Error only if
@@ -13560,6 +13563,7 @@ def test_xv005_xv005_n02_xml(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_xv004_xv004_v01_xml(save_xml):
     """
     Use newly-allowed name characters in schema component names Non-BMP

--- a/tests/test_saxon_meta_856.py
+++ b/tests/test_saxon_meta_856.py
@@ -1991,6 +1991,7 @@ def test_assert001_assert001_n1_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_unique003_unique003_v1_xml(save_xml):
     """
     For the purposes of uniqueness constraints, NaN is effectively equal
@@ -2004,11 +2005,12 @@ def test_unique003_unique003_v1_xml(save_xml):
         instance="saxonData/Complex/unique003.v1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unique003_unique003_v2_xml(save_xml):
     """
     For the purposes of uniqueness constraints, NaN is effectively equal
@@ -2022,11 +2024,12 @@ def test_unique003_unique003_v2_xml(save_xml):
         instance="saxonData/Complex/unique003.v2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unique003_unique003_n1_xml(save_xml):
     """
     For the purposes of uniqueness constraints, NaN is effectively equal
@@ -2040,11 +2043,12 @@ def test_unique003_unique003_n1_xml(save_xml):
         instance="saxonData/Complex/unique003.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unique003_unique003_n2_xml(save_xml):
     """
     For the purposes of uniqueness constraints, NaN is effectively equal
@@ -2058,11 +2062,12 @@ def test_unique003_unique003_n2_xml(save_xml):
         instance="saxonData/Complex/unique003.n2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unique002_unique002_n1_xml(save_xml):
     """
     Test uniqueness constraint on a field having a complex type with mixed
@@ -2075,11 +2080,12 @@ def test_unique002_unique002_n1_xml(save_xml):
         instance="saxonData/Complex/unique002.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unique001_unique001_v1_xml(save_xml):
     """
     Test uniqueness constraint on a field having a complex type with
@@ -2093,11 +2099,12 @@ def test_unique001_unique001_v1_xml(save_xml):
         instance="saxonData/Complex/unique001.v1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_unique001_unique001_n1_xml(save_xml):
     """
     Test uniqueness constraint on a field having a complex type with
@@ -2111,11 +2118,12 @@ def test_unique001_unique001_n1_xml(save_xml):
         instance="saxonData/Complex/unique001.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex022_complex022_n1_xml(save_xml):
     """
     Empty choice should accept no instances A content model defined as an
@@ -2129,11 +2137,12 @@ def test_complex022_complex022_n1_xml(save_xml):
         instance="saxonData/Complex/complex022.n1.xml",
         instance_is_valid=False,
         class_name="Z",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex022_complex022_n2_xml(save_xml):
     """
     Empty choice should accept no instances A content model defined as an
@@ -2147,11 +2156,12 @@ def test_complex022_complex022_n2_xml(save_xml):
         instance="saxonData/Complex/complex022.n2.xml",
         instance_is_valid=False,
         class_name="Z",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex021_complex021_n1_xml(save_xml):
     """
     Element declared with an abstract type Instance is invalid because the
@@ -2163,11 +2173,12 @@ def test_complex021_complex021_n1_xml(save_xml):
         instance="saxonData/Complex/complex021.n1.xml",
         instance_is_valid=False,
         class_name="ECon",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex015_complex015_n1_xml(save_xml):
     """
     xsi:type on complex type must resolve Instance is invalid if xsi:type
@@ -2179,11 +2190,12 @@ def test_complex015_complex015_n1_xml(save_xml):
         instance="saxonData/Complex/complex015.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex014_complex014_v1_xml(save_xml):
     """
     xsi:nil on complex type with element-only content, xs:all compositor
@@ -2196,11 +2208,12 @@ def test_complex014_complex014_v1_xml(save_xml):
         instance="saxonData/Complex/complex013.v1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex014_complex014_v2_xml(save_xml):
     """
     xsi:nil on complex type with element-only content, xs:all compositor
@@ -2213,11 +2226,12 @@ def test_complex014_complex014_v2_xml(save_xml):
         instance="saxonData/Complex/complex013.v2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex014_complex014_n1_xml(save_xml):
     """
     xsi:nil on complex type with element-only content, xs:all compositor
@@ -2230,11 +2244,12 @@ def test_complex014_complex014_n1_xml(save_xml):
         instance="saxonData/Complex/complex013.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex014_complex014_n2_xml(save_xml):
     """
     xsi:nil on complex type with element-only content, xs:all compositor
@@ -2247,11 +2262,12 @@ def test_complex014_complex014_n2_xml(save_xml):
         instance="saxonData/Complex/complex013.n2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex013_complex013_v1_xml(save_xml):
     """
     xsi:nil on complex type with element-only content (not specific to
@@ -2263,11 +2279,12 @@ def test_complex013_complex013_v1_xml(save_xml):
         instance="saxonData/Complex/complex013.v1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex013_complex013_v2_xml(save_xml):
     """
     xsi:nil on complex type with element-only content (not specific to
@@ -2279,11 +2296,12 @@ def test_complex013_complex013_v2_xml(save_xml):
         instance="saxonData/Complex/complex013.v2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex013_complex013_n1_xml(save_xml):
     """
     xsi:nil on complex type with element-only content (not specific to
@@ -2295,11 +2313,12 @@ def test_complex013_complex013_n1_xml(save_xml):
         instance="saxonData/Complex/complex013.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex013_complex013_n2_xml(save_xml):
     """
     xsi:nil on complex type with element-only content (not specific to
@@ -2311,11 +2330,12 @@ def test_complex013_complex013_n2_xml(save_xml):
         instance="saxonData/Complex/complex013.n2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_v1_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2327,11 +2347,12 @@ def test_complex012_complex012_v1_xml(save_xml):
         instance="saxonData/Complex/complex012.v1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_v2_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2343,11 +2364,12 @@ def test_complex012_complex012_v2_xml(save_xml):
         instance="saxonData/Complex/complex012.v2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_v3_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2359,11 +2381,12 @@ def test_complex012_complex012_v3_xml(save_xml):
         instance="saxonData/Complex/complex012.v3.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_v4_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2375,11 +2398,12 @@ def test_complex012_complex012_v4_xml(save_xml):
         instance="saxonData/Complex/complex012.v4.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_v5_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2391,11 +2415,12 @@ def test_complex012_complex012_v5_xml(save_xml):
         instance="saxonData/Complex/complex012.v5.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_v6_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2407,11 +2432,12 @@ def test_complex012_complex012_v6_xml(save_xml):
         instance="saxonData/Complex/complex012.v6.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_n1_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2423,11 +2449,12 @@ def test_complex012_complex012_n1_xml(save_xml):
         instance="saxonData/Complex/complex012.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_n2_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2439,11 +2466,12 @@ def test_complex012_complex012_n2_xml(save_xml):
         instance="saxonData/Complex/complex012.n2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex012_complex012_n3_xml(save_xml):
     """
     xsi:nil on complex type with mixede content (not specific to 1.1) All
@@ -2455,11 +2483,12 @@ def test_complex012_complex012_n3_xml(save_xml):
         instance="saxonData/Complex/complex012.n3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex011_complex011_v1_xml(save_xml):
     """
     xsi:nil on complex type with simple content (not specific to 1.1) All
@@ -2471,11 +2500,12 @@ def test_complex011_complex011_v1_xml(save_xml):
         instance="saxonData/Complex/complex011.v1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex011_complex011_v2_xml(save_xml):
     """
     xsi:nil on complex type with simple content (not specific to 1.1) All
@@ -2487,11 +2517,12 @@ def test_complex011_complex011_v2_xml(save_xml):
         instance="saxonData/Complex/complex011.v2.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex011_complex011_n1_xml(save_xml):
     """
     xsi:nil on complex type with simple content (not specific to 1.1) All
@@ -2503,11 +2534,12 @@ def test_complex011_complex011_n1_xml(save_xml):
         instance="saxonData/Complex/complex011.n1.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex011_complex011_n2_xml(save_xml):
     """
     xsi:nil on complex type with simple content (not specific to 1.1) All
@@ -2519,11 +2551,12 @@ def test_complex011_complex011_n2_xml(save_xml):
         instance="saxonData/Complex/complex011.n2.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_complex011_complex011_n3_xml(save_xml):
     """
     xsi:nil on complex type with simple content (not specific to 1.1) All
@@ -2535,7 +2568,7 @@ def test_complex011_complex011_n3_xml(save_xml):
         instance="saxonData/Complex/complex011.n3.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -3140,6 +3173,7 @@ def test_cta0040_cta0040_n01(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_cta0028_cta0028_v01(save_xml):
     """
     Type alternative using a simple type Static context of XPath
@@ -3151,11 +3185,12 @@ def test_cta0028_cta0028_v01(save_xml):
         instance="saxonData/CTA/cta0023.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0027_cta0027_v01(save_xml):
     """
     Type alternative using a simple type Static context of XPath
@@ -3167,11 +3202,12 @@ def test_cta0027_cta0027_v01(save_xml):
         instance="saxonData/CTA/cta0023.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0026_cta0026_v01(save_xml):
     """
     Type alternative using a simple type Static context of XPath
@@ -3183,11 +3219,12 @@ def test_cta0026_cta0026_v01(save_xml):
         instance="saxonData/CTA/cta0023.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0025_cta0025_v01(save_xml):
     """
     Type alternative using a simple type Static context of XPath
@@ -3199,11 +3236,12 @@ def test_cta0025_cta0025_v01(save_xml):
         instance="saxonData/CTA/cta0023.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0024_cta0024_v01(save_xml):
     """
     Type alternative using a simple type Static context of XPath
@@ -3215,11 +3253,12 @@ def test_cta0024_cta0024_v01(save_xml):
         instance="saxonData/CTA/cta0023.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0023_cta0023_v01(save_xml):
     """
     Type alternative using a simple type Static context of XPath
@@ -3231,11 +3270,12 @@ def test_cta0023_cta0023_v01(save_xml):
         instance="saxonData/CTA/cta0023.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0022_cta0022_v01(save_xml):
     """
     Type alternative using a simple type Dynamic context of XPath
@@ -3247,11 +3287,12 @@ def test_cta0022_cta0022_v01(save_xml):
         instance="saxonData/CTA/cta0017.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0021_cta0021_v01(save_xml):
     """
     Type alternative using a simple type XPath expression sees base URI of
@@ -3263,11 +3304,12 @@ def test_cta0021_cta0021_v01(save_xml):
         instance="saxonData/CTA/cta0021.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0021_cta0021_n01(save_xml):
     """
     Type alternative using a simple type XPath expression sees base URI of
@@ -3279,11 +3321,12 @@ def test_cta0021_cta0021_n01(save_xml):
         instance="saxonData/CTA/cta0021.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0020_cta0020_v01(save_xml):
     """
     Type alternative using a simple type XPath expression sees name of
@@ -3295,11 +3338,12 @@ def test_cta0020_cta0020_v01(save_xml):
         instance="saxonData/CTA/cta0017.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0019_cta0019_v01(save_xml):
     """
     Type alternative using a simple type XPath expression sees untyped
@@ -3311,11 +3355,12 @@ def test_cta0019_cta0019_v01(save_xml):
         instance="saxonData/CTA/cta0017.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0018_cta0018_v01(save_xml):
     """
     Type alternative using a simple type XPath expression sees untyped
@@ -3327,11 +3372,12 @@ def test_cta0018_cta0018_v01(save_xml):
         instance="saxonData/CTA/cta0017.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_cta0017_cta0017_v01(save_xml):
     """
@@ -3344,11 +3390,12 @@ def test_cta0017_cta0017_v01(save_xml):
         instance="saxonData/CTA/cta0017.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0016_cta0016_v01(save_xml):
     """
     Type alternative using a simple type Error in XPath evaluation treated
@@ -3360,11 +3407,12 @@ def test_cta0016_cta0016_v01(save_xml):
         instance="saxonData/CTA/cta0014.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0016_cta0016_v02(save_xml):
     """
     Type alternative using a simple type Error in XPath evaluation treated
@@ -3376,11 +3424,12 @@ def test_cta0016_cta0016_v02(save_xml):
         instance="saxonData/CTA/cta0014.v02.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0016_cta0016_n01(save_xml):
     """
     Type alternative using a simple type Error in XPath evaluation treated
@@ -3392,11 +3441,12 @@ def test_cta0016_cta0016_n01(save_xml):
         instance="saxonData/CTA/cta0014.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0016_cta0016_n02(save_xml):
     """
     Type alternative using a simple type Error in XPath evaluation treated
@@ -3408,7 +3458,7 @@ def test_cta0016_cta0016_n02(save_xml):
         instance="saxonData/CTA/cta0014.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -3890,6 +3940,7 @@ def test_cta0008_cta0008_n01(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_cta0007_cta0007_n01(save_xml):
     """
     Variant of cta0006 using xs:error Chosen alternative has a type of
@@ -3901,11 +3952,12 @@ def test_cta0007_cta0007_n01(save_xml):
         instance="saxonData/CTA/cta0007.n01.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0006_cta0006_v01(save_xml):
     """
     Conditional simple type: selecting a branch of a union Simple type of
@@ -3918,11 +3970,12 @@ def test_cta0006_cta0006_v01(save_xml):
         instance="saxonData/CTA/cta0006.v01.xml",
         instance_is_valid=True,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0006_cta0006_n01(save_xml):
     """
     Conditional simple type: selecting a branch of a union Simple type of
@@ -3935,11 +3988,12 @@ def test_cta0006_cta0006_n01(save_xml):
         instance="saxonData/CTA/cta0006.n01.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0006_cta0006_n02(save_xml):
     """
     Conditional simple type: selecting a branch of a union Simple type of
@@ -3952,11 +4006,12 @@ def test_cta0006_cta0006_n02(save_xml):
         instance="saxonData/CTA/cta0006.n02.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0005_cta0005_v01(save_xml):
     """
     Conditional complex type with namespaces Variant of cta0003 (same
@@ -3969,11 +4024,12 @@ def test_cta0005_cta0005_v01(save_xml):
         instance="saxonData/CTA/cta0003.v01.xml",
         instance_is_valid=True,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0005_cta0005_n01(save_xml):
     """
     Conditional complex type with namespaces Variant of cta0003 (same
@@ -3986,11 +4042,12 @@ def test_cta0005_cta0005_n01(save_xml):
         instance="saxonData/CTA/cta0003.n01.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0004_cta0004_v01(save_xml):
     """
     Conditional complex type with namespaces Variant of cta0003 (same
@@ -4002,11 +4059,12 @@ def test_cta0004_cta0004_v01(save_xml):
         instance="saxonData/CTA/cta0003.v01.xml",
         instance_is_valid=True,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0004_cta0004_n01(save_xml):
     """
     Conditional complex type with namespaces Variant of cta0003 (same
@@ -4018,11 +4076,12 @@ def test_cta0004_cta0004_n01(save_xml):
         instance="saxonData/CTA/cta0003.n01.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0003_cta0003_v01(save_xml):
     """
     Conditional complex type with namespaces Trivial reference to the name
@@ -4034,11 +4093,12 @@ def test_cta0003_cta0003_v01(save_xml):
         instance="saxonData/CTA/cta0003.v01.xml",
         instance_is_valid=True,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0003_cta0003_n01(save_xml):
     """
     Conditional complex type with namespaces Trivial reference to the name
@@ -4050,11 +4110,12 @@ def test_cta0003_cta0003_n01(save_xml):
         instance="saxonData/CTA/cta0003.n01.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="full-xpath-in-CTA",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0002_cta0002_v01(save_xml):
     """
     Conditional complex type with namespaces Complex type of message
@@ -4066,11 +4127,12 @@ def test_cta0002_cta0002_v01(save_xml):
         instance="saxonData/CTA/cta0002.v01.xml",
         instance_is_valid=True,
         class_name="Messages",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0002_cta0002_n01(save_xml):
     """
     Conditional complex type with namespaces Complex type of message
@@ -4082,11 +4144,12 @@ def test_cta0002_cta0002_n01(save_xml):
         instance="saxonData/CTA/cta0002.n01.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0001_cta0001_v01(save_xml):
     """
     Conditional simple type: example based on spec Simple type of message
@@ -4098,11 +4161,12 @@ def test_cta0001_cta0001_v01(save_xml):
         instance="saxonData/CTA/cta0001.v01.xml",
         instance_is_valid=True,
         class_name="Message",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0001_cta0001_v02(save_xml):
     """
     Conditional simple type: example based on spec Simple type of message
@@ -4114,11 +4178,12 @@ def test_cta0001_cta0001_v02(save_xml):
         instance="saxonData/CTA/cta0001.v02.xml",
         instance_is_valid=True,
         class_name="Message",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0001_cta0001_v03(save_xml):
     """
     Conditional simple type: example based on spec Simple type of message
@@ -4130,11 +4195,12 @@ def test_cta0001_cta0001_v03(save_xml):
         instance="saxonData/CTA/cta0001.v03.xml",
         instance_is_valid=True,
         class_name="Messages",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0001_cta0001_n01(save_xml):
     """
     Conditional simple type: example based on spec Simple type of message
@@ -4146,11 +4212,12 @@ def test_cta0001_cta0001_n01(save_xml):
         instance="saxonData/CTA/cta0001.n01.xml",
         instance_is_valid=False,
         class_name="Message",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_cta0001_cta0001_n02(save_xml):
     """
     Conditional simple type: example based on spec Simple type of message
@@ -4162,7 +4229,7 @@ def test_cta0001_cta0001_n02(save_xml):
         instance="saxonData/CTA/cta0001.n02.xml",
         instance_is_valid=False,
         class_name="Messages",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -8731,6 +8798,7 @@ def test_over001_over001_n02_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_simple085_simple085_v01_xml(save_xml):
     """
     Union derived by restriction with a pattern facet Pattern facet
@@ -8743,11 +8811,12 @@ def test_simple085_simple085_v01_xml(save_xml):
         instance="saxonData/Simple/simple085.v01.xml",
         instance_is_valid=True,
         class_name="Elem",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple055_simple055_n01_xml(save_xml):
     """
     Selector in identity constraint mistakenly identifies an element with
@@ -8760,11 +8829,12 @@ def test_simple055_simple055_n01_xml(save_xml):
         instance="saxonData/Simple/simple055.n01.xml",
         instance_is_valid=False,
         class_name="Catalog",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple054_simple053_n01_xml(save_xml):
     """
     xsi:type must resolve xsi:type isn't one of the member type of a
@@ -8776,11 +8846,12 @@ def test_simple054_simple053_n01_xml(save_xml):
         instance="saxonData/Simple/simple054.n01.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple050_simple050_v01_xml(save_xml):
     """
     Use of xs:anyAtomicType Tests use of xs:anyAtomicType as the type of
@@ -8792,11 +8863,12 @@ def test_simple050_simple050_v01_xml(save_xml):
         instance="saxonData/Simple/simple050.v01.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple050_simple050_v02_xml(save_xml):
     """
     Use of xs:anyAtomicType Tests use of xs:anyAtomicType as the type of
@@ -8808,11 +8880,12 @@ def test_simple050_simple050_v02_xml(save_xml):
         instance="saxonData/Simple/simple050.v02.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple050_simple050_n01_xml(save_xml):
     """
     Use of xs:anyAtomicType Tests use of xs:anyAtomicType as the type of
@@ -8824,11 +8897,12 @@ def test_simple050_simple050_n01_xml(save_xml):
         instance="saxonData/Simple/simple050.n01.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple050_simple050_n02_xml(save_xml):
     """
     Use of xs:anyAtomicType Tests use of xs:anyAtomicType as the type of
@@ -8840,11 +8914,12 @@ def test_simple050_simple050_n02_xml(save_xml):
         instance="saxonData/Simple/simple050.n02.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple050_simple050_n03_xml(save_xml):
     """
     Use of xs:anyAtomicType Tests use of xs:anyAtomicType as the type of
@@ -8856,11 +8931,12 @@ def test_simple050_simple050_n03_xml(save_xml):
         instance="saxonData/Simple/simple050.n03.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple046_simple046_v01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8872,11 +8948,12 @@ def test_simple046_simple046_v01_xml(save_xml):
         instance="saxonData/Simple/simple046.v01.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple046_simple046_n01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8888,11 +8965,12 @@ def test_simple046_simple046_n01_xml(save_xml):
         instance="saxonData/Simple/simple046.n01.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple045_simple045_v01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8904,11 +8982,12 @@ def test_simple045_simple045_v01_xml(save_xml):
         instance="saxonData/Simple/simple045.v01.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple045_simple045_n01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8920,11 +8999,12 @@ def test_simple045_simple045_n01_xml(save_xml):
         instance="saxonData/Simple/simple045.n01.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple044_simple044_v01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8936,11 +9016,12 @@ def test_simple044_simple044_v01_xml(save_xml):
         instance="saxonData/Simple/simple044.v01.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple044_simple044_n01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8952,11 +9033,12 @@ def test_simple044_simple044_n01_xml(save_xml):
         instance="saxonData/Simple/simple044.n01.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple040_simple040_v01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8968,11 +9050,12 @@ def test_simple040_simple040_v01_xml(save_xml):
         instance="saxonData/Simple/simple040.v01.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple040_simple040_n01_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -8984,11 +9067,12 @@ def test_simple040_simple040_n01_xml(save_xml):
         instance="saxonData/Simple/simple040.n01.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple040_simple040_n02_xml(save_xml):
     """
     Hyphens in regular expressions Tests use of hyphens in regular
@@ -9000,11 +9084,12 @@ def test_simple040_simple040_n02_xml(save_xml):
         instance="saxonData/Simple/simple040.n02.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple022_simple022_v01_xml(save_xml):
     """
     Enumeration value OK if "equal or identical", so NaN is accepted. See
@@ -9017,11 +9102,12 @@ def test_simple022_simple022_v01_xml(save_xml):
         instance="saxonData/Simple/simple022.v01.xml",
         instance_is_valid=True,
         class_name="Price",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple022_simple022_v02_xml(save_xml):
     """
     Enumeration value OK if "equal or identical", so NaN is accepted. See
@@ -9034,11 +9120,12 @@ def test_simple022_simple022_v02_xml(save_xml):
         instance="saxonData/Simple/simple022.v02.xml",
         instance_is_valid=True,
         class_name="Price",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple022_simple022_v03_xml(save_xml):
     """
     Enumeration value OK if "equal or identical", so NaN is accepted. See
@@ -9051,11 +9138,12 @@ def test_simple022_simple022_v03_xml(save_xml):
         instance="saxonData/Simple/simple022.v03.xml",
         instance_is_valid=True,
         class_name="Price",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple022_simple016_n01_xml(save_xml):
     """
     Enumeration value OK if "equal or identical", so NaN is accepted. See
@@ -9068,11 +9156,12 @@ def test_simple022_simple016_n01_xml(save_xml):
         instance="saxonData/Simple/simple022.n01.xml",
         instance_is_valid=False,
         class_name="Price",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple016_simple016_v01_xml(save_xml):
     """
     xsi:type OK to select a member of a union only if there are no
@@ -9085,11 +9174,12 @@ def test_simple016_simple016_v01_xml(save_xml):
         instance="saxonData/Simple/simple016.v01.xml",
         instance_is_valid=True,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple016_simple016_n01_xml(save_xml):
     """
     xsi:type OK to select a member of a union only if there are no
@@ -9102,11 +9192,12 @@ def test_simple016_simple016_n01_xml(save_xml):
         instance="saxonData/Simple/simple016.n01.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple013_simple013_v01_xml(save_xml):
     """
     Type D is substitutable for union(X,DT) when DT is union (D,T) Tests
@@ -9118,11 +9209,12 @@ def test_simple013_simple013_v01_xml(save_xml):
         instance="saxonData/Simple/simple013.v01.xml",
         instance_is_valid=True,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple013_simple013_n01_xml(save_xml):
     """
     Type D is substitutable for union(X,DT) when DT is union (D,T) Tests
@@ -9134,11 +9226,12 @@ def test_simple013_simple013_n01_xml(save_xml):
         instance="saxonData/Simple/simple013.n01.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple013_simple013_n02_xml(save_xml):
     """
     Type D is substitutable for union(X,DT) when DT is union (D,T) Tests
@@ -9150,11 +9243,12 @@ def test_simple013_simple013_n02_xml(save_xml):
         instance="saxonData/Simple/simple013.n02.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple012_simple012_v01_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) when X is itself a union type
@@ -9167,11 +9261,12 @@ def test_simple012_simple012_v01_xml(save_xml):
         instance="saxonData/Simple/simple012.v01.xml",
         instance_is_valid=True,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple012_simple012_v02_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) when X is itself a union type
@@ -9184,11 +9279,12 @@ def test_simple012_simple012_v02_xml(save_xml):
         instance="saxonData/Simple/simple012.v02.xml",
         instance_is_valid=True,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple012_simple012_n01_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) when X is itself a union type
@@ -9201,11 +9297,12 @@ def test_simple012_simple012_n01_xml(save_xml):
         instance="saxonData/Simple/simple012.n01.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple012_simple012_n02_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) when X is itself a union type
@@ -9218,11 +9315,12 @@ def test_simple012_simple012_n02_xml(save_xml):
         instance="saxonData/Simple/simple012.n02.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple010_simple010_v01_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) Union is substitutable by one
@@ -9234,11 +9332,12 @@ def test_simple010_simple010_v01_xml(save_xml):
         instance="saxonData/Simple/simple010.v01.xml",
         instance_is_valid=True,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple010_simple010_n01_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) Union is substitutable by one
@@ -9250,11 +9349,12 @@ def test_simple010_simple010_n01_xml(save_xml):
         instance="saxonData/Simple/simple010.n01.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple010_simple010_n02_xml(save_xml):
     """
     Type X is substitutable for union(X,Y) Union is substitutable by one
@@ -9266,11 +9366,12 @@ def test_simple010_simple010_n02_xml(save_xml):
         instance="saxonData/Simple/simple010.n02.xml",
         instance_is_valid=False,
         class_name="Book",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple003_simple003_v01_xml(save_xml):
     """
     Test that simpleType/@final = extension is allowed Depends on
@@ -9282,11 +9383,12 @@ def test_simple003_simple003_v01_xml(save_xml):
         instance="saxonData/Simple/simple003.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple002_simple002_v01_xml(save_xml):
     """
     +INF allowed in xs:float lexical space +INF allowed in xs:float
@@ -9298,11 +9400,12 @@ def test_simple002_simple002_v01_xml(save_xml):
         instance="saxonData/Simple/simple001.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple002_simple002_n01_xml(save_xml):
     """
     +INF allowed in xs:float lexical space +INF allowed in xs:float
@@ -9314,11 +9417,12 @@ def test_simple002_simple002_n01_xml(save_xml):
         instance="saxonData/Simple/simple001.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple002_simple002_n02_xml(save_xml):
     """
     +INF allowed in xs:float lexical space +INF allowed in xs:float
@@ -9330,11 +9434,12 @@ def test_simple002_simple002_n02_xml(save_xml):
         instance="saxonData/Simple/simple001.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple001_simple001_v01_xml(save_xml):
     """
     +INF allowed in xs:double lexical space +INF allowed in xs:double
@@ -9346,11 +9451,12 @@ def test_simple001_simple001_v01_xml(save_xml):
         instance="saxonData/Simple/simple001.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple001_simple001_n01_xml(save_xml):
     """
     +INF allowed in xs:double lexical space +INF allowed in xs:double
@@ -9362,11 +9468,12 @@ def test_simple001_simple001_n01_xml(save_xml):
         instance="saxonData/Simple/simple001.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_simple001_simple001_n02_xml(save_xml):
     """
     +INF allowed in xs:double lexical space +INF allowed in xs:double
@@ -9378,11 +9485,12 @@ def test_simple001_simple001_n02_xml(save_xml):
         instance="saxonData/Simple/simple001.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_subsgroup003_subsgroup003_v1_xml(save_xml):
     """
@@ -9398,7 +9506,7 @@ def test_subsgroup003_subsgroup003_v1_xml(save_xml):
         instance="saxonData/Subsgroup/subsgroup003.xml",
         instance_is_valid=True,
         class_name="Command",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -9475,6 +9583,7 @@ def test_subsgroup001_subsgroup001_n1_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_target003_target003_v1_xml(save_xml):
     """
     Simple use of targetNamespace on a local attribute declaration Simple
@@ -9486,11 +9595,12 @@ def test_target003_target003_v1_xml(save_xml):
         instance="saxonData/TargetNS/target003.v1.xml",
         instance_is_valid=True,
         class_name="Parent",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_target003_target003_n1_xml(save_xml):
     """
     Simple use of targetNamespace on a local attribute declaration Simple
@@ -9502,11 +9612,12 @@ def test_target003_target003_n1_xml(save_xml):
         instance="saxonData/TargetNS/target003.n1.xml",
         instance_is_valid=False,
         class_name="Parent",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_target003_target003_n2_xml(save_xml):
     """
     Simple use of targetNamespace on a local attribute declaration Simple
@@ -9518,11 +9629,12 @@ def test_target003_target003_n2_xml(save_xml):
         instance="saxonData/TargetNS/target003.n2.xml",
         instance_is_valid=False,
         class_name="Parent",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_target001_target001_v1_xml(save_xml):
     """
     Simple use of targetNamespace on a local element declaration Simple
@@ -9534,11 +9646,12 @@ def test_target001_target001_v1_xml(save_xml):
         instance="saxonData/TargetNS/target001.v1.xml",
         instance_is_valid=True,
         class_name="Parent",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_target001_target001_n1_xml(save_xml):
     """
     Simple use of targetNamespace on a local element declaration Simple
@@ -9550,11 +9663,12 @@ def test_target001_target001_n1_xml(save_xml):
         instance="saxonData/TargetNS/target001.n1.xml",
         instance_is_valid=False,
         class_name="Parent",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_vc024_11_vc024_v1_xml(save_xml):
     """
     Simple assertion on an attribute value, ignored under XSD 1.0 Simple
@@ -9566,11 +9680,12 @@ def test_vc024_11_vc024_v1_xml(save_xml):
         instance="saxonData/VC/vc001.v1.xml",
         instance_is_valid=True,
         class_name="Temp",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_vc024_11_vc024_n1_xml(save_xml):
     """
     Simple assertion on an attribute value, ignored under XSD 1.0 Simple
@@ -9582,7 +9697,7 @@ def test_vc024_11_vc024_n1_xml(save_xml):
         instance="saxonData/VC/vc001.n1.xml",
         instance_is_valid=True,
         class_name="Temp",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -9655,6 +9770,7 @@ def test_vc020_vc020_v1_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_vc014_vc014_v1_xml(save_xml):
     """
@@ -9667,11 +9783,12 @@ def test_vc014_vc014_v1_xml(save_xml):
         instance="saxonData/VC/vc014.v1.xml",
         instance_is_valid=True,
         class_name="Temp",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_vc014_vc014_n1_xml(save_xml):
     """
@@ -9684,7 +9801,7 @@ def test_vc014_vc014_n1_xml(save_xml):
         instance="saxonData/VC/vc014.n1.xml",
         instance_is_valid=False,
         class_name="Temp",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -9927,6 +10044,7 @@ def test_vc003_vc003_v1_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_vc002_vc002_v1_xml(save_xml):
     """
     Equivalent schemas with different formulations under XSD 1.0 and XSD
@@ -9939,11 +10057,12 @@ def test_vc002_vc002_v1_xml(save_xml):
         instance="saxonData/VC/vc002.v1.xml",
         instance_is_valid=True,
         class_name="Temp",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_vc002_vc002_n1_xml(save_xml):
     """
     Equivalent schemas with different formulations under XSD 1.0 and XSD
@@ -9956,11 +10075,12 @@ def test_vc002_vc002_n1_xml(save_xml):
         instance="saxonData/VC/vc002.n1.xml",
         instance_is_valid=False,
         class_name="Temp",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_vc001_vc001_v1_xml(save_xml):
     """
     Simple assertion on an attribute value, ignored under XSD 1.0 Simple
@@ -9972,11 +10092,12 @@ def test_vc001_vc001_v1_xml(save_xml):
         instance="saxonData/VC/vc001.v1.xml",
         instance_is_valid=True,
         class_name="Temp",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_vc001_vc001_n1_xml(save_xml):
     """
     Simple assertion on an attribute value, ignored under XSD 1.0 Simple
@@ -9988,7 +10109,7 @@ def test_vc001_vc001_n1_xml(save_xml):
         instance="saxonData/VC/vc001.n1.xml",
         instance_is_valid=True,
         class_name="Temp",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
@@ -13019,6 +13140,7 @@ def test_wild001_wild001_n2_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_xv100notc_xv100notc_i_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13030,11 +13152,12 @@ def test_xv100notc_xv100notc_i_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.i.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100notc_xv100notc_c_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13046,11 +13169,12 @@ def test_xv100notc_xv100notc_c_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.c.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100notc_xv100notc_noti_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13062,11 +13186,12 @@ def test_xv100notc_xv100notc_noti_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.noti.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100notc_xv100notc_notc_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13078,11 +13203,12 @@ def test_xv100notc_xv100notc_notc_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.notc.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100noti_xv100noti_i_xml(save_xml):
     r"""
     Test which characters match \I in a regex Name characters in XML 1.1
@@ -13094,11 +13220,12 @@ def test_xv100noti_xv100noti_i_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.i.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100noti_xv100noti_c_xml(save_xml):
     r"""
     Test which characters match \I in a regex Name characters in XML 1.1
@@ -13110,11 +13237,12 @@ def test_xv100noti_xv100noti_c_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.c.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100noti_xv100noti_noti_xml(save_xml):
     r"""
     Test which characters match \I in a regex Name characters in XML 1.1
@@ -13126,11 +13254,12 @@ def test_xv100noti_xv100noti_noti_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.noti.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100noti_xv100noti_notc_xml(save_xml):
     r"""
     Test which characters match \I in a regex Name characters in XML 1.1
@@ -13142,11 +13271,12 @@ def test_xv100noti_xv100noti_notc_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.notc.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100c_xv100c_i_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13158,11 +13288,12 @@ def test_xv100c_xv100c_i_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.i.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100c_xv100c_c_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13174,11 +13305,12 @@ def test_xv100c_xv100c_c_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.c.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100c_xv100c_noti_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13190,11 +13322,12 @@ def test_xv100c_xv100c_noti_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.noti.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100c_xv100c_notc_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13206,11 +13339,12 @@ def test_xv100c_xv100c_notc_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.notc.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100i_xv100i_i_xml(save_xml):
     r"""
     Test which characters match \i in a regex Name characters in XML 1.1
@@ -13222,11 +13356,12 @@ def test_xv100i_xv100i_i_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.i.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100i_xv100i_c_xml(save_xml):
     r"""
     Test which characters match \i in a regex Name characters in XML 1.1
@@ -13238,11 +13373,12 @@ def test_xv100i_xv100i_c_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.c.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100i_xv100i_noti_xml(save_xml):
     r"""
     Test which characters match \i in a regex Name characters in XML 1.1
@@ -13254,11 +13390,12 @@ def test_xv100i_xv100i_noti_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.noti.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv100i_xv100i_notc_xml(save_xml):
     r"""
     Test which characters match \i in a regex Name characters in XML 1.1
@@ -13270,11 +13407,12 @@ def test_xv100i_xv100i_notc_xml(save_xml):
         instance="saxonData/XmlVersions/xv100.notc.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv009_xv009_v01_xml(save_xml):
     """
     Test interpretation of NMTOKENS under XML 1.1 Name characters in XML
@@ -13286,11 +13424,12 @@ def test_xv009_xv009_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv009.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv009_xv009_v02_xml(save_xml):
     """
     Test interpretation of NMTOKENS under XML 1.1 Name characters in XML
@@ -13302,11 +13441,12 @@ def test_xv009_xv009_v02_xml(save_xml):
         instance="saxonData/XmlVersions/xv009.v02.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv009_xv009_n01_xml(save_xml):
     """
     Test interpretation of NMTOKENS under XML 1.1 Name characters in XML
@@ -13318,11 +13458,12 @@ def test_xv009_xv009_n01_xml(save_xml):
         instance="saxonData/XmlVersions/xv009.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv009_xv009_n02_xml(save_xml):
     """
     Test interpretation of NMTOKENS under XML 1.1 Name characters in XML
@@ -13334,11 +13475,12 @@ def test_xv009_xv009_n02_xml(save_xml):
         instance="saxonData/XmlVersions/xv009.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv009_xv009_n03_xml(save_xml):
     """
     Test interpretation of NMTOKENS under XML 1.1 Name characters in XML
@@ -13350,11 +13492,12 @@ def test_xv009_xv009_n03_xml(save_xml):
         instance="saxonData/XmlVersions/xv009.n03.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv008_xv008_v01_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13366,11 +13509,12 @@ def test_xv008_xv008_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv008.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv008_xv008_n01_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13382,11 +13526,12 @@ def test_xv008_xv008_n01_xml(save_xml):
         instance="saxonData/XmlVersions/xv008.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv008_xv008_n02_xml(save_xml):
     r"""
     Test which characters match \C in a regex Name characters in XML 1.1
@@ -13398,11 +13543,12 @@ def test_xv008_xv008_n02_xml(save_xml):
         instance="saxonData/XmlVersions/xv008.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv007_xv007_v01_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13414,11 +13560,12 @@ def test_xv007_xv007_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv007.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv007_xv007_n01_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13430,11 +13577,12 @@ def test_xv007_xv007_n01_xml(save_xml):
         instance="saxonData/XmlVersions/xv007.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv007_xv007_n02_xml(save_xml):
     r"""
     Test which characters match \c in a regex Name characters in XML 1.1
@@ -13446,11 +13594,12 @@ def test_xv007_xv007_n02_xml(save_xml):
         instance="saxonData/XmlVersions/xv007.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv006_xv006_v01_xml(save_xml):
     r"""
     Test which characters match \I in a regex Initial name characters in
@@ -13462,11 +13611,12 @@ def test_xv006_xv006_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv006.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv006_xv006_n01_xml(save_xml):
     r"""
     Test which characters match \I in a regex Initial name characters in
@@ -13478,11 +13628,12 @@ def test_xv006_xv006_n01_xml(save_xml):
         instance="saxonData/XmlVersions/xv006.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv006_xv006_n02_xml(save_xml):
     r"""
     Test which characters match \I in a regex Initial name characters in
@@ -13494,11 +13645,12 @@ def test_xv006_xv006_n02_xml(save_xml):
         instance="saxonData/XmlVersions/xv006.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv006_xv006_n03_xml(save_xml):
     r"""
     Test which characters match \I in a regex Initial name characters in
@@ -13510,11 +13662,12 @@ def test_xv006_xv006_n03_xml(save_xml):
         instance="saxonData/XmlVersions/xv006.n03.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv005_xv005_v01_xml(save_xml):
     r"""
     Test which characters match \i in a regex Initial name characters in
@@ -13526,11 +13679,12 @@ def test_xv005_xv005_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv005.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv005_xv005_n01_xml(save_xml):
     r"""
     Test which characters match \i in a regex Initial name characters in
@@ -13542,11 +13696,12 @@ def test_xv005_xv005_n01_xml(save_xml):
         instance="saxonData/XmlVersions/xv005.n01.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv005_xv005_n02_xml(save_xml):
     r"""
     Test which characters match \i in a regex Initial name characters in
@@ -13558,11 +13713,12 @@ def test_xv005_xv005_n02_xml(save_xml):
         instance="saxonData/XmlVersions/xv005.n02.xml",
         instance_is_valid=False,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_xv004_xv004_v01_xml(save_xml):
     """
@@ -13575,11 +13731,12 @@ def test_xv004_xv004_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv004.v01.xml",
         instance_is_valid=True,
         class_name="DKstra",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv003_xv003_v01_xml(save_xml):
     """
     Use newly-allowed C0 characters in character content and in attribute
@@ -13591,11 +13748,12 @@ def test_xv003_xv003_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv003.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv002_xv002_v01_xml(save_xml):
     """
     Use newly-allowed name characters in NCName value Dutch ligature ij is
@@ -13607,11 +13765,12 @@ def test_xv002_xv002_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv002.v01.xml",
         instance_is_valid=True,
         class_name="Doc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xv001_xv001_v01_xml(save_xml):
     """
     Use newly-allowed name characters in element and attribute name Dutch
@@ -13624,7 +13783,7 @@ def test_xv001_xv001_v01_xml(save_xml):
         instance="saxonData/XmlVersions/xv001.v01.xml",
         instance_is_valid=True,
         class_name="DKstra",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 

--- a/tests/test_sun_meta_919.py
+++ b/tests/test_sun_meta_919.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import assert_bindings
 
 
+@pytest.mark.schema11
 def test_xsd024_xsd024_v00(save_xml):
     """
     xsd024 Use of the chameleon schema and "smart reference reparing"
@@ -13,11 +14,12 @@ def test_xsd024_xsd024_v00(save_xml):
         instance="sunData/combined/xsd024/xsd024.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd022_xsd022_n00(save_xml):
     """
     xsd022 Various forms of forward reference to the simple type.
@@ -28,11 +30,12 @@ def test_xsd022_xsd022_n00(save_xml):
         instance="sunData/combined/xsd022/xsd022.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd022_xsd022_v00(save_xml):
     """
     xsd022 Various forms of forward reference to the simple type.
@@ -43,11 +46,12 @@ def test_xsd022_xsd022_v00(save_xml):
         instance="sunData/combined/xsd022/xsd022.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n00(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -58,11 +62,12 @@ def test_xsd021_xsd021_n00(save_xml):
         instance="sunData/combined/xsd021/xsd021.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n01(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -73,11 +78,12 @@ def test_xsd021_xsd021_n01(save_xml):
         instance="sunData/combined/xsd021/xsd021.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n02(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -88,11 +94,12 @@ def test_xsd021_xsd021_n02(save_xml):
         instance="sunData/combined/xsd021/xsd021.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n03(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -103,11 +110,12 @@ def test_xsd021_xsd021_n03(save_xml):
         instance="sunData/combined/xsd021/xsd021.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n04(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -118,11 +126,12 @@ def test_xsd021_xsd021_n04(save_xml):
         instance="sunData/combined/xsd021/xsd021.n04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n05(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -133,11 +142,12 @@ def test_xsd021_xsd021_n05(save_xml):
         instance="sunData/combined/xsd021/xsd021.n05.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n06(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -148,11 +158,12 @@ def test_xsd021_xsd021_n06(save_xml):
         instance="sunData/combined/xsd021/xsd021.n06.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n07(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -163,11 +174,12 @@ def test_xsd021_xsd021_n07(save_xml):
         instance="sunData/combined/xsd021/xsd021.n07.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n08(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -178,11 +190,12 @@ def test_xsd021_xsd021_n08(save_xml):
         instance="sunData/combined/xsd021/xsd021.n08.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n09(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -193,11 +206,12 @@ def test_xsd021_xsd021_n09(save_xml):
         instance="sunData/combined/xsd021/xsd021.n09.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n10(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -208,11 +222,12 @@ def test_xsd021_xsd021_n10(save_xml):
         instance="sunData/combined/xsd021/xsd021.n10.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_n11(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -223,11 +238,12 @@ def test_xsd021_xsd021_n11(save_xml):
         instance="sunData/combined/xsd021/xsd021.n11.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd021_xsd021_v00(save_xml):
     """
     xsd021 anyOtherAttribute.
@@ -238,11 +254,12 @@ def test_xsd021_xsd021_v00(save_xml):
         instance="sunData/combined/xsd021/xsd021.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd012_xsd012_n00(save_xml):
     """
     xsd012 Mixed content model.
@@ -253,11 +270,12 @@ def test_xsd012_xsd012_n00(save_xml):
         instance="sunData/combined/xsd012/xsd012.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd012_xsd012_v00(save_xml):
     """
     xsd012 Mixed content model.
@@ -268,11 +286,12 @@ def test_xsd012_xsd012_v00(save_xml):
         instance="sunData/combined/xsd012/xsd012.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd011_xsd011_n00(save_xml):
     """
     xsd011 Nillable.
@@ -283,11 +302,12 @@ def test_xsd011_xsd011_n00(save_xml):
         instance="sunData/combined/xsd011/xsd011.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd011_xsd011_n01(save_xml):
     """
     xsd011 Nillable.
@@ -298,11 +318,12 @@ def test_xsd011_xsd011_n01(save_xml):
         instance="sunData/combined/xsd011/xsd011.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd011_xsd011_n02(save_xml):
     """
     xsd011 Nillable.
@@ -313,11 +334,12 @@ def test_xsd011_xsd011_n02(save_xml):
         instance="sunData/combined/xsd011/xsd011.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd011_xsd011_n03(save_xml):
     """
     xsd011 Nillable.
@@ -328,11 +350,12 @@ def test_xsd011_xsd011_n03(save_xml):
         instance="sunData/combined/xsd011/xsd011.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd011_xsd011_n04(save_xml):
     """
     xsd011 Nillable.
@@ -343,11 +366,12 @@ def test_xsd011_xsd011_n04(save_xml):
         instance="sunData/combined/xsd011/xsd011.n04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd011_xsd011_v00(save_xml):
     """
     xsd011 Nillable.
@@ -358,11 +382,12 @@ def test_xsd011_xsd011_v00(save_xml):
         instance="sunData/combined/xsd011/xsd011.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd008_xsd008_n00(save_xml):
     """
     xsd008 Abstract element and element substitution group.
@@ -373,11 +398,12 @@ def test_xsd008_xsd008_n00(save_xml):
         instance="sunData/combined/xsd008/xsd008.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd008_xsd008_n01(save_xml):
     """
     xsd008 Abstract element and element substitution group.
@@ -388,11 +414,12 @@ def test_xsd008_xsd008_n01(save_xml):
         instance="sunData/combined/xsd008/xsd008.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd008_xsd008_n02(save_xml):
     """
     xsd008 Abstract element and element substitution group.
@@ -403,11 +430,12 @@ def test_xsd008_xsd008_n02(save_xml):
         instance="sunData/combined/xsd008/xsd008.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd008_xsd008_v00(save_xml):
     """
     xsd008 Abstract element and element substitution group.
@@ -418,11 +446,12 @@ def test_xsd008_xsd008_v00(save_xml):
         instance="sunData/combined/xsd008/xsd008.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n00(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -433,11 +462,12 @@ def test_xsd006_xsd006_n00(save_xml):
         instance="sunData/combined/xsd006/xsd006.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n01(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -448,11 +478,12 @@ def test_xsd006_xsd006_n01(save_xml):
         instance="sunData/combined/xsd006/xsd006.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n02(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -463,11 +494,12 @@ def test_xsd006_xsd006_n02(save_xml):
         instance="sunData/combined/xsd006/xsd006.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n03(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -478,11 +510,12 @@ def test_xsd006_xsd006_n03(save_xml):
         instance="sunData/combined/xsd006/xsd006.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n04(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -493,11 +526,12 @@ def test_xsd006_xsd006_n04(save_xml):
         instance="sunData/combined/xsd006/xsd006.n04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n05(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -508,11 +542,12 @@ def test_xsd006_xsd006_n05(save_xml):
         instance="sunData/combined/xsd006/xsd006.n05.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n06(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -523,11 +558,12 @@ def test_xsd006_xsd006_n06(save_xml):
         instance="sunData/combined/xsd006/xsd006.n06.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n07(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -538,11 +574,12 @@ def test_xsd006_xsd006_n07(save_xml):
         instance="sunData/combined/xsd006/xsd006.n07.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n08(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -553,11 +590,12 @@ def test_xsd006_xsd006_n08(save_xml):
         instance="sunData/combined/xsd006/xsd006.n08.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n09(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -568,11 +606,12 @@ def test_xsd006_xsd006_n09(save_xml):
         instance="sunData/combined/xsd006/xsd006.n09.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n10(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -583,11 +622,12 @@ def test_xsd006_xsd006_n10(save_xml):
         instance="sunData/combined/xsd006/xsd006.n10.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_n11(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -598,11 +638,12 @@ def test_xsd006_xsd006_n11(save_xml):
         instance="sunData/combined/xsd006/xsd006.n11.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd006_xsd006_v00(save_xml):
     """
     xsd006 minOccurs/maxOccurs. Various combinations.
@@ -613,11 +654,12 @@ def test_xsd006_xsd006_v00(save_xml):
         instance="sunData/combined/xsd006/xsd006.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n00(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -628,11 +670,12 @@ def test_xsd005_xsd005_n00(save_xml):
         instance="sunData/combined/xsd005/xsd005.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n01(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -643,11 +686,12 @@ def test_xsd005_xsd005_n01(save_xml):
         instance="sunData/combined/xsd005/xsd005.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n02(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -658,11 +702,12 @@ def test_xsd005_xsd005_n02(save_xml):
         instance="sunData/combined/xsd005/xsd005.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n03(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -673,11 +718,12 @@ def test_xsd005_xsd005_n03(save_xml):
         instance="sunData/combined/xsd005/xsd005.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n04(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -688,11 +734,12 @@ def test_xsd005_xsd005_n04(save_xml):
         instance="sunData/combined/xsd005/xsd005.n04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n05(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -703,11 +750,12 @@ def test_xsd005_xsd005_n05(save_xml):
         instance="sunData/combined/xsd005/xsd005.n05.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd005_xsd005_n06(save_xml):
     """
     xsd005 Complex type derivation. Missing content model.
@@ -718,11 +766,12 @@ def test_xsd005_xsd005_n06(save_xml):
         instance="sunData/combined/xsd005/xsd005.n06.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_xsd005_xsd005_v00(save_xml):
     """
@@ -734,11 +783,12 @@ def test_xsd005_xsd005_v00(save_xml):
         instance="sunData/combined/xsd005/xsd005.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n00(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -750,11 +800,12 @@ def test_xsd004_xsd004_n00(save_xml):
         instance="sunData/combined/xsd004/xsd004.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n01(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -766,11 +817,12 @@ def test_xsd004_xsd004_n01(save_xml):
         instance="sunData/combined/xsd004/xsd004.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n02(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -782,11 +834,12 @@ def test_xsd004_xsd004_n02(save_xml):
         instance="sunData/combined/xsd004/xsd004.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n03(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -798,11 +851,12 @@ def test_xsd004_xsd004_n03(save_xml):
         instance="sunData/combined/xsd004/xsd004.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n04(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -814,11 +868,12 @@ def test_xsd004_xsd004_n04(save_xml):
         instance="sunData/combined/xsd004/xsd004.n04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n05(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -830,11 +885,12 @@ def test_xsd004_xsd004_n05(save_xml):
         instance="sunData/combined/xsd004/xsd004.n05.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n06(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -846,11 +902,12 @@ def test_xsd004_xsd004_n06(save_xml):
         instance="sunData/combined/xsd004/xsd004.n06.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n07(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -862,11 +919,12 @@ def test_xsd004_xsd004_n07(save_xml):
         instance="sunData/combined/xsd004/xsd004.n07.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n08(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -878,11 +936,12 @@ def test_xsd004_xsd004_n08(save_xml):
         instance="sunData/combined/xsd004/xsd004.n08.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n09(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -894,11 +953,12 @@ def test_xsd004_xsd004_n09(save_xml):
         instance="sunData/combined/xsd004/xsd004.n09.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n10(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -910,11 +970,12 @@ def test_xsd004_xsd004_n10(save_xml):
         instance="sunData/combined/xsd004/xsd004.n10.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n11(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -926,11 +987,12 @@ def test_xsd004_xsd004_n11(save_xml):
         instance="sunData/combined/xsd004/xsd004.n11.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_n12(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -942,11 +1004,12 @@ def test_xsd004_xsd004_n12(save_xml):
         instance="sunData/combined/xsd004/xsd004.n12.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd004_xsd004_v00(save_xml):
     """
     xsd004 Use of three different type of any element with different
@@ -958,11 +1021,12 @@ def test_xsd004_xsd004_v00(save_xml):
         instance="sunData/combined/xsd004/xsd004.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd003b_xsd003b_n00(save_xml):
     """
     xsd003b Element redefinition. Test with redefinition with self-
@@ -975,11 +1039,12 @@ def test_xsd003b_xsd003b_n00(save_xml):
         instance="sunData/combined/xsd003b/xsd003b.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd003b_xsd003b_n01(save_xml):
     """
     xsd003b Element redefinition. Test with redefinition with self-
@@ -992,11 +1057,12 @@ def test_xsd003b_xsd003b_n01(save_xml):
         instance="sunData/combined/xsd003b/xsd003b.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd003b_xsd003b_v00(save_xml):
     """
     xsd003b Element redefinition. Test with redefinition with self-
@@ -1009,11 +1075,12 @@ def test_xsd003b_xsd003b_v00(save_xml):
         instance="sunData/combined/xsd003b/xsd003b.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd003b_xsd003b_v01(save_xml):
     """
     xsd003b Element redefinition. Test with redefinition with self-
@@ -1026,11 +1093,12 @@ def test_xsd003b_xsd003b_v01(save_xml):
         instance="sunData/combined/xsd003b/xsd003b.v01.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd003a_xsd003a_v00(save_xml):
     """
     xsd003a Element redefinition. Test without redefinition.
@@ -1041,11 +1109,12 @@ def test_xsd003a_xsd003a_v00(save_xml):
         instance="sunData/combined/xsd003a/xsd003a.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd002_xsd002_n00(save_xml):
     """
     xsd002 - use of elementFormDefault="unqualified".
@@ -1058,11 +1127,12 @@ def test_xsd002_xsd002_n00(save_xml):
         instance="sunData/combined/xsd002/xsd002.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd002_xsd002_n01(save_xml):
     """
     xsd002 - use of elementFormDefault="unqualified".
@@ -1075,11 +1145,12 @@ def test_xsd002_xsd002_n01(save_xml):
         instance="sunData/combined/xsd002/xsd002.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd002_xsd002_n02(save_xml):
     """
     xsd002 - use of elementFormDefault="unqualified".
@@ -1092,11 +1163,12 @@ def test_xsd002_xsd002_n02(save_xml):
         instance="sunData/combined/xsd002/xsd002.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd002_xsd002_v00(save_xml):
     """
     xsd002 - use of elementFormDefault="unqualified".
@@ -1109,11 +1181,12 @@ def test_xsd002_xsd002_v00(save_xml):
         instance="sunData/combined/xsd002/xsd002.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd002_xsd002_v01(save_xml):
     """
     xsd002 - use of elementFormDefault="unqualified".
@@ -1126,11 +1199,12 @@ def test_xsd002_xsd002_v01(save_xml):
         instance="sunData/combined/xsd002/xsd002.v01.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n00(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1144,11 +1218,12 @@ def test_xsd001_xsd001_n00(save_xml):
         instance="sunData/combined/xsd001/xsd001.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n01(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1162,11 +1237,12 @@ def test_xsd001_xsd001_n01(save_xml):
         instance="sunData/combined/xsd001/xsd001.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n02(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1180,11 +1256,12 @@ def test_xsd001_xsd001_n02(save_xml):
         instance="sunData/combined/xsd001/xsd001.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n03(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1198,11 +1275,12 @@ def test_xsd001_xsd001_n03(save_xml):
         instance="sunData/combined/xsd001/xsd001.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n04(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1216,11 +1294,12 @@ def test_xsd001_xsd001_n04(save_xml):
         instance="sunData/combined/xsd001/xsd001.n04.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n05(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1234,11 +1313,12 @@ def test_xsd001_xsd001_n05(save_xml):
         instance="sunData/combined/xsd001/xsd001.n05.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n06(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1252,11 +1332,12 @@ def test_xsd001_xsd001_n06(save_xml):
         instance="sunData/combined/xsd001/xsd001.n06.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_n07(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1270,11 +1351,12 @@ def test_xsd001_xsd001_n07(save_xml):
         instance="sunData/combined/xsd001/xsd001.n07.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_v00(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1288,11 +1370,12 @@ def test_xsd001_xsd001_v00(save_xml):
         instance="sunData/combined/xsd001/xsd001.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_v01(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1306,11 +1389,12 @@ def test_xsd001_xsd001_v01(save_xml):
         instance="sunData/combined/xsd001/xsd001.v01.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_v02(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1324,11 +1408,12 @@ def test_xsd001_xsd001_v02(save_xml):
         instance="sunData/combined/xsd001/xsd001.v02.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_xsd001_xsd001_v03(save_xml):
     """
     xsd001 - use of elementFormDefault="unqualified"
@@ -1342,11 +1427,12 @@ def test_xsd001_xsd001_v03(save_xml):
         instance="sunData/combined/xsd001/xsd001.v03.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc006_nogen_idc006_nogen_n00(save_xml):
     """
     idc006.nogen ID Constaints. XPath engine test:  ".//a/*/b" and use of
@@ -1358,11 +1444,12 @@ def test_idc006_nogen_idc006_nogen_n00(save_xml):
         instance="sunData/combined/identity/idc006/idc006.nogen.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc006_nogen_idc006_nogen_n01(save_xml):
     """
     idc006.nogen ID Constaints. XPath engine test:  ".//a/*/b" and use of
@@ -1374,11 +1461,12 @@ def test_idc006_nogen_idc006_nogen_n01(save_xml):
         instance="sunData/combined/identity/idc006/idc006.nogen.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc006_nogen_idc006_nogen_v00(save_xml):
     """
     idc006.nogen ID Constaints. XPath engine test:  ".//a/*/b" and use of
@@ -1390,11 +1478,12 @@ def test_idc006_nogen_idc006_nogen_v00(save_xml):
         instance="sunData/combined/identity/idc006/idc006.nogen.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc005_nogen_idc005_nogen_n00(save_xml):
     """
     idc005.nogen ID Constraints. very naive test of identity constraint.
@@ -1405,11 +1494,12 @@ def test_idc005_nogen_idc005_nogen_n00(save_xml):
         instance="sunData/combined/identity/idc005/idc005.nogen.n00.xml",
         instance_is_valid=False,
         class_name="BookCatalogue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc005_nogen_idc005_nogen_n01(save_xml):
     """
     idc005.nogen ID Constraints. very naive test of identity constraint.
@@ -1420,11 +1510,12 @@ def test_idc005_nogen_idc005_nogen_n01(save_xml):
         instance="sunData/combined/identity/idc005/idc005.nogen.n01.xml",
         instance_is_valid=False,
         class_name="BookCatalogue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc005_nogen_idc005_nogen_v00(save_xml):
     """
     idc005.nogen ID Constraints. very naive test of identity constraint.
@@ -1435,11 +1526,12 @@ def test_idc005_nogen_idc005_nogen_v00(save_xml):
         instance="sunData/combined/identity/idc005/idc005.nogen.v00.xml",
         instance_is_valid=True,
         class_name="BookCatalogue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc004_nogen_idc004_nogen_n00(save_xml):
     """
     idc004.nogen ID Constraints.
@@ -1450,11 +1542,12 @@ def test_idc004_nogen_idc004_nogen_n00(save_xml):
         instance="sunData/combined/identity/idc004/idc004.nogen.n00.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc004_nogen_idc004_nogen_n01(save_xml):
     """
     idc004.nogen ID Constraints.
@@ -1465,11 +1558,12 @@ def test_idc004_nogen_idc004_nogen_n01(save_xml):
         instance="sunData/combined/identity/idc004/idc004.nogen.n01.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc004_nogen_idc004_nogen_n02(save_xml):
     """
     idc004.nogen ID Constraints.
@@ -1480,11 +1574,12 @@ def test_idc004_nogen_idc004_nogen_n02(save_xml):
         instance="sunData/combined/identity/idc004/idc004.nogen.n02.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc004_nogen_idc004_nogen_n03(save_xml):
     """
     idc004.nogen ID Constraints.
@@ -1495,11 +1590,12 @@ def test_idc004_nogen_idc004_nogen_n03(save_xml):
         instance="sunData/combined/identity/idc004/idc004.nogen.n03.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc004_nogen_idc004_nogen_v00(save_xml):
     """
     idc004.nogen ID Constraints.
@@ -1510,11 +1606,12 @@ def test_idc004_nogen_idc004_nogen_v00(save_xml):
         instance="sunData/combined/identity/idc004/idc004.nogen.v00.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc001_nogen_idc001_nogen_n00(save_xml):
     """
     idc001.nogen ID Constraints.
@@ -1525,11 +1622,12 @@ def test_idc001_nogen_idc001_nogen_n00(save_xml):
         instance="sunData/combined/identity/idc001/idc001.nogen.n00.xml",
         instance_is_valid=False,
         class_name="BookCatalogue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc001_nogen_idc001_nogen_v00(save_xml):
     """
     idc001.nogen ID Constraints.
@@ -1540,11 +1638,12 @@ def test_idc001_nogen_idc001_nogen_v00(save_xml):
         instance="sunData/combined/identity/idc001/idc001.nogen.v00.xml",
         instance_is_valid=True,
         class_name="BookCatalogue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idc001_nogen_idc001_nogen_v01(save_xml):
     """
     idc001.nogen ID Constraints.
@@ -1555,11 +1654,12 @@ def test_idc001_nogen_idc001_nogen_v01(save_xml):
         instance="sunData/combined/identity/idc001/idc001.nogen.v01.xml",
         instance_is_valid=True,
         class_name="BookCatalogue",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest004_test_1_v(save_xml):
     """
     test
@@ -1570,11 +1670,12 @@ def test_identitytestsuitetest004_test_1_v(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/004/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest004_test_2_n(save_xml):
     """
     test
@@ -1585,11 +1686,12 @@ def test_identitytestsuitetest004_test_2_n(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/004/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest004_test_3_n(save_xml):
     """
     test
@@ -1600,11 +1702,12 @@ def test_identitytestsuitetest004_test_3_n(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/004/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest003_test_1_v(save_xml):
     """
     test
@@ -1615,11 +1718,12 @@ def test_identitytestsuitetest003_test_1_v(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/003/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest003_test_2_v(save_xml):
     """
     test
@@ -1630,11 +1734,12 @@ def test_identitytestsuitetest003_test_2_v(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/003/test.2.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest003_test_3_n(save_xml):
     """
     test
@@ -1645,11 +1750,12 @@ def test_identitytestsuitetest003_test_3_n(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/003/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest002_test_1_v(save_xml):
     """
     test
@@ -1660,11 +1766,12 @@ def test_identitytestsuitetest002_test_1_v(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/002/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest002_test_2_v(save_xml):
     """
     test
@@ -1675,11 +1782,12 @@ def test_identitytestsuitetest002_test_2_v(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/002/test.2.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest002_test_3_n(save_xml):
     """
     test
@@ -1690,11 +1798,12 @@ def test_identitytestsuitetest002_test_3_n(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/002/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest001_test_1_v(save_xml):
     """
     test
@@ -1705,11 +1814,12 @@ def test_identitytestsuitetest001_test_1_v(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/001/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_identitytestsuitetest001_test_2_n(save_xml):
     """
     test
@@ -1720,11 +1830,12 @@ def test_identitytestsuitetest001_test_2_n(save_xml):
         instance="sunData/combined/identity/IdentityTestSuite/001/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_13_n(save_xml):
     """
     test
@@ -1735,11 +1846,12 @@ def test_test009_test_13_n(save_xml):
         instance="sunData/combined/009/test.13.n.xml",
         instance_is_valid=False,
         class_name="Prohibit",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_8_n(save_xml):
     """
     test
@@ -1750,11 +1862,12 @@ def test_test009_test_8_n(save_xml):
         instance="sunData/combined/009/test.8.n.xml",
         instance_is_valid=False,
         class_name="Override",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_1_v(save_xml):
     """
     test
@@ -1765,11 +1878,12 @@ def test_test009_test_1_v(save_xml):
         instance="sunData/combined/009/test.1.v.xml",
         instance_is_valid=True,
         class_name="Base",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_10_v(save_xml):
     """
     test
@@ -1780,11 +1894,12 @@ def test_test009_test_10_v(save_xml):
         instance="sunData/combined/009/test.10.v.xml",
         instance_is_valid=True,
         class_name="Add",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_11_v(save_xml):
     """
     test
@@ -1795,11 +1910,12 @@ def test_test009_test_11_v(save_xml):
         instance="sunData/combined/009/test.11.v.xml",
         instance_is_valid=True,
         class_name="Prohibit",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_12_v(save_xml):
     """
     test
@@ -1810,11 +1926,12 @@ def test_test009_test_12_v(save_xml):
         instance="sunData/combined/009/test.12.v.xml",
         instance_is_valid=True,
         class_name="Prohibit",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_2_v(save_xml):
     """
     test
@@ -1825,11 +1942,12 @@ def test_test009_test_2_v(save_xml):
         instance="sunData/combined/009/test.2.v.xml",
         instance_is_valid=True,
         class_name="Base",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_3_v(save_xml):
     """
     test
@@ -1840,11 +1958,12 @@ def test_test009_test_3_v(save_xml):
         instance="sunData/combined/009/test.3.v.xml",
         instance_is_valid=True,
         class_name="Default",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_4_v(save_xml):
     """
     test
@@ -1855,11 +1974,12 @@ def test_test009_test_4_v(save_xml):
         instance="sunData/combined/009/test.4.v.xml",
         instance_is_valid=True,
         class_name="Default",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_5_v(save_xml):
     """
     test
@@ -1870,11 +1990,12 @@ def test_test009_test_5_v(save_xml):
         instance="sunData/combined/009/test.5.v.xml",
         instance_is_valid=True,
         class_name="Override",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_6_v(save_xml):
     """
     test
@@ -1885,11 +2006,12 @@ def test_test009_test_6_v(save_xml):
         instance="sunData/combined/009/test.6.v.xml",
         instance_is_valid=True,
         class_name="Override",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_7_v(save_xml):
     """
     test
@@ -1900,11 +2022,12 @@ def test_test009_test_7_v(save_xml):
         instance="sunData/combined/009/test.7.v.xml",
         instance_is_valid=True,
         class_name="Override",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test009_test_9_v(save_xml):
     """
     test
@@ -1915,11 +2038,12 @@ def test_test009_test_9_v(save_xml):
         instance="sunData/combined/009/test.9.v.xml",
         instance_is_valid=True,
         class_name="Add",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_1_n(save_xml):
     """
     test
@@ -1930,11 +2054,12 @@ def test_test008_test_1_n(save_xml):
         instance="sunData/combined/008/test.1.n.xml",
         instance_is_valid=False,
         class_name="Extension",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_10_n(save_xml):
     """
     test
@@ -1945,11 +2070,12 @@ def test_test008_test_10_n(save_xml):
         instance="sunData/combined/008/test.10.n.xml",
         instance_is_valid=False,
         class_name="Alias",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_11_n(save_xml):
     """
     test
@@ -1960,11 +2086,12 @@ def test_test008_test_11_n(save_xml):
         instance="sunData/combined/008/test.11.n.xml",
         instance_is_valid=False,
         class_name="Alias",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_12_n(save_xml):
     """
     test
@@ -1975,11 +2102,12 @@ def test_test008_test_12_n(save_xml):
         instance="sunData/combined/008/test.12.n.xml",
         instance_is_valid=False,
         class_name="Alias",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_5_n(save_xml):
     """
     test
@@ -1990,11 +2118,12 @@ def test_test008_test_5_n(save_xml):
         instance="sunData/combined/008/test.5.n.xml",
         instance_is_valid=False,
         class_name="Restriction",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_7_n(save_xml):
     """
     test
@@ -2005,11 +2134,12 @@ def test_test008_test_7_n(save_xml):
         instance="sunData/combined/008/test.7.n.xml",
         instance_is_valid=False,
         class_name="Restriction",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_8_n(save_xml):
     """
     test
@@ -2020,11 +2150,12 @@ def test_test008_test_8_n(save_xml):
         instance="sunData/combined/008/test.8.n.xml",
         instance_is_valid=False,
         class_name="Restriction",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_9_n(save_xml):
     """
     test
@@ -2035,11 +2166,12 @@ def test_test008_test_9_n(save_xml):
         instance="sunData/combined/008/test.9.n.xml",
         instance_is_valid=False,
         class_name="Alias",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_2_v(save_xml):
     """
     test
@@ -2050,11 +2182,12 @@ def test_test008_test_2_v(save_xml):
         instance="sunData/combined/008/test.2.v.xml",
         instance_is_valid=True,
         class_name="Extension",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_3_v(save_xml):
     """
     test
@@ -2065,11 +2198,12 @@ def test_test008_test_3_v(save_xml):
         instance="sunData/combined/008/test.3.v.xml",
         instance_is_valid=True,
         class_name="Extension",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_4_v(save_xml):
     """
     test
@@ -2080,11 +2214,12 @@ def test_test008_test_4_v(save_xml):
         instance="sunData/combined/008/test.4.v.xml",
         instance_is_valid=True,
         class_name="Extension",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test008_test_6_v(save_xml):
     """
     test
@@ -2095,11 +2230,12 @@ def test_test008_test_6_v(save_xml):
         instance="sunData/combined/008/test.6.v.xml",
         instance_is_valid=True,
         class_name="Restriction",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_1_v(save_xml):
     """
     test
@@ -2110,11 +2246,12 @@ def test_test007_test_1_v(save_xml):
         instance="sunData/combined/007/test.1.v.xml",
         instance_is_valid=True,
         class_name="Emptywc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_6_v(save_xml):
     """
     test
@@ -2125,11 +2262,12 @@ def test_test007_test_6_v(save_xml):
         instance="sunData/combined/007/test.6.v.xml",
         instance_is_valid=True,
         class_name="JustA",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_2_n(save_xml):
     """
     test
@@ -2140,11 +2278,12 @@ def test_test007_test_2_n(save_xml):
         instance="sunData/combined/007/test.2.n.xml",
         instance_is_valid=False,
         class_name="Emptywc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_3_n(save_xml):
     """
     test
@@ -2155,11 +2294,12 @@ def test_test007_test_3_n(save_xml):
         instance="sunData/combined/007/test.3.n.xml",
         instance_is_valid=False,
         class_name="Emptywc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_4_n(save_xml):
     """
     test
@@ -2170,11 +2310,12 @@ def test_test007_test_4_n(save_xml):
         instance="sunData/combined/007/test.4.n.xml",
         instance_is_valid=False,
         class_name="Emptywc",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_5_n(save_xml):
     """
     test
@@ -2185,11 +2326,12 @@ def test_test007_test_5_n(save_xml):
         instance="sunData/combined/007/test.5.n.xml",
         instance_is_valid=False,
         class_name="JustA",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_7_n(save_xml):
     """
     test
@@ -2200,11 +2342,12 @@ def test_test007_test_7_n(save_xml):
         instance="sunData/combined/007/test.7.n.xml",
         instance_is_valid=False,
         class_name="JustA",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test007_test_8_n(save_xml):
     """
     test
@@ -2215,11 +2358,12 @@ def test_test007_test_8_n(save_xml):
         instance="sunData/combined/007/test.8.n.xml",
         instance_is_valid=False,
         class_name="JustA",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_1_v(save_xml):
     """
     test
@@ -2230,11 +2374,12 @@ def test_test006_test_1_v(save_xml):
         instance="sunData/combined/006/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_10_n(save_xml):
     """
     test
@@ -2245,11 +2390,12 @@ def test_test006_test_10_n(save_xml):
         instance="sunData/combined/006/test.10.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_11_n(save_xml):
     """
     test
@@ -2260,11 +2406,12 @@ def test_test006_test_11_n(save_xml):
         instance="sunData/combined/006/test.11.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_12_n(save_xml):
     """
     test
@@ -2275,11 +2422,12 @@ def test_test006_test_12_n(save_xml):
         instance="sunData/combined/006/test.12.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_13_n(save_xml):
     """
     test
@@ -2290,11 +2438,12 @@ def test_test006_test_13_n(save_xml):
         instance="sunData/combined/006/test.13.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_14_n(save_xml):
     """
     test
@@ -2305,11 +2454,12 @@ def test_test006_test_14_n(save_xml):
         instance="sunData/combined/006/test.14.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_15_n(save_xml):
     """
     test
@@ -2320,11 +2470,12 @@ def test_test006_test_15_n(save_xml):
         instance="sunData/combined/006/test.15.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_16_n(save_xml):
     """
     test
@@ -2335,11 +2486,12 @@ def test_test006_test_16_n(save_xml):
         instance="sunData/combined/006/test.16.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_17_n(save_xml):
     """
     test
@@ -2350,11 +2502,12 @@ def test_test006_test_17_n(save_xml):
         instance="sunData/combined/006/test.17.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_18_n(save_xml):
     """
     test
@@ -2365,11 +2518,12 @@ def test_test006_test_18_n(save_xml):
         instance="sunData/combined/006/test.18.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_19_n(save_xml):
     """
     test
@@ -2380,11 +2534,12 @@ def test_test006_test_19_n(save_xml):
         instance="sunData/combined/006/test.19.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_2_v(save_xml):
     """
     test
@@ -2395,11 +2550,12 @@ def test_test006_test_2_v(save_xml):
         instance="sunData/combined/006/test.2.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_20_n(save_xml):
     """
     test
@@ -2410,11 +2566,12 @@ def test_test006_test_20_n(save_xml):
         instance="sunData/combined/006/test.20.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_21_n(save_xml):
     """
     test
@@ -2425,11 +2582,12 @@ def test_test006_test_21_n(save_xml):
         instance="sunData/combined/006/test.21.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_22_n(save_xml):
     """
     test
@@ -2440,11 +2598,12 @@ def test_test006_test_22_n(save_xml):
         instance="sunData/combined/006/test.22.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_23_n(save_xml):
     """
     test
@@ -2455,11 +2614,12 @@ def test_test006_test_23_n(save_xml):
         instance="sunData/combined/006/test.23.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_24_n(save_xml):
     """
     test
@@ -2470,11 +2630,12 @@ def test_test006_test_24_n(save_xml):
         instance="sunData/combined/006/test.24.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_25_n(save_xml):
     """
     test
@@ -2485,11 +2646,12 @@ def test_test006_test_25_n(save_xml):
         instance="sunData/combined/006/test.25.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_26_n(save_xml):
     """
     test
@@ -2500,11 +2662,12 @@ def test_test006_test_26_n(save_xml):
         instance="sunData/combined/006/test.26.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_27_n(save_xml):
     """
     test
@@ -2515,11 +2678,12 @@ def test_test006_test_27_n(save_xml):
         instance="sunData/combined/006/test.27.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_28_n(save_xml):
     """
     test
@@ -2530,11 +2694,12 @@ def test_test006_test_28_n(save_xml):
         instance="sunData/combined/006/test.28.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_29_n(save_xml):
     """
     test
@@ -2545,11 +2710,12 @@ def test_test006_test_29_n(save_xml):
         instance="sunData/combined/006/test.29.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_3_n(save_xml):
     """
     test
@@ -2560,11 +2726,12 @@ def test_test006_test_3_n(save_xml):
         instance="sunData/combined/006/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_30_n(save_xml):
     """
     test
@@ -2575,11 +2742,12 @@ def test_test006_test_30_n(save_xml):
         instance="sunData/combined/006/test.30.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_31_n(save_xml):
     """
     test
@@ -2590,11 +2758,12 @@ def test_test006_test_31_n(save_xml):
         instance="sunData/combined/006/test.31.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_32_n(save_xml):
     """
     test
@@ -2605,11 +2774,12 @@ def test_test006_test_32_n(save_xml):
         instance="sunData/combined/006/test.32.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_33_n(save_xml):
     """
     test
@@ -2620,11 +2790,12 @@ def test_test006_test_33_n(save_xml):
         instance="sunData/combined/006/test.33.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_34_n(save_xml):
     """
     test
@@ -2635,11 +2806,12 @@ def test_test006_test_34_n(save_xml):
         instance="sunData/combined/006/test.34.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_4_n(save_xml):
     """
     test
@@ -2650,11 +2822,12 @@ def test_test006_test_4_n(save_xml):
         instance="sunData/combined/006/test.4.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_5_n(save_xml):
     """
     test
@@ -2665,11 +2838,12 @@ def test_test006_test_5_n(save_xml):
         instance="sunData/combined/006/test.5.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_6_n(save_xml):
     """
     test
@@ -2680,11 +2854,12 @@ def test_test006_test_6_n(save_xml):
         instance="sunData/combined/006/test.6.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_7_n(save_xml):
     """
     test
@@ -2695,11 +2870,12 @@ def test_test006_test_7_n(save_xml):
         instance="sunData/combined/006/test.7.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_8_n(save_xml):
     """
     test
@@ -2710,11 +2886,12 @@ def test_test006_test_8_n(save_xml):
         instance="sunData/combined/006/test.8.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test006_test_9_n(save_xml):
     """
     test
@@ -2725,11 +2902,12 @@ def test_test006_test_9_n(save_xml):
         instance="sunData/combined/006/test.9.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test005_test_1_v(save_xml):
     """
     test
@@ -2740,11 +2918,12 @@ def test_test005_test_1_v(save_xml):
         instance="sunData/combined/005/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test005_test_2_n(save_xml):
     """
     test
@@ -2755,11 +2934,12 @@ def test_test005_test_2_n(save_xml):
         instance="sunData/combined/005/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test005_test_3_n(save_xml):
     """
     test
@@ -2770,11 +2950,12 @@ def test_test005_test_3_n(save_xml):
         instance="sunData/combined/005/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test005_test_4_n(save_xml):
     """
     test
@@ -2785,11 +2966,12 @@ def test_test005_test_4_n(save_xml):
         instance="sunData/combined/005/test.4.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test005_test_5_n(save_xml):
     """
     test
@@ -2800,11 +2982,12 @@ def test_test005_test_5_n(save_xml):
         instance="sunData/combined/005/test.5.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test004_test_1_v(save_xml):
     """
     test
@@ -2815,11 +2998,12 @@ def test_test004_test_1_v(save_xml):
         instance="sunData/combined/004/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test004_test_2_n(save_xml):
     """
     test
@@ -2830,11 +3014,12 @@ def test_test004_test_2_n(save_xml):
         instance="sunData/combined/004/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test004_test_3_n(save_xml):
     """
     test
@@ -2845,11 +3030,12 @@ def test_test004_test_3_n(save_xml):
         instance="sunData/combined/004/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test004_test_4_n(save_xml):
     """
     test
@@ -2860,11 +3046,12 @@ def test_test004_test_4_n(save_xml):
         instance="sunData/combined/004/test.4.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test004_test_5_n(save_xml):
     """
     test
@@ -2875,11 +3062,12 @@ def test_test004_test_5_n(save_xml):
         instance="sunData/combined/004/test.5.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test003_test_1_v(save_xml):
     """
     test
@@ -2890,11 +3078,12 @@ def test_test003_test_1_v(save_xml):
         instance="sunData/combined/003/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test003_test_2_n(save_xml):
     """
     test
@@ -2905,11 +3094,12 @@ def test_test003_test_2_n(save_xml):
         instance="sunData/combined/003/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test003_test_3_n(save_xml):
     """
     test
@@ -2920,11 +3110,12 @@ def test_test003_test_3_n(save_xml):
         instance="sunData/combined/003/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test003_test_4_n(save_xml):
     """
     test
@@ -2935,11 +3126,12 @@ def test_test003_test_4_n(save_xml):
         instance="sunData/combined/003/test.4.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test003_test_5_n(save_xml):
     """
     test
@@ -2950,11 +3142,12 @@ def test_test003_test_5_n(save_xml):
         instance="sunData/combined/003/test.5.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test002_test_1_v(save_xml):
     """
     test
@@ -2965,11 +3158,12 @@ def test_test002_test_1_v(save_xml):
         instance="sunData/combined/002/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test002_test_2_n(save_xml):
     """
     test
@@ -2980,11 +3174,12 @@ def test_test002_test_2_n(save_xml):
         instance="sunData/combined/002/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test002_test_3_n(save_xml):
     """
     test
@@ -2995,11 +3190,12 @@ def test_test002_test_3_n(save_xml):
         instance="sunData/combined/002/test.3.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test002_test_4_n(save_xml):
     """
     test
@@ -3010,11 +3206,12 @@ def test_test002_test_4_n(save_xml):
         instance="sunData/combined/002/test.4.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test002_test_5_n(save_xml):
     """
     test
@@ -3025,11 +3222,12 @@ def test_test002_test_5_n(save_xml):
         instance="sunData/combined/002/test.5.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test001_test_1_v(save_xml):
     """
     test
@@ -3040,11 +3238,12 @@ def test_test001_test_1_v(save_xml):
         instance="sunData/combined/001/test.1.v.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_test001_test_2_n(save_xml):
     """
     test
@@ -3055,11 +3254,12 @@ def test_test001_test_2_n(save_xml):
         instance="sunData/combined/001/test.2.n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m4_positive(save_xml):
     """
     machine-targeted  annotation for an attribute group definition (valid
@@ -3074,11 +3274,12 @@ def test_annotation00101m4_positive(save_xml):
         instance="sunData/AGroupDef/annotation/annotation00101m/annotation00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive(save_xml):
     """
     human-targeted  annotation for an attribute group definition (valid
@@ -3093,11 +3294,12 @@ def test_annotation00101m1_positive(save_xml):
         instance="sunData/AGroupDef/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ag_targetns00101m1_p_positive(save_xml):
     """
     Attribute group reference with QName. (valid schema) Attribute Group
@@ -3110,11 +3312,12 @@ def test_ag_targetns00101m1_p_positive(save_xml):
         instance="sunData/AGroupDef/AG_targetNS/AG_targetNS00101m/AG_targetNS00101m1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ag_name00101m1_p_positive(save_xml):
     """
     Attribute group declaration. (valid schema) Attribute Group use should
@@ -3126,11 +3329,12 @@ def test_ag_name00101m1_p_positive(save_xml):
         instance="sunData/AGroupDef/AG_name/AG_name00101m/AG_name00101m1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ag_attrwcard00101m1_positive(save_xml):
     """
     Attribute wildcard is declared in attribute group.  (valid schema)
@@ -3144,11 +3348,12 @@ def test_ag_attrwcard00101m1_positive(save_xml):
         instance="sunData/AGroupDef/AG_attrWCard/AG_attrWCard00101m/AG_attrWCard00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ag_attrusens00101m1_p_positive(save_xml):
     """
     Attribute is declared in attribute group by reference with QName.
@@ -3162,11 +3367,12 @@ def test_ag_attrusens00101m1_p_positive(save_xml):
         instance="sunData/AGroupDef/AG_attrUse/AG_attrUseNS00101m/AG_attrUseNS00101m1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_valconstr00201m3_positive(save_xml):
     """
     Attribute with 'default' value and "optional" 'use' is declared
@@ -3180,11 +3386,12 @@ def test_ad_valconstr00201m3_positive(save_xml):
         instance="sunData/AttrDecl/AD_valConstr/AD_valConstr00201m/AD_valConstr00201m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_valconstr00101m_ad_val_constr00101m1_p(save_xml):
     """
     Attribute with fixed value is declared within element by reference
@@ -3197,11 +3404,12 @@ def test_ad_valconstr00101m_ad_val_constr00101m1_p(save_xml):
         instance="sunData/AttrDecl/AD_valConstr/AD_valConstr00101m/AD_valConstr00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_valconstr00101m_ad_val_constr00101m1_n(save_xml):
     """
     Attribute with fixed value is declared within element by reference
@@ -3214,11 +3422,12 @@ def test_ad_valconstr00101m_ad_val_constr00101m1_n(save_xml):
         instance="sunData/AttrDecl/AD_valConstr/AD_valConstr00101m/AD_valConstr00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_valconstr00101m_ad_val_constr00101m2_p(save_xml):
     """
     Attribute with fixed value is declared within element by reference
@@ -3231,11 +3440,12 @@ def test_ad_valconstr00101m_ad_val_constr00101m2_p(save_xml):
         instance="sunData/AttrDecl/AD_valConstr/AD_valConstr00101m/AD_valConstr00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_valconstr00101m_ad_val_constr00101m2_n(save_xml):
     """
     Attribute with fixed value is declared within element by reference
@@ -3248,11 +3458,12 @@ def test_ad_valconstr00101m_ad_val_constr00101m2_n(save_xml):
         instance="sunData/AttrDecl/AD_valConstr/AD_valConstr00101m/AD_valConstr00101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00102m_ad_type00102m1_p(save_xml):
     """
     Attribute with restriction type is declared within element by
@@ -3265,11 +3476,12 @@ def test_ad_type00102m_ad_type00102m1_p(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00102m/AD_type00102m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00102m_ad_type00102m1_n(save_xml):
     """
     Attribute with restriction type is declared within element by
@@ -3282,11 +3494,12 @@ def test_ad_type00102m_ad_type00102m1_n(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00102m/AD_type00102m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00102m_ad_type00102m2_p(save_xml):
     """
     Attribute with restriction type is declared within element by
@@ -3299,11 +3512,12 @@ def test_ad_type00102m_ad_type00102m2_p(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00102m/AD_type00102m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00102m_ad_type00102m2_n(save_xml):
     """
     Attribute with restriction type is declared within element by
@@ -3316,11 +3530,12 @@ def test_ad_type00102m_ad_type00102m2_n(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00102m/AD_type00102m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00101m_ad_type00101m1_p(save_xml):
     """
     Attribute declared within element by reference (valid schema) The
@@ -3333,11 +3548,12 @@ def test_ad_type00101m_ad_type00101m1_p(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00101m/AD_type00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00101m_ad_type00101m1_n(save_xml):
     """
     Attribute declared within element by reference (valid schema) The
@@ -3350,11 +3566,12 @@ def test_ad_type00101m_ad_type00101m1_n(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00101m/AD_type00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00101m_ad_type00101m2_p(save_xml):
     """
     Attribute declared within element by reference (valid schema) The
@@ -3367,11 +3584,12 @@ def test_ad_type00101m_ad_type00101m2_p(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00101m/AD_type00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_type00101m_ad_type00101m2_n(save_xml):
     """
     Attribute declared within element by reference (valid schema) The
@@ -3384,11 +3602,12 @@ def test_ad_type00101m_ad_type00101m2_n(save_xml):
         instance="sunData/AttrDecl/AD_type/AD_type00101m/AD_type00101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_targetns00101m_ad_target_ns00101m1_p(save_xml):
     """
     Attribute explicitly declared qualified. (valid schema) Attribute
@@ -3400,11 +3619,12 @@ def test_ad_targetns00101m_ad_target_ns00101m1_p(save_xml):
         instance="sunData/AttrDecl/AD_targetNS/AD_targetNS00101m/AD_targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_targetns00101m_ad_target_ns00101m1_n(save_xml):
     """
     Attribute explicitly declared qualified. (valid schema) Attribute
@@ -3416,11 +3636,12 @@ def test_ad_targetns00101m_ad_target_ns00101m1_n(save_xml):
         instance="sunData/AttrDecl/AD_targetNS/AD_targetNS00101m/AD_targetNS00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_targetns00101m_ad_target_ns00101m2_n(save_xml):
     """
     Attribute explicitly declared qualified. (valid schema) Attribute
@@ -3432,11 +3653,12 @@ def test_ad_targetns00101m_ad_target_ns00101m2_n(save_xml):
         instance="sunData/AttrDecl/AD_targetNS/AD_targetNS00101m/AD_targetNS00101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_targetns00101m_ad_target_ns00101m3_p(save_xml):
     """
     Attribute explicitly declared qualified. (valid schema) Attribute
@@ -3448,11 +3670,12 @@ def test_ad_targetns00101m_ad_target_ns00101m3_p(save_xml):
         instance="sunData/AttrDecl/AD_targetNS/AD_targetNS00101m/AD_targetNS00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_targetns00101m_ad_target_ns00101m3_n(save_xml):
     """
     Attribute explicitly declared qualified. (valid schema) Attribute
@@ -3464,11 +3687,12 @@ def test_ad_targetns00101m_ad_target_ns00101m3_n(save_xml):
         instance="sunData/AttrDecl/AD_targetNS/AD_targetNS00101m/AD_targetNS00101m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_scope00101m1_positive(save_xml):
     """
     Attribute declared with global scope (valid schema) Attribute declared
@@ -3480,11 +3704,12 @@ def test_ad_scope00101m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_scope/AD_scope00101m/AD_scope00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00118_ad_name00118_p(save_xml):
     """
     Attribute names contain an uncased letter followed by upper or lower
@@ -3499,11 +3724,12 @@ def test_ad_name00118_ad_name00118_p(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00118/AD_name00118_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00115_ad_name00115_p(save_xml):
     """
     Attribute names contain only punctuation characters and digits. (valid
@@ -3519,11 +3745,12 @@ def test_ad_name00115_ad_name00115_p(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00115/AD_name00115_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00114_ad_name00114_p(save_xml):
     """
     Attribute names contain lower case and upper case letters and non-
@@ -3544,11 +3771,12 @@ def test_ad_name00114_ad_name00114_p(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00114/AD_name00114_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00113_ad_name00113_p(save_xml):
     """
     Attribute names contain digits followed by a non-digit characters.
@@ -3564,11 +3792,12 @@ def test_ad_name00113_ad_name00113_p(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00113/AD_name00113_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00112_ad_name00112_p(save_xml):
     r"""
     Attribute name contains 7 punctuation characters. (valid schema)
@@ -3589,11 +3818,12 @@ def test_ad_name00112_ad_name00112_p(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00112/AD_name00112_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00111_ad_name00111_p(save_xml):
     r"""
     Attribute names contain several punctuation characters. (valid schema)
@@ -3613,11 +3843,12 @@ def test_ad_name00111_ad_name00111_p(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00111/AD_name00111_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m9_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0f39,
@@ -3636,11 +3867,12 @@ def test_ad_name00110m9_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m8_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0e31,
@@ -3659,11 +3891,12 @@ def test_ad_name00110m8_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m7_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0c82,
@@ -3684,11 +3917,12 @@ def test_ad_name00110m7_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m6_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0b82,
@@ -3709,11 +3943,12 @@ def test_ad_name00110m6_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m5_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0abc,
@@ -3734,11 +3969,12 @@ def test_ad_name00110m5_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m4_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x09e2,
@@ -3757,11 +3993,12 @@ def test_ad_name00110m4_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m3_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0951,
@@ -3780,11 +4017,12 @@ def test_ad_name00110m3_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m2_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0670,
@@ -3804,11 +4042,12 @@ def test_ad_name00110m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m10_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x20d0,
@@ -3824,11 +4063,12 @@ def test_ad_name00110m10_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00110m1_positive(save_xml):
     """
     Attributes have names that end with the combining characters 0x0300,
@@ -3849,11 +4089,12 @@ def test_ad_name00110m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00110m/AD_name00110m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00109m2_positive(save_xml):
     """
     Attributes have names that end with the digit characters 0x0ce6,
@@ -3870,11 +4111,12 @@ def test_ad_name00109m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00109m/AD_name00109m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00109m1_positive(save_xml):
     """
     Attributes have names that end with the digit characters 0x0030,
@@ -3895,11 +4137,12 @@ def test_ad_name00109m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00109m/AD_name00109m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m9_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0a8f,
@@ -3920,11 +4163,12 @@ def test_ad_name00108m9_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m8_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0a13,
@@ -3945,11 +4189,12 @@ def test_ad_name00108m8_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m7_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x098f,
@@ -3970,11 +4215,12 @@ def test_ad_name00108m7_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m6_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0671,
@@ -3995,11 +4241,12 @@ def test_ad_name00108m6_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m5_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x04d0,
@@ -4020,11 +4267,12 @@ def test_ad_name00108m5_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m4_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x03d0,
@@ -4045,11 +4293,12 @@ def test_ad_name00108m4_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m3_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0276,
@@ -4070,11 +4319,12 @@ def test_ad_name00108m3_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m21_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x1fe8,
@@ -4093,11 +4343,12 @@ def test_ad_name00108m21_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m21_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m20_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x1f5b,
@@ -4117,11 +4368,12 @@ def test_ad_name00108m20_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m20_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m2_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x014a,
@@ -4142,11 +4394,12 @@ def test_ad_name00108m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m19_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x1ea0,
@@ -4165,11 +4418,12 @@ def test_ad_name00108m19_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m19_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m18_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x11ab,
@@ -4188,11 +4442,12 @@ def test_ad_name00108m18_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m18_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m17_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x115f,
@@ -4210,11 +4465,12 @@ def test_ad_name00108m17_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m17_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m16_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x110b,
@@ -4232,11 +4488,12 @@ def test_ad_name00108m16_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m16_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m15_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0eb0,
@@ -4255,11 +4512,12 @@ def test_ad_name00108m15_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m15_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m14_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0e87,
@@ -4278,11 +4536,12 @@ def test_ad_name00108m14_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m14_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m13_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0d0e,
@@ -4303,11 +4562,12 @@ def test_ad_name00108m13_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m13_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m12_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0c35,
@@ -4328,11 +4588,12 @@ def test_ad_name00108m12_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m12_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m11_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0b9c,
@@ -4353,11 +4614,12 @@ def test_ad_name00108m11_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m11_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m10_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0b2a,
@@ -4378,11 +4640,12 @@ def test_ad_name00108m10_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00108m1_positive(save_xml):
     """
     Attributes have names that end with the basic characters 0x0041,
@@ -4403,11 +4666,12 @@ def test_ad_name00108m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00108m/AD_name00108m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00107m1_positive(save_xml):
     """
     Attributes have names that end with the ideographic characters 0x4e00,
@@ -4423,11 +4687,12 @@ def test_ad_name00107m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00107m/AD_name00107m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00106m1_positive(save_xml):
     """
     Attributes have names that end with the underscore, dot and minus
@@ -4442,11 +4707,12 @@ def test_ad_name00106m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00106m/AD_name00106m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00105m1_positive(save_xml):
     """
     Attribute has name that begins with the underscore character 0x005f
@@ -4460,11 +4726,12 @@ def test_ad_name00105m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00105m/AD_name00105m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m9_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0a8f,
@@ -4485,11 +4752,12 @@ def test_ad_name00104m9_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m8_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0a13,
@@ -4510,11 +4778,12 @@ def test_ad_name00104m8_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m7_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x098f,
@@ -4535,11 +4804,12 @@ def test_ad_name00104m7_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m6_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0671,
@@ -4560,11 +4830,12 @@ def test_ad_name00104m6_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m5_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x04d0,
@@ -4585,11 +4856,12 @@ def test_ad_name00104m5_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m4_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x03d0,
@@ -4610,11 +4882,12 @@ def test_ad_name00104m4_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m3_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0276,
@@ -4635,11 +4908,12 @@ def test_ad_name00104m3_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m21_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x1fe8,
@@ -4658,11 +4932,12 @@ def test_ad_name00104m21_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m21_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m20_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x1f5b,
@@ -4682,11 +4957,12 @@ def test_ad_name00104m20_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m20_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m2_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x014a,
@@ -4707,11 +4983,12 @@ def test_ad_name00104m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m19_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x1ea0,
@@ -4730,11 +5007,12 @@ def test_ad_name00104m19_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m19_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m18_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x11ab,
@@ -4753,11 +5031,12 @@ def test_ad_name00104m18_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m18_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m17_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x115f,
@@ -4775,11 +5054,12 @@ def test_ad_name00104m17_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m17_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m16_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x110b,
@@ -4797,11 +5077,12 @@ def test_ad_name00104m16_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m16_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m15_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0eb0,
@@ -4820,11 +5101,12 @@ def test_ad_name00104m15_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m15_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m14_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0e87,
@@ -4843,11 +5125,12 @@ def test_ad_name00104m14_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m14_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m13_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0d0e,
@@ -4868,11 +5151,12 @@ def test_ad_name00104m13_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m13_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m12_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0c35,
@@ -4893,11 +5177,12 @@ def test_ad_name00104m12_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m12_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m11_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0b9c,
@@ -4918,11 +5203,12 @@ def test_ad_name00104m11_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m11_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m10_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0b2a,
@@ -4943,11 +5229,12 @@ def test_ad_name00104m10_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00104m1_positive(save_xml):
     """
     Attributes have names that begin with the basic characters 0x0041,
@@ -4968,11 +5255,12 @@ def test_ad_name00104m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00104m/AD_name00104m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00103m2_positive(save_xml):
     """
     Attributes have names that end with the extender characters 0x30fc,
@@ -4987,11 +5275,12 @@ def test_ad_name00103m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00103m/AD_name00103m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00103m1_positive(save_xml):
     """
     Attributes have names that end with the extender characters 0x00b7,
@@ -5008,11 +5297,12 @@ def test_ad_name00103m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00103m/AD_name00103m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00102m1_positive(save_xml):
     """
     Attributes have names that begin with the ideographic characters
@@ -5028,11 +5318,12 @@ def test_ad_name00102m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00102m/AD_name00102m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m4_positive(save_xml):
     """
     Attribute in schema with "qualified" default form (valid schema)
@@ -5045,11 +5336,12 @@ def test_ad_name00101m4_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m4_negative(save_xml):
     """
     Attribute in schema with "qualified" default form (valid schema)
@@ -5062,11 +5354,12 @@ def test_ad_name00101m4_negative(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m3_positive(save_xml):
     """
     Attribute explicitly declared "unqualified" while default form is
@@ -5079,11 +5372,12 @@ def test_ad_name00101m3_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m3_negative(save_xml):
     """
     Attribute explicitly declared "unqualified" while default form is
@@ -5096,11 +5390,12 @@ def test_ad_name00101m3_negative(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m2_positive(save_xml):
     """
     Attribute in schema with "unqualified" default form (valid schema)
@@ -5113,11 +5408,12 @@ def test_ad_name00101m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m2_negative(save_xml):
     """
     Attribute in schema with "unqualified" default form (valid schema)
@@ -5130,11 +5426,12 @@ def test_ad_name00101m2_negative(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m1_positive(save_xml):
     """
     Attribute explicitly declared "qualified" while default form is
@@ -5147,11 +5444,12 @@ def test_ad_name00101m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_name00101m1_negative(save_xml):
     """
     Attribute explicitly declared "qualified" while default form is
@@ -5164,11 +5462,12 @@ def test_ad_name00101m1_negative(save_xml):
         instance="sunData/AttrDecl/AD_name/AD_name00101m/AD_name00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_annotation00101m2_positive(save_xml):
     """
     machine-targeted annotation  for attribute declarations (valid schema)
@@ -5181,11 +5480,12 @@ def test_ad_annotation00101m2_positive(save_xml):
         instance="sunData/AttrDecl/AD_annotation/AD_annotation00101m/AD_annotation00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_ad_annotation00101m1_positive(save_xml):
     """
     human-targeted annotation  for attribute declarations (valid schema)
@@ -5198,11 +5498,12 @@ def test_ad_annotation00101m1_positive(save_xml):
         instance="sunData/AttrDecl/AD_annotation/AD_annotation00101m/AD_annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_au_valconstr00101m1_positive(save_xml):
     """
     Attribute with fixed value is declared within element by reference
@@ -5215,11 +5516,12 @@ def test_au_valconstr00101m1_positive(save_xml):
         instance="sunData/AttrUse/AU_valConstr/AU_valConstr00101m/AU_valConstr00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_au_valconstr00101m1_negative(save_xml):
     """
     Attribute with fixed value is declared within element by reference
@@ -5232,11 +5534,12 @@ def test_au_valconstr00101m1_negative(save_xml):
         instance="sunData/AttrUse/AU_valConstr/AU_valConstr00101m/AU_valConstr00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_au_required00101m1_positive(save_xml):
     """
     Attribute use is declared required.  (valid schema) Element whose
@@ -5248,11 +5551,12 @@ def test_au_required00101m1_positive(save_xml):
         instance="sunData/AttrUse/AU_required/AU_required00101m/AU_required00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_au_required00101m1_negative(save_xml):
     """
     Attribute use is declared required.  (valid schema) Element whose
@@ -5264,11 +5568,12 @@ def test_au_required00101m1_negative(save_xml):
         instance="sunData/AttrUse/AU_required/AU_required00101m/AU_required00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_au_attrdecl00101m1_p_positive(save_xml):
     """
     Attribute declaration is resolved for attribute use. (valid schema)
@@ -5281,11 +5586,12 @@ def test_au_attrdecl00101m1_p_positive(save_xml):
         instance="sunData/AttrUse/AU_attrDecl/AU_attrDecl00101m/AU_attrDecl00101m1.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_targetns00101m_target_ns00101m1_p(save_xml):
     """
@@ -5299,11 +5605,12 @@ def test_targetns00101m_target_ns00101m1_p(save_xml):
         instance="sunData/CType/targetNS/targetNS00101m/targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m_target_ns00101m1_n(save_xml):
     """
     Simple types are identified by their {name} and {target namespace}.
@@ -5316,11 +5623,12 @@ def test_targetns00101m_target_ns00101m1_n(save_xml):
         instance="sunData/CType/targetNS/targetNS00101m/targetNS00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00104m_p_substitutions00104m1_p(save_xml):
     """
     {prohibited substitutions} is #all (valid schema) {prohibited
@@ -5334,11 +5642,12 @@ def test_psubstitutions00104m_p_substitutions00104m1_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00104m/pSubstitutions00104m1_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00104m_p_substitutions00104m1_n(save_xml):
     """
     {prohibited substitutions} is #all (valid schema) {prohibited
@@ -5352,11 +5661,12 @@ def test_psubstitutions00104m_p_substitutions00104m1_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00104m/pSubstitutions00104m1_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00104m_p_substitutions00104m2_p(save_xml):
     """
     {prohibited substitutions} is #all (valid schema) {prohibited
@@ -5370,11 +5680,12 @@ def test_psubstitutions00104m_p_substitutions00104m2_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00104m/pSubstitutions00104m2_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00104m_p_substitutions00104m2_n(save_xml):
     """
     {prohibited substitutions} is #all (valid schema) {prohibited
@@ -5388,11 +5699,12 @@ def test_psubstitutions00104m_p_substitutions00104m2_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00104m/pSubstitutions00104m2_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_psubstitutions00103m_p_substitutions00103m1_p(save_xml):
     """
@@ -5407,11 +5719,12 @@ def test_psubstitutions00103m_p_substitutions00103m1_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00103m/pSubstitutions00103m1_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00103m_p_substitutions00103m1_n(save_xml):
     """
     {prohibited substitutions} is restriction (valid schema) {prohibited
@@ -5425,11 +5738,12 @@ def test_psubstitutions00103m_p_substitutions00103m1_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00103m/pSubstitutions00103m1_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00103m_p_substitutions00103m2_p(save_xml):
     """
     {prohibited substitutions} is restriction (valid schema) {prohibited
@@ -5443,11 +5757,12 @@ def test_psubstitutions00103m_p_substitutions00103m2_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00103m/pSubstitutions00103m2_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00103m_p_substitutions00103m2_n(save_xml):
     """
     {prohibited substitutions} is restriction (valid schema) {prohibited
@@ -5461,11 +5776,12 @@ def test_psubstitutions00103m_p_substitutions00103m2_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00103m/pSubstitutions00103m2_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00102m_p_substitutions00102m1_p(save_xml):
     """
     {prohibited substitutions} is extension (valid schema) {prohibited
@@ -5479,11 +5795,12 @@ def test_psubstitutions00102m_p_substitutions00102m1_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00102m/pSubstitutions00102m1_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00102m_p_substitutions00102m1_n(save_xml):
     """
     {prohibited substitutions} is extension (valid schema) {prohibited
@@ -5497,11 +5814,12 @@ def test_psubstitutions00102m_p_substitutions00102m1_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00102m/pSubstitutions00102m1_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00102m_p_substitutions00102m2_p(save_xml):
     """
     {prohibited substitutions} is extension (valid schema) {prohibited
@@ -5515,11 +5833,12 @@ def test_psubstitutions00102m_p_substitutions00102m2_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00102m/pSubstitutions00102m2_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00102m_p_substitutions00102m2_n(save_xml):
     """
     {prohibited substitutions} is extension (valid schema) {prohibited
@@ -5533,11 +5852,12 @@ def test_psubstitutions00102m_p_substitutions00102m2_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00102m/pSubstitutions00102m2_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_psubstitutions00101m_p_substitutions00101m1_p(save_xml):
     """
@@ -5550,11 +5870,12 @@ def test_psubstitutions00101m_p_substitutions00101m1_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00101m/pSubstitutions00101m1_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00101m_p_substitutions00101m1_n(save_xml):
     """
     {prohibited substitutions} is empty (valid schema) If {prohibited
@@ -5566,11 +5887,12 @@ def test_psubstitutions00101m_p_substitutions00101m1_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00101m/pSubstitutions00101m1_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00101m_p_substitutions00101m2_p(save_xml):
     """
     {prohibited substitutions} is empty (valid schema) If {prohibited
@@ -5582,11 +5904,12 @@ def test_psubstitutions00101m_p_substitutions00101m2_p(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00101m/pSubstitutions00101m2_p.xml",
         instance_is_valid=True,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_psubstitutions00101m_p_substitutions00101m2_n(save_xml):
     """
     {prohibited substitutions} is empty (valid schema) If {prohibited
@@ -5598,11 +5921,12 @@ def test_psubstitutions00101m_p_substitutions00101m2_n(save_xml):
         instance="sunData/CType/pSubstitutions/pSubstitutions00101m/pSubstitutions00101m2_n.xml",
         instance_is_valid=False,
         class_name="E",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m_name00101m1_p(save_xml):
     """
     Simple types are identified by their {name} and {target namespace}.
@@ -5615,11 +5939,12 @@ def test_name00101m_name00101m1_p(save_xml):
         instance="sunData/CType/name/name00101m/name00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m_name00101m1_n(save_xml):
     """
     Simple types are identified by their {name} and {target namespace}.
@@ -5632,11 +5957,12 @@ def test_name00101m_name00101m1_n(save_xml):
         instance="sunData/CType/name/name00101m/name00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_final00101m3_positive(save_xml):
     """
     the value is restriction (valid schema) The explicit values extension,
@@ -5651,11 +5977,12 @@ def test_final00101m3_positive(save_xml):
         instance="sunData/CType/final/final00101m/final00101m3_p.xml",
         instance_is_valid=True,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_final00101m3_negative(save_xml):
     """
     the value is restriction (valid schema) The explicit values extension,
@@ -5670,11 +5997,12 @@ def test_final00101m3_negative(save_xml):
         instance="sunData/CType/final/final00101m/final00101m3_n.xml",
         instance_is_valid=False,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00102m2_positive(save_xml):
     """
     extension of the type int by adding the attribute 't' of the type int
@@ -5688,11 +6016,12 @@ def test_derivationmethod00102m2_positive(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00102m/derivationMethod00102m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00102m2_negative(save_xml):
     """
     extension of the type int by adding the attribute 't' of the type int
@@ -5706,11 +6035,12 @@ def test_derivationmethod00102m2_negative(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00102m/derivationMethod00102m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00102m1_positive(save_xml):
     """
     extension of the type int (valid schema) Schema Component Constraint:
@@ -5723,11 +6053,12 @@ def test_derivationmethod00102m1_positive(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00102m/derivationMethod00102m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00102m1_negative(save_xml):
     """
     extension of the type int (valid schema) Schema Component Constraint:
@@ -5740,11 +6071,12 @@ def test_derivationmethod00102m1_negative(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00102m/derivationMethod00102m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00101m2_positive(save_xml):
     """
     items: 1.1, 1.2, 1.3, 1.4.2.1, 1.4.2.2.1 (valid schema) Schema
@@ -5757,11 +6089,12 @@ def test_derivationmethod00101m2_positive(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00101m/derivationMethod00101m2_p.xml",
         instance_is_valid=True,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00101m2_negative(save_xml):
     """
     items: 1.1, 1.2, 1.3, 1.4.2.1, 1.4.2.2.1 (valid schema) Schema
@@ -5774,11 +6107,12 @@ def test_derivationmethod00101m2_negative(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00101m/derivationMethod00101m2_n.xml",
         instance_is_valid=False,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00101m1_positive(save_xml):
     """
     items: 1.1, 1.2, 1.3, 1.4.1 (valid schema) Schema Component
@@ -5791,11 +6125,12 @@ def test_derivationmethod00101m1_positive(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00101m/derivationMethod00101m1_p.xml",
         instance_is_valid=True,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_derivationmethod00101m1_negative(save_xml):
     """
     items: 1.1, 1.2, 1.3, 1.4.1 (valid schema) Schema Component
@@ -5808,11 +6143,12 @@ def test_derivationmethod00101m1_negative(save_xml):
         instance="sunData/CType/derivationMethod/derivationMethod00101m/derivationMethod00101m1_n.xml",
         instance_is_valid=False,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00401m_content_type00401m1_p(save_xml):
     """
     An mixed content type (valid schema) A mixed {content type}
@@ -5827,11 +6163,12 @@ def test_contenttype00401m_content_type00401m1_p(save_xml):
         instance="sunData/CType/contentType/contentType00401m/contentType00401m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00401m_content_type00401m1_n(save_xml):
     """
     An mixed content type (valid schema) A mixed {content type}
@@ -5846,11 +6183,12 @@ def test_contenttype00401m_content_type00401m1_n(save_xml):
         instance="sunData/CType/contentType/contentType00401m/contentType00401m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00301m_content_type00301m1_p(save_xml):
     """
     An element-only content type (valid schema) An element-only {content
@@ -5863,11 +6201,12 @@ def test_contenttype00301m_content_type00301m1_p(save_xml):
         instance="sunData/CType/contentType/contentType00301m/contentType00301m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00301m_content_type00301m1_n(save_xml):
     """
     An element-only content type (valid schema) An element-only {content
@@ -5880,11 +6219,12 @@ def test_contenttype00301m_content_type00301m1_n(save_xml):
         instance="sunData/CType/contentType/contentType00301m/contentType00301m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00201m_content_type00201m1_p(save_xml):
     """
     A simple content type (valid schema) A {content type} which is a
@@ -5897,11 +6237,12 @@ def test_contenttype00201m_content_type00201m1_p(save_xml):
         instance="sunData/CType/contentType/contentType00201m/contentType00201m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00201m_content_type00201m1_n(save_xml):
     """
     A simple content type (valid schema) A {content type} which is a
@@ -5914,11 +6255,12 @@ def test_contenttype00201m_content_type00201m1_n(save_xml):
         instance="sunData/CType/contentType/contentType00201m/contentType00201m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00101m_content_type00101m1_p(save_xml):
     """
     An empty content type (valid schema) A {content type} with the
@@ -5931,11 +6273,12 @@ def test_contenttype00101m_content_type00101m1_p(save_xml):
         instance="sunData/CType/contentType/contentType00101m/contentType00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_contenttype00101m_content_type00101m1_n(save_xml):
     """
     An empty content type (valid schema) A {content type} with the
@@ -5948,11 +6291,12 @@ def test_contenttype00101m_content_type00101m1_n(save_xml):
         instance="sunData/CType/contentType/contentType00101m/contentType00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m4_positive(save_xml):
     """
     restriction of complex content (valid schema) The type definition
@@ -5964,11 +6308,12 @@ def test_basetd00101m4_positive(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m4_negative(save_xml):
     """
     restriction of complex content (valid schema) The type definition
@@ -5980,11 +6325,12 @@ def test_basetd00101m4_negative(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m3_positive(save_xml):
     """
     extention of complex content (valid schema) The type definition
@@ -5996,11 +6342,12 @@ def test_basetd00101m3_positive(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m3_negative(save_xml):
     """
     extention of complex content (valid schema) The type definition
@@ -6012,11 +6359,12 @@ def test_basetd00101m3_negative(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m2_positive(save_xml):
     """
     extention of simple content (valid schema) The type definition
@@ -6028,11 +6376,12 @@ def test_basetd00101m2_positive(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m2_negative(save_xml):
     """
     extention of simple content (valid schema) The type definition
@@ -6044,11 +6393,12 @@ def test_basetd00101m2_negative(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m1_positive(save_xml):
     """
     restriction of simple content (valid schema) The type definition
@@ -6060,11 +6410,12 @@ def test_basetd00101m1_positive(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_basetd00101m1_negative(save_xml):
     """
     restriction of simple content (valid schema) The type definition
@@ -6076,11 +6427,12 @@ def test_basetd00101m1_negative(save_xml):
         instance="sunData/CType/baseTD/baseTD00101m/baseTD00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attributeuses00101m1_positive(save_xml):
     """
     <attribute> [children] (valid schema) The set of attribute uses
@@ -6092,11 +6444,12 @@ def test_attributeuses00101m1_positive(save_xml):
         instance="sunData/CType/attributeUses/attributeUses00101m/attributeUses00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attributeuses00101m1_negative(save_xml):
     """
     <attribute> [children] (valid schema) The set of attribute uses
@@ -6108,11 +6461,12 @@ def test_attributeuses00101m1_negative(save_xml):
         instance="sunData/CType/attributeUses/attributeUses00101m/attributeUses00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_attrwildcard00101m1_positive(save_xml):
     """
     type definition with any attributes (valid schema) any: [attributes]
@@ -6124,11 +6478,12 @@ def test_attrwildcard00101m1_positive(save_xml):
         instance="sunData/CType/attrWildcard/attrWildcard00101m/attrWildcard00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m2_positive(save_xml):
     """
     machine-targeted annotation  for complex type definition (valid
@@ -6141,11 +6496,12 @@ def test_annotation00101m2_positive(save_xml):
         instance="sunData/CType/annotation/annotation00101m/annotation00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_355(save_xml):
     """
     human-targeted annotation  for complex type definition (valid schema)
@@ -6158,11 +6514,12 @@ def test_annotation00101m1_positive_355(save_xml):
         instance="sunData/CType/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00101m2_negative(save_xml):
     """
     declaration of element of abstract type (valid schema) Complex types
@@ -6175,11 +6532,12 @@ def test_abstract00101m2_negative(save_xml):
         instance="sunData/CType/abstract/abstract00101m/abstract00101m2_n.xml",
         instance_is_valid=False,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00101m1_positive(save_xml):
     """
     abstract type extension (valid schema) Abstract complex types can be
@@ -6191,11 +6549,12 @@ def test_abstract00101m1_positive(save_xml):
         instance="sunData/CType/abstract/abstract00101m/abstract00101m1_p.xml",
         instance_is_valid=True,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00101m1_negative(save_xml):
     """
     abstract type extension (valid schema) Abstract complex types can be
@@ -6207,11 +6566,12 @@ def test_abstract00101m1_negative(save_xml):
         instance="sunData/CType/abstract/abstract00101m/abstract00101m1_n.xml",
         instance_is_valid=False,
         class_name="B",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01101m4_negative(save_xml):
     """
     default value is invalid for the local type definition (valid schema)
@@ -6227,11 +6587,12 @@ def test_valueconstraint01101m4_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01101m/valueConstraint01101m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01101m3_positive(save_xml):
     """
     default value is valid (valid schema) For a string to be a valid
@@ -6246,11 +6607,12 @@ def test_valueconstraint01101m3_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01101m/valueConstraint01101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01101m2_negative(save_xml):
     """
     fixed value is invalid for the local type definition (valid schema)
@@ -6265,11 +6627,12 @@ def test_valueconstraint01101m2_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01101m/valueConstraint01101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01101m1_positive(save_xml):
     """
     fixed value is valid (valid schema) For a string to be a valid default
@@ -6284,11 +6647,12 @@ def test_valueconstraint01101m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01101m/valueConstraint01101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01001m8_positive(save_xml):
     """
     default value constraint with string type (valid schema) Declare an
@@ -6301,11 +6665,12 @@ def test_valueconstraint01001m8_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01001m/valueConstraint01001m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01001m7_positive(save_xml):
     """
     fixed value constraint with string type (valid schema) Declare an
@@ -6318,11 +6683,12 @@ def test_valueconstraint01001m7_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01001m/valueConstraint01001m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01001m4_positive(save_xml):
     """
     no value constraint with a type derived from ID (valid schema) Declare
@@ -6335,11 +6701,12 @@ def test_valueconstraint01001m4_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01001m/valueConstraint01001m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint01001m1_positive(save_xml):
     """
     no value constraint with ID type (valid schema) Declare an element.
@@ -6352,11 +6719,12 @@ def test_valueconstraint01001m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint01001m/valueConstraint01001m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00901m1_positive(save_xml):
     """
     value of simple content type must match the fixed value (valid schema)
@@ -6372,11 +6740,12 @@ def test_valueconstraint00901m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00901m/valueConstraint00901m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00901m1_negative(save_xml):
     """
     value of simple content type must match the fixed value (valid schema)
@@ -6392,11 +6761,12 @@ def test_valueconstraint00901m1_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00901m/valueConstraint00901m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00801m1_positive(save_xml):
     """
     value of mixed content type must match the fixed value (valid schema)
@@ -6412,11 +6782,12 @@ def test_valueconstraint00801m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00801m/valueConstraint00801m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00801m1_negative(save_xml):
     """
     value of mixed content type must match the fixed value (valid schema)
@@ -6432,11 +6803,12 @@ def test_valueconstraint00801m1_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00801m/valueConstraint00801m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00701m1_positive(save_xml):
     """
     fixed value constraint forbids element children (valid schema) If
@@ -6450,11 +6822,12 @@ def test_valueconstraint00701m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00701m/valueConstraint00701m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00701m1_negative(save_xml):
     """
     fixed value constraint forbids element children (valid schema) If
@@ -6468,11 +6841,12 @@ def test_valueconstraint00701m1_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00701m/valueConstraint00701m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00601m7_positive(save_xml):
     """
     default value a derived type is valid (valid schema) The element
@@ -6488,11 +6862,12 @@ def test_valueconstraint00601m7_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00601m/valueConstraint00601m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00601m5_positive(save_xml):
     """
     fixed value of a derived type is valid (valid schema) The element
@@ -6508,11 +6883,12 @@ def test_valueconstraint00601m5_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00601m/valueConstraint00601m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00601m3_positive(save_xml):
     """
     default value of built-in type is valid (valid schema) The element
@@ -6528,11 +6904,12 @@ def test_valueconstraint00601m3_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00601m/valueConstraint00601m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00601m1_positive(save_xml):
     """
     fixed value of built-in type is valid (valid schema) The element
@@ -6548,11 +6925,12 @@ def test_valueconstraint00601m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00601m/valueConstraint00601m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00501m6_negative(save_xml):
     """
     default value is invalid for the local type definition (valid schema)
@@ -6571,11 +6949,12 @@ def test_valueconstraint00501m6_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00501m/valueConstraint00501m6_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00501m5_positive(save_xml):
     """
     default value is valid (valid schema) If the declaration has a {value
@@ -6593,11 +6972,12 @@ def test_valueconstraint00501m5_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00501m/valueConstraint00501m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00501m4_positive(save_xml):
     """
     default value is valid (valid schema) If the declaration has a {value
@@ -6615,11 +6995,12 @@ def test_valueconstraint00501m4_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00501m/valueConstraint00501m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00501m3_negative(save_xml):
     """
     fixed value is invalid for the local type definition (valid schema) If
@@ -6637,11 +7018,12 @@ def test_valueconstraint00501m3_negative(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00501m/valueConstraint00501m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00501m2_positive(save_xml):
     """
     fixed value is valid (valid schema) If the declaration has a {value
@@ -6659,11 +7041,12 @@ def test_valueconstraint00501m2_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00501m/valueConstraint00501m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00501m1_positive(save_xml):
     """
     fixed value is valid (valid schema) If the declaration has a {value
@@ -6681,11 +7064,12 @@ def test_valueconstraint00501m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00501m/valueConstraint00501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00402m9_positive(save_xml):
     """
     fixed value is set for anySimpleType (valid schema) Declare an
@@ -6698,11 +7082,12 @@ def test_valueconstraint00402m9_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00402m/valueConstraint00402m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00402m7_positive(save_xml):
     """
     fixed value is set for a simple type (valid schema) Declare an
@@ -6716,11 +7101,12 @@ def test_valueconstraint00402m7_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00402m/valueConstraint00402m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00402m5_positive(save_xml):
     """
     fixed value is set for a complex type with a simple content (valid
@@ -6734,11 +7120,12 @@ def test_valueconstraint00402m5_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00402m/valueConstraint00402m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00402m4_positive(save_xml):
     """
     fixed value is set for anyType (valid schema) Declare an element. Set
@@ -6751,11 +7138,12 @@ def test_valueconstraint00402m4_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00402m/valueConstraint00402m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00402m3_positive(save_xml):
     """
     fixed value is set for ur-type (valid schema) Declare an element. Set
@@ -6768,11 +7156,12 @@ def test_valueconstraint00402m3_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00402m/valueConstraint00402m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00402m1_positive(save_xml):
     """
     fixed value is set for type boolean (valid schema) Declare an element.
@@ -6785,11 +7174,12 @@ def test_valueconstraint00402m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00402m/valueConstraint00402m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00401m9_positive(save_xml):
     """
     default value is set for anySimpleType (valid schema) Declare an
@@ -6802,11 +7192,12 @@ def test_valueconstraint00401m9_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00401m/valueConstraint00401m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00401m7_positive(save_xml):
     """
     default value is set for a simple type (valid schema) Declare an
@@ -6820,11 +7211,12 @@ def test_valueconstraint00401m7_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00401m/valueConstraint00401m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00401m5_positive(save_xml):
     """
     default value is set for a complex type with a simple content (valid
@@ -6838,11 +7230,12 @@ def test_valueconstraint00401m5_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00401m/valueConstraint00401m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00401m4_positive(save_xml):
     """
     default value is set for anyType (valid schema) Declare an element.
@@ -6855,11 +7248,12 @@ def test_valueconstraint00401m4_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00401m/valueConstraint00401m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00401m3_positive(save_xml):
     """
     default value is set for ur-type (valid schema) Declare an element.
@@ -6872,11 +7266,12 @@ def test_valueconstraint00401m3_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00401m/valueConstraint00401m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00401m1_positive(save_xml):
     """
     default value is set for type boolean (valid schema) Declare an
@@ -6889,11 +7284,12 @@ def test_valueconstraint00401m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00401m/valueConstraint00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00301m2_positive(save_xml):
     """
     only fixed is present (valid schema) Define an element. Set fixed="0".
@@ -6905,11 +7301,12 @@ def test_valueconstraint00301m2_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00301m/valueConstraint00301m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00301m1_positive(save_xml):
     """
     only default is present (valid schema) Define an element. Set
@@ -6922,11 +7319,12 @@ def test_valueconstraint00301m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00301m/valueConstraint00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00201m_value_constraint00201m1_p(save_xml):
     """
     Validation of the fixed value attribute. (valid schema) Define an
@@ -6940,11 +7338,12 @@ def test_valueconstraint00201m_value_constraint00201m1_p(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00201m/valueConstraint00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00201m_value_constraint00201m1_n(save_xml):
     """
     Validation of the fixed value attribute. (valid schema) Define an
@@ -6958,11 +7357,12 @@ def test_valueconstraint00201m_value_constraint00201m1_n(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00201m/valueConstraint00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_valueconstraint00101m1_positive(save_xml):
     """
     Validation of the default value attribute (positive case). (valid
@@ -6975,11 +7375,12 @@ def test_valueconstraint00101m1_positive(save_xml):
         instance="sunData/ElemDecl/valueConstraint/valueConstraint00101m/valueConstraint00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01501m1_positive(save_xml):
     """
     value must be valid with respect to the type definition (valid schema)
@@ -6994,11 +7395,12 @@ def test_typedef01501m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01501m/typeDef01501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01501m1_negative(save_xml):
     """
     value must be valid with respect to the type definition (valid schema)
@@ -7013,11 +7415,12 @@ def test_typedef01501m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01501m/typeDef01501m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01401m1_positive(save_xml):
     """
     normalized value must be valid with respect to the type definition
@@ -7032,11 +7435,12 @@ def test_typedef01401m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01401m/typeDef01401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01401m1_negative(save_xml):
     """
     normalized value must be valid with respect to the type definition
@@ -7051,11 +7455,12 @@ def test_typedef01401m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01401m/typeDef01401m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01301m1_positive(save_xml):
     """
     trying to use element children in the element of a simple type (valid
@@ -7070,11 +7475,12 @@ def test_typedef01301m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01301m/typeDef01301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01301m1_negative(save_xml):
     """
     trying to use element children in the element of a simple type (valid
@@ -7089,11 +7495,12 @@ def test_typedef01301m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01301m/typeDef01301m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01202m1_positive(save_xml):
     """
     element of a simple type has noNamespaceSchemaLocation, type and nil
@@ -7112,11 +7519,12 @@ def test_typedef01202m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01202m/typeDef01202m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01202m1_negative(save_xml):
     """
     element of a simple type has noNamespaceSchemaLocation, type and nil
@@ -7135,11 +7543,12 @@ def test_typedef01202m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01202m/typeDef01202m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01201m1_positive(save_xml):
     """
     element of a simple type has schemaLocation, type and nil attributes
@@ -7158,11 +7567,12 @@ def test_typedef01201m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01201m/typeDef01201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01201m1_negative(save_xml):
     """
     element of a simple type has schemaLocation, type and nil attributes
@@ -7181,11 +7591,12 @@ def test_typedef01201m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01201m/typeDef01201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01101m1_positive(save_xml):
     """
     actual type must not be abstract (valid schema) For an element to be
@@ -7199,11 +7610,12 @@ def test_typedef01101m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01101m/typeDef01101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef01101m1_negative(save_xml):
     """
     actual type must not be abstract (valid schema) For an element to be
@@ -7217,11 +7629,12 @@ def test_typedef01101m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef01101m/typeDef01101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00901m1_positive(save_xml):
     """
     the element information item must be valid with respect to the actual
@@ -7236,11 +7649,12 @@ def test_typedef00901m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00901m/typeDef00901m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00901m1_negative(save_xml):
     """
     the element information item must be valid with respect to the actual
@@ -7255,11 +7669,12 @@ def test_typedef00901m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00901m/typeDef00901m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00802m2_negative(save_xml):
     """
     local type is 'dissalowed' (valid schema) If it is a simple type
@@ -7274,11 +7689,12 @@ def test_typedef00802m2_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00802m/typeDef00802m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00802m1_positive(save_xml):
     """
     local type definition is validly derived from simpleType (valid
@@ -7293,11 +7709,12 @@ def test_typedef00802m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00802m/typeDef00802m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00802m1_negative(save_xml):
     """
     local type definition is validly derived from simpleType (valid
@@ -7312,11 +7729,12 @@ def test_typedef00802m1_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00802m/typeDef00802m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00801m3_negative(save_xml):
     """
     local type is 'dissalowed' (valid schema) If it is a complex type
@@ -7332,11 +7750,12 @@ def test_typedef00801m3_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00801m/typeDef00801m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00801m2_negative(save_xml):
     """
     local type is 'prohibited' (valid schema) If it is a complex type
@@ -7352,11 +7771,12 @@ def test_typedef00801m2_negative(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00801m/typeDef00801m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00801m1_positive(save_xml):
     """
     local type definition is validly derived from complexType (valid
@@ -7372,11 +7792,12 @@ def test_typedef00801m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00801m/typeDef00801m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00701m_type_def00701m1_p(save_xml):
     """
     local name and namespace name of the xsi:type must resolve to a type
@@ -7389,11 +7810,12 @@ def test_typedef00701m_type_def00701m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00701m/typeDef00701m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00701m_type_def00701m1_n(save_xml):
     """
     local name and namespace name of the xsi:type must resolve to a type
@@ -7406,11 +7828,12 @@ def test_typedef00701m_type_def00701m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00701m/typeDef00701m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00601m_type_def00601m1_p(save_xml):
     """
     a normalized value of the type attribute must be valid (valid schema)
@@ -7423,11 +7846,12 @@ def test_typedef00601m_type_def00601m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00601m/typeDef00601m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00502m1_positive(save_xml):
     """
     simpleType and type are mutually exclusive (valid schema) Declare an
@@ -7441,11 +7865,12 @@ def test_typedef00502m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00502m/typeDef00502m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00501m1_positive(save_xml):
     """
     complexType and type are mutually exclusive (valid schema) Declare an
@@ -7459,11 +7884,12 @@ def test_typedef00501m1_positive(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00501m/typeDef00501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00403m_type_def00403m1_p(save_xml):
     """
     Various setting of the {type definition} property. (valid schema) For
@@ -7478,11 +7904,12 @@ def test_typedef00403m_type_def00403m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00403m/typeDef00403m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00402m_type_def00402m1_p(save_xml):
     """
     Eelements within complexType. (valid schema) Eelements within
@@ -7496,11 +7923,12 @@ def test_typedef00402m_type_def00402m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00402m/typeDef00402m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00402m_type_def00402m1_n(save_xml):
     """
     Eelements within complexType. (valid schema) Eelements within
@@ -7514,11 +7942,12 @@ def test_typedef00402m_type_def00402m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00402m/typeDef00402m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00401m_type_def00401m1_p(save_xml):
     """
     Eelements within group. (valid schema) Eelements within  group
@@ -7532,11 +7961,12 @@ def test_typedef00401m_type_def00401m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00401m/typeDef00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00401m_type_def00401m1_n(save_xml):
     """
     Eelements within group. (valid schema) Eelements within  group
@@ -7550,11 +7980,12 @@ def test_typedef00401m_type_def00401m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00401m/typeDef00401m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00301m_type_def00301m1_p(save_xml):
     """
     The {type definition} property is specified by reference. (valid
@@ -7568,11 +7999,12 @@ def test_typedef00301m_type_def00301m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00301m/typeDef00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00301m_type_def00301m1_n(save_xml):
     """
     The {type definition} property is specified by reference. (valid
@@ -7586,11 +8018,12 @@ def test_typedef00301m_type_def00301m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00301m/typeDef00301m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00205m_type_def00205m1_p(save_xml):
     """
     default type is used to define {type definition} property. (valid
@@ -7604,11 +8037,12 @@ def test_typedef00205m_type_def00205m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00205m/typeDef00205m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00204m_type_def00204m1_p(save_xml):
     """
     type attribute is used to define {type definition} property. (valid
@@ -7622,11 +8056,12 @@ def test_typedef00204m_type_def00204m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00204m/typeDef00204m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00204m_type_def00204m1_n(save_xml):
     """
     type attribute is used to define {type definition} property. (valid
@@ -7640,11 +8075,12 @@ def test_typedef00204m_type_def00204m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00204m/typeDef00204m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00203m_type_def00203m1_p(save_xml):
     """
     type attribute is used to define {type definition} property. (valid
@@ -7657,11 +8093,12 @@ def test_typedef00203m_type_def00203m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00203m/typeDef00203m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00203m_type_def00203m1_n(save_xml):
     """
     type attribute is used to define {type definition} property. (valid
@@ -7674,11 +8111,12 @@ def test_typedef00203m_type_def00203m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00203m/typeDef00203m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00202m_type_def00202m1_p(save_xml):
     """
     complexType is used to define {type definition} property. (valid
@@ -7691,11 +8129,12 @@ def test_typedef00202m_type_def00202m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00202m/typeDef00202m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00202m_type_def00202m1_n(save_xml):
     """
     complexType is used to define {type definition} property. (valid
@@ -7708,11 +8147,12 @@ def test_typedef00202m_type_def00202m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00202m/typeDef00202m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00201m_type_def00201m1_p(save_xml):
     """
     simpleType is used to define {type definition} property. (valid
@@ -7725,11 +8165,12 @@ def test_typedef00201m_type_def00201m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00201m/typeDef00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00201m_type_def00201m1_n(save_xml):
     """
     simpleType is used to define {type definition} property. (valid
@@ -7742,11 +8183,12 @@ def test_typedef00201m_type_def00201m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00201m/typeDef00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00101m_type_def00101m1_p(save_xml):
     """
     General check of the {type definition} property. (valid schema) Define
@@ -7759,11 +8201,12 @@ def test_typedef00101m_type_def00101m1_p(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00101m/typeDef00101m1_p.xml",
         instance_is_valid=True,
         class_name="Answer",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_typedef00101m_type_def00101m1_n(save_xml):
     """
     General check of the {type definition} property. (valid schema) Define
@@ -7776,11 +8219,12 @@ def test_typedef00101m_type_def00101m1_n(save_xml):
         instance="sunData/ElemDecl/typeDef/typeDef00101m/typeDef00101m1_n.xml",
         instance_is_valid=False,
         class_name="Answer",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_term00101m_term00101m1_p(save_xml):
     """
     The (top-level) element declaration resolved to by the actual value of
@@ -7795,11 +8239,12 @@ def test_term00101m_term00101m1_p(save_xml):
         instance="sunData/ElemDecl/term/term00101m/term00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_term00101m_term00101m1_n(save_xml):
     """
     The (top-level) element declaration resolved to by the actual value of
@@ -7814,11 +8259,12 @@ def test_term00101m_term00101m1_n(save_xml):
         instance="sunData/ElemDecl/term/term00101m/term00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00402m_target_ns00402m1_p(save_xml):
     """
     Global elements must be qualified. (valid schema) If {target
@@ -7831,11 +8277,12 @@ def test_targetns00402m_target_ns00402m1_p(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00402m/targetNS00402m1_p.xml",
         instance_is_valid=True,
         class_name="GlobalType",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00402m_target_ns00402m1_n(save_xml):
     """
     Global elements must be qualified. (valid schema) If {target
@@ -7848,11 +8295,12 @@ def test_targetns00402m_target_ns00402m1_n(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00402m/targetNS00402m1_n.xml",
         instance_is_valid=False,
         class_name="GlobalType",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00401m_target_ns00401m1_p(save_xml):
     """
     Global elements must be qualified. (valid schema) Element information
@@ -7865,11 +8313,12 @@ def test_targetns00401m_target_ns00401m1_p(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00401m/targetNS00401m1_p.xml",
         instance_is_valid=True,
         class_name="GlobalType",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00401m_target_ns00401m1_n(save_xml):
     """
     Global elements must be qualified. (valid schema) Element information
@@ -7882,11 +8331,12 @@ def test_targetns00401m_target_ns00401m1_n(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00401m/targetNS00401m1_n.xml",
         instance_is_valid=False,
         class_name="GlobalType",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00303m3_positive(save_xml):
     """
     The form attribute is omitted, the elementFormDefault is set to
@@ -7900,11 +8350,12 @@ def test_targetns00303m3_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00303m/targetNS00303m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00303m3_negative(save_xml):
     """
     The form attribute is omitted, the elementFormDefault is set to
@@ -7918,11 +8369,12 @@ def test_targetns00303m3_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00303m/targetNS00303m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00303m2_positive(save_xml):
     """
     The form attribute is set to unqualified, the elementFormDefault is
@@ -7936,11 +8388,12 @@ def test_targetns00303m2_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00303m/targetNS00303m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00303m2_negative(save_xml):
     """
     The form attribute is set to unqualified, the elementFormDefault is
@@ -7954,11 +8407,12 @@ def test_targetns00303m2_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00303m/targetNS00303m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00303m1_positive(save_xml):
     """
     The form attribute is set to qualified, the elementFormDefault is set
@@ -7972,11 +8426,12 @@ def test_targetns00303m1_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00303m/targetNS00303m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00303m1_negative(save_xml):
     """
     The form attribute is set to qualified, the elementFormDefault is set
@@ -7990,11 +8445,12 @@ def test_targetns00303m1_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00303m/targetNS00303m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00302m3_positive(save_xml):
     """
     The form attribute is omitted, the elementFormDefault is set to
@@ -8008,11 +8464,12 @@ def test_targetns00302m3_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00302m/targetNS00302m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00302m3_negative(save_xml):
     """
     The form attribute is omitted, the elementFormDefault is set to
@@ -8026,11 +8483,12 @@ def test_targetns00302m3_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00302m/targetNS00302m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00302m2_positive(save_xml):
     """
     The form attribute is set to unqualified, the elementFormDefault is
@@ -8044,11 +8502,12 @@ def test_targetns00302m2_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00302m/targetNS00302m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00302m2_negative(save_xml):
     """
     The form attribute is set to unqualified, the elementFormDefault is
@@ -8062,11 +8521,12 @@ def test_targetns00302m2_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00302m/targetNS00302m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00302m1_positive(save_xml):
     """
     The form attribute is set to qualified, the elementFormDefault is set
@@ -8080,11 +8540,12 @@ def test_targetns00302m1_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00302m/targetNS00302m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00302m1_negative(save_xml):
     """
     The form attribute is set to qualified, the elementFormDefault is set
@@ -8098,11 +8559,12 @@ def test_targetns00302m1_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00302m/targetNS00302m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00301m3_positive(save_xml):
     """
     Both the form and elementFormDefault attributes are omitted.  (valid
@@ -8115,11 +8577,12 @@ def test_targetns00301m3_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00301m/targetNS00301m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00301m3_negative(save_xml):
     """
     Both the form and elementFormDefault attributes are omitted.  (valid
@@ -8132,11 +8595,12 @@ def test_targetns00301m3_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00301m/targetNS00301m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00301m2_positive(save_xml):
     """
     The form attribute is set to unqualified. The elementFormDefault
@@ -8150,11 +8614,12 @@ def test_targetns00301m2_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00301m/targetNS00301m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00301m2_negative(save_xml):
     """
     The form attribute is set to unqualified. The elementFormDefault
@@ -8168,11 +8633,12 @@ def test_targetns00301m2_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00301m/targetNS00301m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00301m1_positive(save_xml):
     """
     The form attribute is set to qualified. The elementFormDefault
@@ -8186,11 +8652,12 @@ def test_targetns00301m1_positive(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00301m/targetNS00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00301m1_negative(save_xml):
     """
     The form attribute is set to qualified. The elementFormDefault
@@ -8204,11 +8671,12 @@ def test_targetns00301m1_negative(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00301m/targetNS00301m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00201m_target_ns00201m1_p(save_xml):
     """
     Absent values of {target namespace} validate unqualified items. (valid
@@ -8220,11 +8688,12 @@ def test_targetns00201m_target_ns00201m1_p(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00201m/targetNS00201m1_p.xml",
         instance_is_valid=True,
         class_name="Number",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00201m_target_ns00201m1_n(save_xml):
     """
     Absent values of {target namespace} validate unqualified items. (valid
@@ -8236,11 +8705,12 @@ def test_targetns00201m_target_ns00201m1_n(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00201m/targetNS00201m1_n.xml",
         instance_is_valid=False,
         class_name="Number",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_targetns00101m_target_ns00101m1_p_469(save_xml):
     """
@@ -8256,11 +8726,12 @@ def test_targetns00101m_target_ns00101m1_p_469(save_xml):
         instance="sunData/ElemDecl/targetNS/targetNS00101m/targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="Number",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00402m7_positive(save_xml):
     """
     Various subsets of values for the final attribute. (valid schema)
@@ -8273,11 +8744,12 @@ def test_substgrpexcl00402m7_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00402m/substGrpExcl00402m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00401m6_positive(save_xml):
     """
     Rule out restriction extension (valid schema) Set finalDefault
@@ -8289,11 +8761,12 @@ def test_substgrpexcl00401m6_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00401m/substGrpExcl00401m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00401m5_positive(save_xml):
     """
     Rule out extension restriction (valid schema) Set finalDefault
@@ -8305,11 +8778,12 @@ def test_substgrpexcl00401m5_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00401m/substGrpExcl00401m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00401m4_positive(save_xml):
     """
     Rule out extension (valid schema) Set finalDefault attribute to
@@ -8321,11 +8795,12 @@ def test_substgrpexcl00401m4_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00401m/substGrpExcl00401m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00401m3_positive(save_xml):
     """
     Rule out restriction (valid schema) Set finalDefault attribute to
@@ -8337,11 +8812,12 @@ def test_substgrpexcl00401m3_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00401m/substGrpExcl00401m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00401m2_positive(save_xml):
     """
     Rule out #all (valid schema) Set finalDefault attribute to "#all"
@@ -8352,11 +8828,12 @@ def test_substgrpexcl00401m2_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00401m/substGrpExcl00401m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00401m1_positive(save_xml):
     """
     Rule out nothing (valid schema) Omit the finalDefault attribute.
@@ -8367,11 +8844,12 @@ def test_substgrpexcl00401m1_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00401m/substGrpExcl00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00303m3_positive(save_xml):
     """
     Rule out both restriction and extension substitutions (positive case).
@@ -8390,11 +8868,12 @@ def test_substgrpexcl00303m3_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00303m/substGrpExcl00303m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00303m1_positive(save_xml):
     """
     Rule out both restriction and extension substitutions (positive case).
@@ -8413,11 +8892,12 @@ def test_substgrpexcl00303m1_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00303m/substGrpExcl00303m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00301m3_positive(save_xml):
     """
     Rule out both restriction and extension substitutions (positive case).
@@ -8435,11 +8915,12 @@ def test_substgrpexcl00301m3_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00301m/substGrpExcl00301m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00301m1_positive(save_xml):
     """
     Rule out both restriction and extension substitutions (positive case).
@@ -8457,11 +8938,12 @@ def test_substgrpexcl00301m1_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00301m/substGrpExcl00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpexcl00202m1_positive(save_xml):
     """
     Rule out extension substitutions (positive case). (valid schema)
@@ -8479,11 +8961,12 @@ def test_substgrpexcl00202m1_positive(save_xml):
         instance="sunData/ElemDecl/substGroupExclusions/substGrpExcl00202m/substGrpExcl00202m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpaffil00201m_subst_grp_affil00201m1_p(save_xml):
     """
     Substitution group memebership is transitive but not symmetric. (valid
@@ -8500,11 +8983,12 @@ def test_substgrpaffil00201m_subst_grp_affil00201m1_p(save_xml):
         instance="sunData/ElemDecl/substGroupAffilation/substGrpAffil00201m/substGrpAffil00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpaffil00201m_subst_grp_affil00201m1_n(save_xml):
     """
     Substitution group memebership is transitive but not symmetric. (valid
@@ -8521,11 +9005,12 @@ def test_substgrpaffil00201m_subst_grp_affil00201m1_n(save_xml):
         instance="sunData/ElemDecl/substGroupAffilation/substGrpAffil00201m/substGrpAffil00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpaffil00101m_subst_grp_affil00101m1_p(save_xml):
     """
     General check of the {substitution group affiliation} property. (valid
@@ -8538,11 +9023,12 @@ def test_substgrpaffil00101m_subst_grp_affil00101m1_p(save_xml):
         instance="sunData/ElemDecl/substGroupAffilation/substGrpAffil00101m/substGrpAffil00101m1_p.xml",
         instance_is_valid=True,
         class_name="BookStore",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_substgrpaffil00101m_subst_grp_affil00101m1_n(save_xml):
     """
     General check of the {substitution group affiliation} property. (valid
@@ -8555,11 +9041,12 @@ def test_substgrpaffil00101m_subst_grp_affil00101m1_n(save_xml):
         instance="sunData/ElemDecl/substGroupAffilation/substGrpAffil00101m/substGrpAffil00101m1_n.xml",
         instance_is_valid=False,
         class_name="BookStore",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_scope00301m_scope00301m1_p(save_xml):
     """
     Scope of a named group. (valid schema) Define a group with two
@@ -8572,11 +9059,12 @@ def test_scope00301m_scope00301m1_p(save_xml):
         instance="sunData/ElemDecl/scope/scope00301m/scope00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_scope00201m1_positive(save_xml):
     """
     Locally scoped element (positive case). (valid schema) Using localy
@@ -8588,11 +9076,12 @@ def test_scope00201m1_positive(save_xml):
         instance="sunData/ElemDecl/scope/scope00201m/scope00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_scope00101m_scope00101m1_p(save_xml):
     """
     General check of the {scope} property. (valid schema) Define one
@@ -8604,11 +9093,12 @@ def test_scope00101m_scope00101m1_p(save_xml):
         instance="sunData/ElemDecl/scope/scope00101m/scope00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00401m2_positive(save_xml):
     """
     there may be a fixed {value constraint} along with nillable set to
@@ -8621,11 +9111,12 @@ def test_nillable00401m2_positive(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00401m/nillable00401m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00401m1_positive(save_xml):
     """
     there may be a fixed {value constraint} along with nillable set to
@@ -8638,11 +9129,12 @@ def test_nillable00401m1_positive(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00401m/nillable00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00302m_nillable00302m1_p(save_xml):
     """
     the element information item must have no element information children
@@ -8656,11 +9148,12 @@ def test_nillable00302m_nillable00302m1_p(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00302m/nillable00302m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00302m_nillable00302m1_n(save_xml):
     """
     the element information item must have no element information children
@@ -8674,11 +9167,12 @@ def test_nillable00302m_nillable00302m1_n(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00302m/nillable00302m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00301m_nillable00301m1_p(save_xml):
     """
     the element information item must have no character if nil is
@@ -8692,11 +9186,12 @@ def test_nillable00301m_nillable00301m1_p(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00301m/nillable00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00301m_nillable00301m1_n(save_xml):
     """
     the element information item must have no character if nil is
@@ -8710,11 +9205,12 @@ def test_nillable00301m_nillable00301m1_n(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00301m/nillable00301m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00201m_nillable00201m1_n(save_xml):
     """
     nillable=false and xsi:nil=true (valid schema) Declare a non-nillable
@@ -8726,11 +9222,12 @@ def test_nillable00201m_nillable00201m1_n(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00201m/nillable00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00201m_nillable00201m2_n(save_xml):
     """
     nillable=false and xsi:nil=true (valid schema) Declare a non-nillable
@@ -8742,11 +9239,12 @@ def test_nillable00201m_nillable00201m2_n(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00201m/nillable00201m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00201m_nillable00201m3_p(save_xml):
     """
     nillable=false and xsi:nil=true (valid schema) Declare a non-nillable
@@ -8758,11 +9256,12 @@ def test_nillable00201m_nillable00201m3_p(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00201m/nillable00201m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00102m_nillable00102m1_p(save_xml):
     """
     xsi:nil=false (valid schema) Define nillable element with content type
@@ -8775,11 +9274,12 @@ def test_nillable00102m_nillable00102m1_p(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00102m/nillable00102m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00102m_nillable00102m1_n(save_xml):
     """
     xsi:nil=false (valid schema) Define nillable element with content type
@@ -8792,11 +9292,12 @@ def test_nillable00102m_nillable00102m1_n(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00102m/nillable00102m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00101m2_negative(save_xml):
     """
     nillable=false (negative case) (valid schema) Define nillable element
@@ -8809,11 +9310,12 @@ def test_nillable00101m2_negative(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00101m/nillable00101m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nillable00101m1_positive(save_xml):
     """
     nillable=false (positive case) (valid schema) Define nillable element
@@ -8826,11 +9328,12 @@ def test_nillable00101m1_positive(save_xml):
         instance="sunData/ElemDecl/nillable/nillable00101m/nillable00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00805_name00805_p(save_xml):
     """
     Element names contain only punctuation characters and digits. (valid
@@ -8846,11 +9349,12 @@ def test_name00805_name00805_p(save_xml):
         instance="sunData/ElemDecl/name/name008/name00805/name00805_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00804_name00804_p(save_xml):
     """
     Element names contain lower case and upper case letters and non-letter
@@ -8871,11 +9375,12 @@ def test_name00804_name00804_p(save_xml):
         instance="sunData/ElemDecl/name/name008/name00804/name00804_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00803_name00803_p(save_xml):
     """
     Element names contain digits followed by a non-digit characters.
@@ -8891,11 +9396,12 @@ def test_name00803_name00803_p(save_xml):
         instance="sunData/ElemDecl/name/name008/name00803/name00803_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00802_name00802_p(save_xml):
     r"""
     Element name contains 7 punctuation characters. (valid schema) Declare
@@ -8916,11 +9422,12 @@ def test_name00802_name00802_p(save_xml):
         instance="sunData/ElemDecl/name/name008/name00802/name00802_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00801_name00801_p(save_xml):
     r"""
     Element names contain several punctuation characters. (valid schema)
@@ -8940,11 +9447,12 @@ def test_name00801_name00801_p(save_xml):
         instance="sunData/ElemDecl/name/name008/name00801/name00801_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00601m_name00601m1_p(save_xml):
     """
     The declaration must not be absent (valid schema) Declare an element
@@ -8958,11 +9466,12 @@ def test_name00601m_name00601m1_p(save_xml):
         instance="sunData/ElemDecl/name/name00601m/name00601m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00601m_name00601m1_n(save_xml):
     """
     The declaration must not be absent (valid schema) Declare an element
@@ -8976,11 +9485,12 @@ def test_name00601m_name00601m1_n(save_xml):
         instance="sunData/ElemDecl/name/name00601m/name00601m1_n.xml",
         instance_is_valid=False,
         class_name="Toor",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00505m1_positive(save_xml):
     """
     element declaration with keyref (valid schema) Declare an element with
@@ -8993,11 +9503,12 @@ def test_name00505m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00505m/name00505m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00504m3_positive(save_xml):
     """
     element declaration with unique (valid schema) Declare an element with
@@ -9010,11 +9521,12 @@ def test_name00504m3_positive(save_xml):
         instance="sunData/ElemDecl/name/name00504m/name00504m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00504m1_positive(save_xml):
     """
     element declaration with key (valid schema) Declare an element with
@@ -9027,11 +9539,12 @@ def test_name00504m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00504m/name00504m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00503m1_positive(save_xml):
     """
     element declaration with simple type (valid schema) Declare an element
@@ -9044,11 +9557,12 @@ def test_name00503m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00503m/name00503m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00502m1_positive(save_xml):
     """
     element declaration with complex type (valid schema) Declare an
@@ -9061,11 +9575,12 @@ def test_name00502m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00502m/name00502m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m9_positive(save_xml):
     """
     block is present (valid schema) Declare an element. Set name ="Local"
@@ -9078,11 +9593,12 @@ def test_name00501m9_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m7_positive(save_xml):
     """
     form is present (valid schema) Declare an element. Set name ="Local"
@@ -9095,11 +9611,12 @@ def test_name00501m7_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m5_positive(save_xml):
     """
     fixed is present (valid schema) Declare an element. Set name ="Local"
@@ -9112,11 +9629,12 @@ def test_name00501m5_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m3_positive(save_xml):
     """
     default is present (valid schema) Declare an element. Set name
@@ -9129,11 +9647,12 @@ def test_name00501m3_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m15_positive(save_xml):
     """
     id and ref are present (valid schema) Declare an element. Set
@@ -9146,11 +9665,12 @@ def test_name00501m15_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m15_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m14_positive(save_xml):
     """
     maxOccurs and ref are present (valid schema) Declare an element. Set
@@ -9163,11 +9683,12 @@ def test_name00501m14_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m14_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m13_positive(save_xml):
     """
     minOccurs and ref are present (valid schema) Declare an element. Set
@@ -9180,11 +9701,12 @@ def test_name00501m13_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m13_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m11_positive(save_xml):
     """
     type is present (valid schema) Declare an element. Set name ="Local"
@@ -9197,11 +9719,12 @@ def test_name00501m11_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m11_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00501m1_positive(save_xml):
     """
     nillable is present (valid schema) Declare an element. Set name
@@ -9214,11 +9737,12 @@ def test_name00501m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00501m/name00501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00401m2_positive(save_xml):
     """
     the root attribute is set (valid schema) Declare an element. Set
@@ -9231,11 +9755,12 @@ def test_name00401m2_positive(save_xml):
         instance="sunData/ElemDecl/name/name00401m/name00401m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00401m1_positive(save_xml):
     """
     the name attribute is set (valid schema) Declare an element. Set
@@ -9248,11 +9773,12 @@ def test_name00401m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00401m/name00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00301m1_positive(save_xml):
     """
     Local element names do not clash. (valid schema) Declare two local
@@ -9265,11 +9791,12 @@ def test_name00301m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00301m/name00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00201m2_positive(save_xml):
     """
     simpleType definitions and element  declarations have different symbol
@@ -9283,11 +9810,12 @@ def test_name00201m2_positive(save_xml):
         instance="sunData/ElemDecl/name/name00201m/name00201m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00201m1_positive(save_xml):
     """
     complexType definitions and element  declarations have different
@@ -9301,11 +9829,12 @@ def test_name00201m1_positive(save_xml):
         instance="sunData/ElemDecl/name/name00201m/name00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m_name00101m1_p_528(save_xml):
     """
     General check of the {name} property. (valid schema) Define two
@@ -9318,11 +9847,12 @@ def test_name00101m_name00101m1_p_528(save_xml):
         instance="sunData/ElemDecl/name/name00101m/name00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m_name00101m1_n_529(save_xml):
     """
     General check of the {name} property. (valid schema) Define two
@@ -9335,11 +9865,12 @@ def test_name00101m_name00101m1_n_529(save_xml):
         instance="sunData/ElemDecl/name/name00101m/name00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_minoccurs00201m_min_occurs00201m1_p(save_xml):
     """
     Default value of the {minOccurs} property when the ref attribute is
@@ -9353,11 +9884,12 @@ def test_minoccurs00201m_min_occurs00201m1_p(save_xml):
         instance="sunData/ElemDecl/minOccurs/minOccurs00201m/minOccurs00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_minoccurs00201m_min_occurs00201m1_n(save_xml):
     """
     Default value of the {minOccurs} property when the ref attribute is
@@ -9371,11 +9903,12 @@ def test_minoccurs00201m_min_occurs00201m1_n(save_xml):
         instance="sunData/ElemDecl/minOccurs/minOccurs00201m/minOccurs00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_minoccurs00101m_min_occurs00101m1_p(save_xml):
     """
     Default value of the {minOccurs} property. (valid schema) Define one
@@ -9388,11 +9921,12 @@ def test_minoccurs00101m_min_occurs00101m1_p(save_xml):
         instance="sunData/ElemDecl/minOccurs/minOccurs00101m/minOccurs00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_minoccurs00101m_min_occurs00101m1_n(save_xml):
     """
     Default value of the {minOccurs} property. (valid schema) Define one
@@ -9405,11 +9939,12 @@ def test_minoccurs00101m_min_occurs00101m1_n(save_xml):
         instance="sunData/ElemDecl/minOccurs/minOccurs00101m/minOccurs00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_maxoccurs00201m_max_occurs00201m1_p(save_xml):
     """
     Default value of the {maxOccurs} property when the ref attribute is
@@ -9423,11 +9958,12 @@ def test_maxoccurs00201m_max_occurs00201m1_p(save_xml):
         instance="sunData/ElemDecl/maxOccurs/maxOccurs00201m/maxOccurs00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_maxoccurs00201m_max_occurs00201m1_n(save_xml):
     """
     Default value of the {maxOccurs} property when the ref attribute is
@@ -9441,11 +9977,12 @@ def test_maxoccurs00201m_max_occurs00201m1_n(save_xml):
         instance="sunData/ElemDecl/maxOccurs/maxOccurs00201m/maxOccurs00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_maxoccurs00101m_max_occurs00101m1_p(save_xml):
     """
     Default value of the {maxOccurs} property. (valid schema) Define one
@@ -9458,11 +9995,12 @@ def test_maxoccurs00101m_max_occurs00101m1_p(save_xml):
         instance="sunData/ElemDecl/maxOccurs/maxOccurs00101m/maxOccurs00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_maxoccurs00101m_max_occurs00101m1_n(save_xml):
     """
     Default value of the {maxOccurs} property. (valid schema) Define one
@@ -9475,11 +10013,12 @@ def test_maxoccurs00101m_max_occurs00101m1_n(save_xml):
         instance="sunData/ElemDecl/maxOccurs/maxOccurs00101m/maxOccurs00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00501m_id_constr_defs00501m1_p(save_xml):
     """
     there must be no multiply-defined ID (valid schema) Declare an
@@ -9493,11 +10032,12 @@ def test_idconstrdefs00501m_id_constr_defs00501m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00501m/idConstrDefs00501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00501m_id_constr_defs00501m1_n(save_xml):
     """
     there must be no multiply-defined ID (valid schema) Declare an
@@ -9511,11 +10051,12 @@ def test_idconstrdefs00501m_id_constr_defs00501m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00501m/idConstrDefs00501m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00403m_id_constr_defs00403m1_p(save_xml):
     """
     derived IDREFS must refer to IDs that are defined (valid schema)
@@ -9530,11 +10071,12 @@ def test_idconstrdefs00403m_id_constr_defs00403m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00403m/idConstrDefs00403m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00403m_id_constr_defs00403m1_n(save_xml):
     """
     derived IDREFS must refer to IDs that are defined (valid schema)
@@ -9549,11 +10091,12 @@ def test_idconstrdefs00403m_id_constr_defs00403m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00403m/idConstrDefs00403m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00402m_id_constr_defs00402m1_p(save_xml):
     """
     derived IDREF must refer to an ID that is defined (valid schema)
@@ -9568,11 +10111,12 @@ def test_idconstrdefs00402m_id_constr_defs00402m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00402m/idConstrDefs00402m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00402m_id_constr_defs00402m1_n(save_xml):
     """
     derived IDREF must refer to an ID that is defined (valid schema)
@@ -9587,11 +10131,12 @@ def test_idconstrdefs00402m_id_constr_defs00402m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00402m/idConstrDefs00402m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00401m_id_constr_defs00401m1_p(save_xml):
     """
     derived IDREF must refer to an ID that is defined (cyclic) (valid
@@ -9607,11 +10152,12 @@ def test_idconstrdefs00401m_id_constr_defs00401m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00401m/idConstrDefs00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00302m_id_constr_defs00302m1_p(save_xml):
     """
     all attributes of type ID, IDREF, IDREFS are valid (valid schema) All
@@ -9623,11 +10169,12 @@ def test_idconstrdefs00302m_id_constr_defs00302m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00302m/idConstrDefs00302m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00302m_id_constr_defs00302m2_n(save_xml):
     """
     all attributes of type ID, IDREF, IDREFS are valid (valid schema) All
@@ -9639,11 +10186,12 @@ def test_idconstrdefs00302m_id_constr_defs00302m2_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00302m/idConstrDefs00302m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00302m_id_constr_defs00302m3_n(save_xml):
     """
     all attributes of type ID, IDREF, IDREFS are valid (valid schema) All
@@ -9655,11 +10203,12 @@ def test_idconstrdefs00302m_id_constr_defs00302m3_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00302m/idConstrDefs00302m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00302m_id_constr_defs00302m4_n(save_xml):
     """
     all attributes of type ID, IDREF, IDREFS are valid (valid schema) All
@@ -9671,11 +10220,12 @@ def test_idconstrdefs00302m_id_constr_defs00302m4_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00302m/idConstrDefs00302m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00301m_id_constr_defs00301m1_p(save_xml):
     """
     all ID, IDREF, IDREFS are valid (valid schema) All ID, IDREF and
@@ -9687,11 +10237,12 @@ def test_idconstrdefs00301m_id_constr_defs00301m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00301m/idConstrDefs00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00301m_id_constr_defs00301m2_n(save_xml):
     """
     all ID, IDREF, IDREFS are valid (valid schema) All ID, IDREF and
@@ -9703,11 +10254,12 @@ def test_idconstrdefs00301m_id_constr_defs00301m2_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00301m/idConstrDefs00301m2_n.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00301m_id_constr_defs00301m3_n(save_xml):
     """
     all ID, IDREF, IDREFS are valid (valid schema) All ID, IDREF and
@@ -9719,11 +10271,12 @@ def test_idconstrdefs00301m_id_constr_defs00301m3_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00301m/idConstrDefs00301m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00301m_id_constr_defs00301m4_n(save_xml):
     """
     all ID, IDREF, IDREFS are valid (valid schema) All ID, IDREF and
@@ -9735,11 +10288,12 @@ def test_idconstrdefs00301m_id_constr_defs00301m4_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00301m/idConstrDefs00301m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00204m_id_constr_defs00204m1_p(save_xml):
     """
     keyref must refer to a key that is defined (valid schema) Define a key
@@ -9753,11 +10307,12 @@ def test_idconstrdefs00204m_id_constr_defs00204m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00204m/idConstrDefs00204m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00204m_id_constr_defs00204m1_n(save_xml):
     """
     keyref must refer to a key that is defined (valid schema) Define a key
@@ -9771,11 +10326,12 @@ def test_idconstrdefs00204m_id_constr_defs00204m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00204m/idConstrDefs00204m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00203m_id_constr_defs00203m1_p(save_xml):
     """
     there must be no uniqueness violations (valid schema) Define a
@@ -9789,11 +10345,12 @@ def test_idconstrdefs00203m_id_constr_defs00203m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00203m/idConstrDefs00203m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00203m_id_constr_defs00203m1_n(save_xml):
     """
     there must be no uniqueness violations (valid schema) Define a
@@ -9807,11 +10364,12 @@ def test_idconstrdefs00203m_id_constr_defs00203m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00203m/idConstrDefs00203m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00202m_id_constr_defs00202m1_p(save_xml):
     """
     there must be no multiply-defined ID (valid schema) Define a key
@@ -9825,11 +10383,12 @@ def test_idconstrdefs00202m_id_constr_defs00202m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00202m/idConstrDefs00202m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00202m_id_constr_defs00202m1_n(save_xml):
     """
     there must be no multiply-defined ID (valid schema) Define a key
@@ -9843,11 +10402,12 @@ def test_idconstrdefs00202m_id_constr_defs00202m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00202m/idConstrDefs00202m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00201m_id_constr_defs00201m1_p(save_xml):
     """
     all kinds of identity constraint are not violated (valid schema)
@@ -9860,11 +10420,12 @@ def test_idconstrdefs00201m_id_constr_defs00201m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00201m/idConstrDefs00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00201m_id_constr_defs00201m2_n(save_xml):
     """
     all kinds of identity constraint are not violated (valid schema)
@@ -9877,11 +10438,12 @@ def test_idconstrdefs00201m_id_constr_defs00201m2_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00201m/idConstrDefs00201m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00201m_id_constr_defs00201m3_n(save_xml):
     """
     all kinds of identity constraint are not violated (valid schema)
@@ -9894,11 +10456,12 @@ def test_idconstrdefs00201m_id_constr_defs00201m3_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00201m/idConstrDefs00201m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00201m_id_constr_defs00201m4_n(save_xml):
     """
     all kinds of identity constraint are not violated (valid schema)
@@ -9911,11 +10474,12 @@ def test_idconstrdefs00201m_id_constr_defs00201m4_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00201m/idConstrDefs00201m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00101m_id_constr_defs00101m1_p(save_xml):
     """
     Uniqueness among values of elements. (valid schema) Define and check a
@@ -9927,11 +10491,12 @@ def test_idconstrdefs00101m_id_constr_defs00101m1_p(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00101m/idConstrDefs00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_idconstrdefs00101m_id_constr_defs00101m1_n(save_xml):
     """
     Uniqueness among values of elements. (valid schema) Define and check a
@@ -9943,11 +10508,12 @@ def test_idconstrdefs00101m_id_constr_defs00101m1_n(save_xml):
         instance="sunData/ElemDecl/identityConstraintDefs/idConstrDefs00101m/idConstrDefs00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00503m5_negative(save_xml):
     """
     derived by restriction: prohibiting substitutions contains '#all'
@@ -9962,11 +10528,12 @@ def test_disallowedsubst00503m5_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00503m/disallowedSubst00503m5_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00503m4_negative(save_xml):
     """
     derived by restriction: prohibiting substitutions contains
@@ -9982,11 +10549,12 @@ def test_disallowedsubst00503m4_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00503m/disallowedSubst00503m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00503m3_negative(save_xml):
     """
     derived by restriction: prohibiting substitutions contains
@@ -10002,11 +10570,12 @@ def test_disallowedsubst00503m3_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00503m/disallowedSubst00503m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00503m2_positive(save_xml):
     """
     derived by restriction: prohibiting substitutions contains 'extension'
@@ -10021,11 +10590,12 @@ def test_disallowedsubst00503m2_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00503m/disallowedSubst00503m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00503m1_positive(save_xml):
     """
     derived by restriction: prohibiting substitutions is empty (valid
@@ -10040,11 +10610,12 @@ def test_disallowedsubst00503m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00503m/disallowedSubst00503m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00502m4_negative(save_xml):
     """
     complex type substitution: extension and restriction are blocked
@@ -10060,11 +10631,12 @@ def test_disallowedsubst00502m4_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00502m/disallowedSubst00502m4_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00502m3_negative(save_xml):
     """
     complex type substitution: extension is blocked (valid schema) Two
@@ -10079,11 +10651,12 @@ def test_disallowedsubst00502m3_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00502m/disallowedSubst00502m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00502m2_positive(save_xml):
     """
     complex type substitution: restriction is blocked (valid schema) Two
@@ -10098,11 +10671,12 @@ def test_disallowedsubst00502m2_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00502m/disallowedSubst00502m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00502m1_positive(save_xml):
     """
     complex type substitution: no blocking constraints (valid schema) Two
@@ -10117,11 +10691,12 @@ def test_disallowedsubst00502m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00502m/disallowedSubst00502m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00501m2_negative(save_xml):
     """
     restriction is blocked (valid schema) Two elements are declared. The
@@ -10136,11 +10711,12 @@ def test_disallowedsubst00501m2_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00501m/disallowedSubst00501m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00501m1_positive(save_xml):
     """
     no blocking constraints (valid schema) Two elements are declared. The
@@ -10155,11 +10731,12 @@ def test_disallowedsubst00501m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00501m/disallowedSubst00501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00401m2_negative(save_xml):
     """
     substitution is disallowed (valid schema) The blocking constraint must
@@ -10175,11 +10752,12 @@ def test_disallowedsubst00401m2_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00401m/disallowedSubst00401m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00401m1_positive(save_xml):
     """
     substitution is allowed (valid schema) The blocking constraint must
@@ -10195,11 +10773,12 @@ def test_disallowedsubst00401m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00401m/disallowedSubst00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00301m2_negative(save_xml):
     """
     substitution is disallowed (valid schema) The blocking constraint must
@@ -10215,11 +10794,12 @@ def test_disallowedsubst00301m2_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00301m/disallowedSubst00301m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00301m1_positive(save_xml):
     """
     substitution is allowed (valid schema) The blocking constraint must
@@ -10235,11 +10815,12 @@ def test_disallowedsubst00301m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00301m/disallowedSubst00301m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00202m12_positive(save_xml):
     """
     Various subsets of blocking values. (valid schema) Various subsets of
@@ -10252,11 +10833,12 @@ def test_disallowedsubst00202m12_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00202m/disallowedSubst00202m12_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00106m2_negative(save_xml):
     """
     Blocking any extension (negative case) (valid schema) Define an
@@ -10272,11 +10854,12 @@ def test_disallowedsubst00106m2_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00106m/disallowedSubst00106m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00106m1_positive(save_xml):
     """
     Blocking any extension (positive case) (valid schema) Define an
@@ -10292,11 +10875,12 @@ def test_disallowedsubst00106m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00106m/disallowedSubst00106m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00105m_disallowed_subst00105m1_p(save_xml):
     """
     Blocking any extension. (valid schema) Define an element within a
@@ -10312,11 +10896,12 @@ def test_disallowedsubst00105m_disallowed_subst00105m1_p(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00105m/disallowedSubst00105m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00105m_disallowed_subst00105m1_n(save_xml):
     """
     Blocking any extension. (valid schema) Define an element within a
@@ -10332,11 +10917,12 @@ def test_disallowedsubst00105m_disallowed_subst00105m1_n(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00105m/disallowedSubst00105m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00102m2_negative(save_xml):
     """
     Blocking any substitution (negative case) (valid schema) Define an
@@ -10351,11 +10937,12 @@ def test_disallowedsubst00102m2_negative(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00102m/disallowedSubst00102m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00102m1_positive(save_xml):
     """
     Blocking any substitution (positive case) (valid schema) Define an
@@ -10370,11 +10957,12 @@ def test_disallowedsubst00102m1_positive(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00102m/disallowedSubst00102m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00101m_disallowed_subst00101m1_p(save_xml):
     """
     Blocking any substitution. (valid schema) Define an element within a
@@ -10389,11 +10977,12 @@ def test_disallowedsubst00101m_disallowed_subst00101m1_p(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00101m/disallowedSubst00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_disallowedsubst00101m_disallowed_subst00101m1_n(save_xml):
     """
     Blocking any substitution. (valid schema) Define an element within a
@@ -10408,11 +10997,12 @@ def test_disallowedsubst00101m_disallowed_subst00101m1_n(save_xml):
         instance="sunData/ElemDecl/disallowedSubst/disallowedSubst00101m/disallowedSubst00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m3_positive(save_xml):
     """
     machine-targeted  annotation for element declaration (valid schema)
@@ -10427,11 +11017,12 @@ def test_annotation00101m3_positive(save_xml):
         instance="sunData/ElemDecl/annotation/annotation00101m/annotation00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_590(save_xml):
     """
     human-targeted  annotation for element declaration (valid schema)
@@ -10446,11 +11037,12 @@ def test_annotation00101m1_positive_590(save_xml):
         instance="sunData/ElemDecl/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00201m3_positive(save_xml):
     """
     use default value of the attribute abstract  (valid schema) Declare an
@@ -10463,11 +11055,12 @@ def test_abstract00201m3_positive(save_xml):
         instance="sunData/ElemDecl/abstract/abstract00201m/abstract00201m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00201m2_positive(save_xml):
     """
     use abstarct explicitly set to false  (valid schema) Declare an
@@ -10480,11 +11073,12 @@ def test_abstract00201m2_positive(save_xml):
         instance="sunData/ElemDecl/abstract/abstract00201m/abstract00201m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00201m1_negative(save_xml):
     """
     use abstarct explicitly set to true  (valid schema) Declare an element
@@ -10497,11 +11091,12 @@ def test_abstract00201m1_negative(save_xml):
         instance="sunData/ElemDecl/abstract/abstract00201m/abstract00201m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00101m_abstract00101m1_p(save_xml):
     """
     Abstract declarations may not be used to validate element content.
@@ -10516,11 +11111,12 @@ def test_abstract00101m_abstract00101m1_p(save_xml):
         instance="sunData/ElemDecl/abstract/abstract00101m/abstract00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_abstract00101m_abstract00101m1_n(save_xml):
     """
     Abstract declarations may not be used to validate element content.
@@ -10535,11 +11131,12 @@ def test_abstract00101m_abstract00101m1_n(save_xml):
         instance="sunData/ElemDecl/abstract/abstract00101m/abstract00101m1_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m1_positive(save_xml):
     """
     Identity-constraint definition identities must be unique: different
@@ -10556,11 +11153,12 @@ def test_targetns00101m1_positive(save_xml):
         instance="sunData/IdConstrDefs/targetNS/targetNS00101m/targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00201m1_positive_597(save_xml):
     """
     constraints have separate symbol space (valid schema) With the same
@@ -10574,11 +11172,12 @@ def test_name00201m1_positive_597(save_xml):
         instance="sunData/IdConstrDefs/name/name00201m/name00201m1_p.xml",
         instance_is_valid=True,
         class_name="Name",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m1_positive(save_xml):
     """
     In one namespace Identity-constraint definition names must be unique:
@@ -10594,11 +11193,12 @@ def test_name00101m1_positive(save_xml):
         instance="sunData/IdConstrDefs/name/name00101m/name00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00203m5_negative(save_xml):
     """
     values of the fields are checked for equality:  string(3.0) compares
@@ -10618,11 +11218,12 @@ def test_fields00203m5_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00203m/fields00203m5_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00203m4_positive(save_xml):
     """
     values of the fields are checked for equality:  string(3.0) compares
@@ -10642,11 +11243,12 @@ def test_fields00203m4_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00203m/fields00203m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00203m3_negative(save_xml):
     """
     values of the fields are checked for equality:  decimal(3.0) compares
@@ -10666,11 +11268,12 @@ def test_fields00203m3_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00203m/fields00203m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00203m2_negative(save_xml):
     """
     values of the fields are checked for equality:  decimal(3.0) compares
@@ -10690,11 +11293,12 @@ def test_fields00203m2_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00203m/fields00203m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00203m1_positive(save_xml):
     """
     values of the fields are checked for equality:  decimal(3.0) compares
@@ -10714,11 +11318,12 @@ def test_fields00203m1_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00203m/fields00203m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00202m5_negative(save_xml):
     """
     values of the fields are checked for equality:  string(3.0) compares
@@ -10738,11 +11343,12 @@ def test_fields00202m5_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00202m/fields00202m5_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00202m4_positive(save_xml):
     """
     values of the fields are checked for equality:  string(3.0) compares
@@ -10762,11 +11368,12 @@ def test_fields00202m4_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00202m/fields00202m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_fields00202m3_positive(save_xml):
     """
@@ -10787,11 +11394,12 @@ def test_fields00202m3_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00202m/fields00202m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00202m2_positive(save_xml):
     """
     values of the fields are checked for equality:  string(3.0) compares
@@ -10811,11 +11419,12 @@ def test_fields00202m2_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00202m/fields00202m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00202m1_positive(save_xml):
     """
     values of the fields are checked for equality:  string(3.0) compares
@@ -10835,11 +11444,12 @@ def test_fields00202m1_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00202m/fields00202m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00201m5_negative(save_xml):
     """
     values of the fields are checked for equality:  type is string, values
@@ -10858,11 +11468,12 @@ def test_fields00201m5_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00201m/fields00201m5_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00201m4_positive(save_xml):
     """
     values of the fields are checked for equality:  type is string, values
@@ -10881,11 +11492,12 @@ def test_fields00201m4_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00201m/fields00201m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00201m3_negative(save_xml):
     """
     values of the fields are checked for equality:  type is decimal,
@@ -10904,11 +11516,12 @@ def test_fields00201m3_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00201m/fields00201m3_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00201m2_negative(save_xml):
     """
     values of the fields are checked for equality:  type is decimal,
@@ -10927,11 +11540,12 @@ def test_fields00201m2_negative(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00201m/fields00201m2_n.xml",
         instance_is_valid=False,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00201m1_positive(save_xml):
     """
     values of the fields are checked for equality:  type is decimal,
@@ -10950,11 +11564,12 @@ def test_fields00201m1_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00201m/fields00201m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_fields00101m1_positive(save_xml):
     """
     fields may have different types (valid schema) Define a uniqueness
@@ -10966,11 +11581,12 @@ def test_fields00101m1_positive(save_xml):
         instance="sunData/IdConstrDefs/fields/fields00101m/fields00101m1_p.xml",
         instance_is_valid=True,
         class_name="People",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m4_positive_615(save_xml):
     """
     machine-targeted  annotation for an Identity-constraint Definition
@@ -10985,11 +11601,12 @@ def test_annotation00101m4_positive_615(save_xml):
         instance="sunData/IdConstrDefs/annotation/annotation00101m/annotation00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_616(save_xml):
     """
     human-targeted  annotation for an Identity-constraint Definition
@@ -11004,11 +11621,12 @@ def test_annotation00101m1_positive_616(save_xml):
         instance="sunData/IdConstrDefs/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00305m1_positive(save_xml):
     """
     {particles}: 1 <any> (valid schema) The {particles} of 'sequence' must
@@ -11021,11 +11639,12 @@ def test_particles00305m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00305m/particles00305m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00305m1_negative(save_xml):
     """
     {particles}: 1 <any> (valid schema) The {particles} of 'sequence' must
@@ -11038,11 +11657,12 @@ def test_particles00305m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00305m/particles00305m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00304m1_positive(save_xml):
     """
     {particles}: 2 <sequence> (valid schema) The {particles} of 'sequence'
@@ -11055,11 +11675,12 @@ def test_particles00304m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00304m/particles00304m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00304m1_negative(save_xml):
     """
     {particles}: 2 <sequence> (valid schema) The {particles} of 'sequence'
@@ -11072,11 +11693,12 @@ def test_particles00304m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00304m/particles00304m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00303m1_positive(save_xml):
     """
     {particles}: 2 <choice> (valid schema) The {particles} of 'sequence'
@@ -11089,11 +11711,12 @@ def test_particles00303m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00303m/particles00303m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00303m1_negative(save_xml):
     """
     {particles}: 2 <choice> (valid schema) The {particles} of 'sequence'
@@ -11106,11 +11729,12 @@ def test_particles00303m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00303m/particles00303m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00302m1_positive(save_xml):
     """
     {particles}: 2 <group> (valid schema) The {particles} of 'sequence'
@@ -11123,11 +11747,12 @@ def test_particles00302m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00302m/particles00302m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00302m1_negative(save_xml):
     """
     {particles}: 2 <group> (valid schema) The {particles} of 'sequence'
@@ -11140,11 +11765,12 @@ def test_particles00302m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00302m/particles00302m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00301m1_positive(save_xml):
     """
     {particles}: 2 <element> (valid schema) The {particles} of 'sequence'
@@ -11157,11 +11783,12 @@ def test_particles00301m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00301m/particles00301m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00301m1_negative(save_xml):
     """
     {particles}: 2 <element> (valid schema) The {particles} of 'sequence'
@@ -11174,11 +11801,12 @@ def test_particles00301m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00301m/particles00301m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00205m1_positive(save_xml):
     """
     {particles}: 1 <any> (valid schema) The {particles} of 'choice' must
@@ -11191,11 +11819,12 @@ def test_particles00205m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00205m/particles00205m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00205m1_negative(save_xml):
     """
     {particles}: 1 <any> (valid schema) The {particles} of 'choice' must
@@ -11208,11 +11837,12 @@ def test_particles00205m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00205m/particles00205m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00204m1_positive(save_xml):
     """
     {particles}: 2 <sequence> (valid schema) The {particles} of 'choice'
@@ -11225,11 +11855,12 @@ def test_particles00204m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00204m/particles00204m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00204m1_negative(save_xml):
     """
     {particles}: 2 <sequence> (valid schema) The {particles} of 'choice'
@@ -11242,11 +11873,12 @@ def test_particles00204m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00204m/particles00204m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00203m1_positive(save_xml):
     """
     {particles}: 2 <choice> (valid schema) The {particles} of 'choice'
@@ -11259,11 +11891,12 @@ def test_particles00203m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00203m/particles00203m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00203m1_negative(save_xml):
     """
     {particles}: 2 <choice> (valid schema) The {particles} of 'choice'
@@ -11276,11 +11909,12 @@ def test_particles00203m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00203m/particles00203m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00202m1_positive(save_xml):
     """
     {particles}: 2 <group> (valid schema) The {particles} of 'choice' must
@@ -11293,11 +11927,12 @@ def test_particles00202m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00202m/particles00202m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00202m1_negative(save_xml):
     """
     {particles}: 2 <group> (valid schema) The {particles} of 'choice' must
@@ -11310,11 +11945,12 @@ def test_particles00202m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00202m/particles00202m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00201m1_positive(save_xml):
     """
     {particles}: 2 <element> (valid schema) The {particles} of 'choice'
@@ -11327,11 +11963,12 @@ def test_particles00201m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00201m/particles00201m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00201m1_negative(save_xml):
     """
     {particles}: 2 <element> (valid schema) The {particles} of 'choice'
@@ -11344,11 +11981,12 @@ def test_particles00201m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00201m/particles00201m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00101m2_positive(save_xml):
     """
     {particles}: 2 <element> (valid schema) The {particles} of 'all' must
@@ -11360,11 +11998,12 @@ def test_particles00101m2_positive(save_xml):
         instance="sunData/MGroup/particles/particles00101m/particles00101m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00101m2_negative(save_xml):
     """
     {particles}: 2 <element> (valid schema) The {particles} of 'all' must
@@ -11376,11 +12015,12 @@ def test_particles00101m2_negative(save_xml):
         instance="sunData/MGroup/particles/particles00101m/particles00101m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00101m1_positive(save_xml):
     """
     {particles}: 1 <element> (valid schema) The {particles} of 'all' must
@@ -11392,11 +12032,12 @@ def test_particles00101m1_positive(save_xml):
         instance="sunData/MGroup/particles/particles00101m/particles00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_particles00101m1_negative(save_xml):
     """
     {particles}: 1 <element> (valid schema) The {particles} of 'all' must
@@ -11408,11 +12049,12 @@ def test_particles00101m1_negative(save_xml):
         instance="sunData/MGroup/particles/particles00101m/particles00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00203m1_positive(save_xml):
     """
     An empty all (valid schema) The XMLSchema specification allows an
@@ -11424,11 +12066,12 @@ def test_compositor00203m1_positive(save_xml):
         instance="sunData/MGroup/compositor/compositor00203m/compositor00203m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00202m1_positive(save_xml):
     """
     An empty choice (valid schema) The XMLSchema specification allows an
@@ -11440,11 +12083,12 @@ def test_compositor00202m1_positive(save_xml):
         instance="sunData/MGroup/compositor/compositor00202m/compositor00202m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00201m1_positive(save_xml):
     """
     An empty sequence (valid schema) The XMLSchema specification allows an
@@ -11456,11 +12100,12 @@ def test_compositor00201m1_positive(save_xml):
         instance="sunData/MGroup/compositor/compositor00201m/compositor00201m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00103m1_positive(save_xml):
     """
     The {compositor} is all, {particles} are element declarations (valid
@@ -11472,11 +12117,12 @@ def test_compositor00103m1_positive(save_xml):
         instance="sunData/MGroup/compositor/compositor00103m/compositor00103m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00103m1_negative(save_xml):
     """
     The {compositor} is all, {particles} are element declarations (valid
@@ -11488,11 +12134,12 @@ def test_compositor00103m1_negative(save_xml):
         instance="sunData/MGroup/compositor/compositor00103m/compositor00103m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00102m1_positive(save_xml):
     """
     The {compositor} is choice, {particles} are element declarations
@@ -11504,11 +12151,12 @@ def test_compositor00102m1_positive(save_xml):
         instance="sunData/MGroup/compositor/compositor00102m/compositor00102m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00102m1_negative(save_xml):
     """
     The {compositor} is choice, {particles} are element declarations
@@ -11520,11 +12168,12 @@ def test_compositor00102m1_negative(save_xml):
         instance="sunData/MGroup/compositor/compositor00102m/compositor00102m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00101m1_positive(save_xml):
     """
     The {compositor} is <sequence> of 3 elements, {particles} are element
@@ -11537,11 +12186,12 @@ def test_compositor00101m1_positive(save_xml):
         instance="sunData/MGroup/compositor/compositor00101m/compositor00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_compositor00101m1_negative(save_xml):
     """
     The {compositor} is <sequence> of 3 elements, {particles} are element
@@ -11554,11 +12204,12 @@ def test_compositor00101m1_negative(save_xml):
         instance="sunData/MGroup/compositor/compositor00101m/compositor00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m7_positive(save_xml):
     """
     human-targeted  annotation for a model group schema component (choice)
@@ -11573,11 +12224,12 @@ def test_annotation00101m7_positive(save_xml):
         instance="sunData/MGroup/annotation/annotation00101m/annotation00101m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m4_positive_651(save_xml):
     """
     machine-targeted  annotation for a model group schema component (all)
@@ -11592,11 +12244,12 @@ def test_annotation00101m4_positive_651(save_xml):
         instance="sunData/MGroup/annotation/annotation00101m/annotation00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m16_positive(save_xml):
     """
     machine-targeted  annotation for a model group schema component
@@ -11612,11 +12265,12 @@ def test_annotation00101m16_positive(save_xml):
         instance="sunData/MGroup/annotation/annotation00101m/annotation00101m16_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m13_positive(save_xml):
     """
     human-targeted  annotation for a model group schema component
@@ -11632,11 +12286,12 @@ def test_annotation00101m13_positive(save_xml):
         instance="sunData/MGroup/annotation/annotation00101m/annotation00101m13_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m10_positive(save_xml):
     """
     machine-targeted  annotation for a model group schema component
@@ -11652,11 +12307,12 @@ def test_annotation00101m10_positive(save_xml):
         instance="sunData/MGroup/annotation/annotation00101m/annotation00101m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_655(save_xml):
     """
     human-targeted  annotation for a model group schema component (all)
@@ -11671,11 +12327,12 @@ def test_annotation00101m1_positive_655(save_xml):
         instance="sunData/MGroup/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m2_positive(save_xml):
     """
     Use the model group definition defined in other namespace (valid
@@ -11689,11 +12346,12 @@ def test_targetns00101m2_positive(save_xml):
         instance="sunData/MGroupDef/targetNS/targetNS00101m/targetNS00101m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m2_negative(save_xml):
     """
     Use the model group definition defined in other namespace (valid
@@ -11707,11 +12365,12 @@ def test_targetns00101m2_negative(save_xml):
         instance="sunData/MGroupDef/targetNS/targetNS00101m/targetNS00101m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m1_positive_658(save_xml):
     """
     The auxiliary schema for targetNS00101m2.xsd (valid schema) Model
@@ -11725,11 +12384,12 @@ def test_targetns00101m1_positive_658(save_xml):
         instance="sunData/MGroupDef/targetNS/targetNS00101m/targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m1_negative(save_xml):
     """
     The auxiliary schema for targetNS00101m2.xsd (valid schema) Model
@@ -11743,11 +12403,12 @@ def test_targetns00101m1_negative(save_xml):
         instance="sunData/MGroupDef/targetNS/targetNS00101m/targetNS00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m1_positive_660(save_xml):
     """
     Identify a model group definition by name (valid schema) Model group
@@ -11760,11 +12421,12 @@ def test_name00101m1_positive_660(save_xml):
         instance="sunData/MGroupDef/name/name00101m/name00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m1_negative(save_xml):
     """
     Identify a model group definition by name (valid schema) Model group
@@ -11777,11 +12439,12 @@ def test_name00101m1_negative(save_xml):
         instance="sunData/MGroupDef/name/name00101m/name00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_modelgroup00101m3_positive(save_xml):
     """
     A model group is <sequence> (valid schema) A model group which is the
@@ -11794,11 +12457,12 @@ def test_modelgroup00101m3_positive(save_xml):
         instance="sunData/MGroupDef/modelGroup/modelGroup00101m/modelGroup00101m3_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_modelgroup00101m3_negative(save_xml):
     """
     A model group is <sequence> (valid schema) A model group which is the
@@ -11811,11 +12475,12 @@ def test_modelgroup00101m3_negative(save_xml):
         instance="sunData/MGroupDef/modelGroup/modelGroup00101m/modelGroup00101m3_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_modelgroup00101m2_positive(save_xml):
     """
     A model group is <choice> (valid schema) A model group which is the
@@ -11828,11 +12493,12 @@ def test_modelgroup00101m2_positive(save_xml):
         instance="sunData/MGroupDef/modelGroup/modelGroup00101m/modelGroup00101m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_modelgroup00101m2_negative(save_xml):
     """
     A model group is <choice> (valid schema) A model group which is the
@@ -11845,11 +12511,12 @@ def test_modelgroup00101m2_negative(save_xml):
         instance="sunData/MGroupDef/modelGroup/modelGroup00101m/modelGroup00101m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_modelgroup00101m1_positive(save_xml):
     """
     A model group is <all> (valid schema) A model group which is the
@@ -11862,11 +12529,12 @@ def test_modelgroup00101m1_positive(save_xml):
         instance="sunData/MGroupDef/modelGroup/modelGroup00101m/modelGroup00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_modelgroup00101m1_negative(save_xml):
     """
     A model group is <all> (valid schema) A model group which is the
@@ -11879,11 +12547,12 @@ def test_modelgroup00101m1_negative(save_xml):
         instance="sunData/MGroupDef/modelGroup/modelGroup00101m/modelGroup00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m4_positive_668(save_xml):
     """
     machine-targeted  annotation for a model group definition (valid
@@ -11898,11 +12567,12 @@ def test_annotation00101m4_positive_668(save_xml):
         instance="sunData/MGroupDef/annotation/annotation00101m/annotation00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_669(save_xml):
     """
     human-targeted  annotation for a model group definition (valid schema)
@@ -11917,11 +12587,12 @@ def test_annotation00101m1_positive_669(save_xml):
         instance="sunData/MGroupDef/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m2_positive_670(save_xml):
     """
     Use of the notation declared in the namespace 'tck_test' (valid
@@ -11935,11 +12606,12 @@ def test_targetns00101m2_positive_670(save_xml):
         instance="sunData/Notation/targetNS/targetNS00101m/targetNS00101m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_targetns00101m1_positive_671(save_xml):
     """
     Declaration of the notation with the name 'png' and the namespace
@@ -11952,11 +12624,12 @@ def test_targetns00101m1_positive_671(save_xml):
         instance="sunData/Notation/targetNS/targetNS00101m/targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_systemid00201m1_positive(save_xml):
     """
     Declare a notation without the {system identifier} (valid schema) The
@@ -11968,11 +12641,12 @@ def test_systemid00201m1_positive(save_xml):
         instance="sunData/Notation/systemId/systemId00201m/systemId00201m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_systemid00101m1_positive(save_xml):
     """
     Declare a notation with the {system identifier} 'sdtimage' (valid
@@ -11985,11 +12659,12 @@ def test_systemid00101m1_positive(save_xml):
         instance="sunData/Notation/systemId/systemId00101m/systemId00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_publicid00101m1_positive(save_xml):
     """
     Declare a notation with the {public identifier} 'image/png' (valid
@@ -12002,11 +12677,12 @@ def test_publicid00101m1_positive(save_xml):
         instance="sunData/Notation/publicId/publicId00101m/publicId00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_name00101m1_positive_675(save_xml):
     """
     Use the declared notation with the name 'png' (valid schema) Notation
@@ -12021,11 +12697,12 @@ def test_name00101m1_positive_675(save_xml):
         instance="sunData/Notation/name/name00101m/name00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m3_positive_676(save_xml):
     """
     machine-targeted  annotation for a notation declaration (valid schema)
@@ -12040,11 +12717,12 @@ def test_annotation00101m3_positive_676(save_xml):
         instance="sunData/Notation/annotation/annotation00101m/annotation00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_677(save_xml):
     """
     human-targeted  annotation for a notation declaration (valid schema)
@@ -12059,11 +12737,12 @@ def test_annotation00101m1_positive_677(save_xml):
         instance="sunData/Notation/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_variety00101m2_positive(save_xml):
     """
     The {variety} is atomic (valid schema) If the {variety} is atomic,
@@ -12084,11 +12763,12 @@ def test_st_variety00101m2_positive(save_xml):
         instance="sunData/SType/ST_variety/ST_variety00101m/ST_variety00101m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_variety00101m2_negative(save_xml):
     """
     The {variety} is atomic (valid schema) If the {variety} is atomic,
@@ -12109,11 +12789,12 @@ def test_st_variety00101m2_negative(save_xml):
         instance="sunData/SType/ST_variety/ST_variety00101m/ST_variety00101m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_variety00101m1_positive(save_xml):
     """
     The {variety} is atomic (valid schema) If the {variety} is atomic,
@@ -12134,11 +12815,12 @@ def test_st_variety00101m1_positive(save_xml):
         instance="sunData/SType/ST_variety/ST_variety00101m/ST_variety00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_variety00101m1_negative(save_xml):
     """
     The {variety} is atomic (valid schema) If the {variety} is atomic,
@@ -12159,11 +12841,12 @@ def test_st_variety00101m1_negative(save_xml):
         instance="sunData/SType/ST_variety/ST_variety00101m/ST_variety00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_st_targetns00201m_st_target_ns00201m1_p(save_xml):
     """
@@ -12176,11 +12859,12 @@ def test_st_targetns00201m_st_target_ns00201m1_p(save_xml):
         instance="sunData/SType/ST_targetNS/ST_targetNS00201m/ST_targetNS00201m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_st_targetns00101m_st_target_ns00101m1_p(save_xml):
     """
@@ -12194,11 +12878,12 @@ def test_st_targetns00101m_st_target_ns00101m1_p(save_xml):
         instance="sunData/SType/ST_targetNS/ST_targetNS00101m/ST_targetNS00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_targetns00101m_st_target_ns00101m1_n(save_xml):
     """
     Identify the type by their {name} and {target namespace} (valid
@@ -12211,11 +12896,12 @@ def test_st_targetns00101m_st_target_ns00101m1_n(save_xml):
         instance="sunData/SType/ST_targetNS/ST_targetNS00101m/ST_targetNS00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_targetns00101m_st_target_ns00101m2_p(save_xml):
     """
     Identify the type by their {name} and {target namespace} (valid
@@ -12228,11 +12914,12 @@ def test_st_targetns00101m_st_target_ns00101m2_p(save_xml):
         instance="sunData/SType/ST_targetNS/ST_targetNS00101m/ST_targetNS00101m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_targetns00101m_st_target_ns00101m2_n(save_xml):
     """
     Identify the type by their {name} and {target namespace} (valid
@@ -12245,11 +12932,12 @@ def test_st_targetns00101m_st_target_ns00101m2_n(save_xml):
         instance="sunData/SType/ST_targetNS/ST_targetNS00101m/ST_targetNS00101m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_st_name00401m_st_name00401m1_p(save_xml):
     """
@@ -12262,11 +12950,12 @@ def test_st_name00401m_st_name00401m1_p(save_xml):
         instance="sunData/SType/ST_name/ST_name00401m/ST_name00401m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_name00101m_st_name00101m1_p(save_xml):
     """
     Simple types are identified by their {name} and {target namespace}.
@@ -12279,11 +12968,12 @@ def test_st_name00101m_st_name00101m1_p(save_xml):
         instance="sunData/SType/ST_name/ST_name00101m/ST_name00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_name00101m_st_name00101m1_n(save_xml):
     """
     Simple types are identified by their {name} and {target namespace}.
@@ -12296,11 +12986,12 @@ def test_st_name00101m_st_name00101m1_n(save_xml):
         instance="sunData/SType/ST_name/ST_name00101m/ST_name00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00103m3_positive(save_xml):
     """
     derivation by list (valid schema) The explicit value union prevents
@@ -12312,11 +13003,12 @@ def test_st_final00103m3_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00103m/ST_final00103m3_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00103m3_negative(save_xml):
     """
     derivation by list (valid schema) The explicit value union prevents
@@ -12328,11 +13020,12 @@ def test_st_final00103m3_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00103m/ST_final00103m3_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00103m2_positive(save_xml):
     """
     derivation by restriction (valid schema) The explicit value union
@@ -12344,11 +13037,12 @@ def test_st_final00103m2_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00103m/ST_final00103m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00103m2_negative(save_xml):
     """
     derivation by restriction (valid schema) The explicit value union
@@ -12360,11 +13054,12 @@ def test_st_final00103m2_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00103m/ST_final00103m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m6_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12376,11 +13071,12 @@ def test_st_final00102m6_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m6_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m6_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12392,11 +13088,12 @@ def test_st_final00102m6_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m6_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m5_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12408,11 +13105,12 @@ def test_st_final00102m5_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m5_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m5_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12424,11 +13122,12 @@ def test_st_final00102m5_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m5_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m4_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12440,11 +13139,12 @@ def test_st_final00102m4_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m4_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m4_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12456,11 +13156,12 @@ def test_st_final00102m4_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m4_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m3_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12472,11 +13173,12 @@ def test_st_final00102m3_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m3_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m3_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value list prevents
@@ -12488,11 +13190,12 @@ def test_st_final00102m3_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m3_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m2_positive(save_xml):
     """
     derivation by restriction (valid schema) The explicit value list
@@ -12504,11 +13207,12 @@ def test_st_final00102m2_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00102m2_negative(save_xml):
     """
     derivation by restriction (valid schema) The explicit value list
@@ -12520,11 +13224,12 @@ def test_st_final00102m2_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00102m/ST_final00102m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m6_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12536,11 +13241,12 @@ def test_st_final00101m6_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m6_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m6_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12552,11 +13258,12 @@ def test_st_final00101m6_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m6_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m5_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12568,11 +13275,12 @@ def test_st_final00101m5_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m5_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m5_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12584,11 +13292,12 @@ def test_st_final00101m5_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m5_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m4_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12600,11 +13309,12 @@ def test_st_final00101m4_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m4_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m4_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12616,11 +13326,12 @@ def test_st_final00101m4_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m4_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m3_positive(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12632,11 +13343,12 @@ def test_st_final00101m3_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m3_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m3_negative(save_xml):
     """
     derivation by union (valid schema) The explicit value restriction
@@ -12648,11 +13360,12 @@ def test_st_final00101m3_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m3_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m2_positive(save_xml):
     """
     derivation by list (valid schema) The explicit value restriction
@@ -12664,11 +13377,12 @@ def test_st_final00101m2_positive(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_final00101m2_negative(save_xml):
     """
     derivation by list (valid schema) The explicit value restriction
@@ -12680,11 +13394,12 @@ def test_st_final00101m2_negative(save_xml):
         instance="sunData/SType/ST_final/ST_final00101m/ST_final00101m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00608_st_facets00608_p(save_xml):
     """
     Enumeration values contain an uncased letter followed by upper or
@@ -12700,11 +13415,12 @@ def test_st_facets00608_st_facets00608_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00608/ST_facets00608_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00605_st_facets00605_p(save_xml):
     """
     Enumeration values contain only punctuation characters and digits.
@@ -12719,11 +13435,12 @@ def test_st_facets00605_st_facets00605_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00605/ST_facets00605_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00604_st_facets00604_p(save_xml):
     """
     Enumeration values contain lower case and upper case letters and non-
@@ -12746,11 +13463,12 @@ def test_st_facets00604_st_facets00604_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00604/ST_facets00604_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00603_st_facets00603_p(save_xml):
     """
     Enumeration values contain digits followed by a non-digit characters.
@@ -12765,11 +13483,12 @@ def test_st_facets00603_st_facets00603_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00603/ST_facets00603_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00602_st_facets00602_p(save_xml):
     """
     Enumeration values contain several punctuation characters. (valid
@@ -12785,11 +13504,12 @@ def test_st_facets00602_st_facets00602_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00602/ST_facets00602_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00601_st_facets00601_p(save_xml):
     r"""
     Enumeration values contain several punctuation characters. (valid
@@ -12808,11 +13528,12 @@ def test_st_facets00601_st_facets00601_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00601/ST_facets00601_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00506m2_positive(save_xml):
     """
     Enumeration values end with the extender characters 0x30fc, 0x30fd,
@@ -12827,11 +13548,12 @@ def test_st_facets00506m2_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00506m/ST_facets00506m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00506m1_positive(save_xml):
     """
     Enumeration values end with the extender characters 0x00b7, 0x02d0,
@@ -12848,11 +13570,12 @@ def test_st_facets00506m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00506m/ST_facets00506m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m9_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0f39, 0x0f3e,
@@ -12871,11 +13594,12 @@ def test_st_facets00505m9_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m8_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0e31, 0x0e34,
@@ -12894,11 +13618,12 @@ def test_st_facets00505m8_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m7_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0c82, 0x0c82,
@@ -12919,11 +13644,12 @@ def test_st_facets00505m7_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m6_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0b82, 0x0b82,
@@ -12944,11 +13670,12 @@ def test_st_facets00505m6_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m5_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0abc, 0x0abe,
@@ -12968,11 +13695,12 @@ def test_st_facets00505m5_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m4_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x09e2, 0x09e2,
@@ -12991,11 +13719,12 @@ def test_st_facets00505m4_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m3_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0951, 0x0952,
@@ -13014,11 +13743,12 @@ def test_st_facets00505m3_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m2_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0670, 0x06d6,
@@ -13038,11 +13768,12 @@ def test_st_facets00505m2_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m10_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x20d0, 0x20d6,
@@ -13058,11 +13789,12 @@ def test_st_facets00505m10_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00505m1_positive(save_xml):
     """
     Enumeration values end with the combining characters 0x0300, 0x0322,
@@ -13082,11 +13814,12 @@ def test_st_facets00505m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00505m/ST_facets00505m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00504m2_positive(save_xml):
     """
     Enumeration values end with the digit characters 0x0ce6, 0x0cea,
@@ -13103,11 +13836,12 @@ def test_st_facets00504m2_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00504m/ST_facets00504m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00504m1_positive(save_xml):
     """
     Enumeration values end with the digit characters 0x0030, 0x0034,
@@ -13128,11 +13862,12 @@ def test_st_facets00504m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00504m/ST_facets00504m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00503m1_positive(save_xml):
     """
     Enumeration values end with the characters 0x005f, 0x002e, 0x002d
@@ -13147,11 +13882,12 @@ def test_st_facets00503m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00503m/ST_facets00503m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00502m1_positive(save_xml):
     """
     Enumeration values end with the ideographic characters 0x4e00, 0x76d2,
@@ -13166,11 +13902,12 @@ def test_st_facets00502m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00502m/ST_facets00502m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m9_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0a8f, 0x0a90,
@@ -13190,11 +13927,12 @@ def test_st_facets00501m9_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m8_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0a13, 0x0a1d,
@@ -13214,11 +13952,12 @@ def test_st_facets00501m8_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m7_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x098f, 0x098f,
@@ -13239,11 +13978,12 @@ def test_st_facets00501m7_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m6_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0671, 0x0694,
@@ -13263,11 +14003,12 @@ def test_st_facets00501m6_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m5_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x04d0, 0x04dd,
@@ -13288,11 +14029,12 @@ def test_st_facets00501m5_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m4_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x03d0, 0x03d3,
@@ -13313,11 +14055,12 @@ def test_st_facets00501m4_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m3_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0276, 0x027a,
@@ -13337,11 +14080,12 @@ def test_st_facets00501m3_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m21_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x1fe8, 0x1fea,
@@ -13360,11 +14104,12 @@ def test_st_facets00501m21_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m21_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m20_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x1f5b, 0x1f5d,
@@ -13384,11 +14129,12 @@ def test_st_facets00501m20_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m20_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m2_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x014a, 0x0164,
@@ -13409,11 +14155,12 @@ def test_st_facets00501m2_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m19_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x1ea0, 0x1ecc,
@@ -13432,11 +14179,12 @@ def test_st_facets00501m19_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m19_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m18_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x11ab, 0x11ae,
@@ -13454,11 +14202,12 @@ def test_st_facets00501m18_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m18_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m17_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x115f, 0x1160,
@@ -13476,11 +14225,12 @@ def test_st_facets00501m17_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m17_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m16_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x110b, 0x110b,
@@ -13498,11 +14248,12 @@ def test_st_facets00501m16_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m16_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m15_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0eb0, 0x0eb2,
@@ -13521,11 +14272,12 @@ def test_st_facets00501m15_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m15_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m14_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0e87, 0x0e87,
@@ -13544,11 +14296,12 @@ def test_st_facets00501m14_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m14_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m13_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0d0e, 0x0d0f,
@@ -13568,11 +14321,12 @@ def test_st_facets00501m13_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m13_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m12_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0c35, 0x0c37,
@@ -13593,11 +14347,12 @@ def test_st_facets00501m12_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m12_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m11_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0b9c, 0x0b9e,
@@ -13618,11 +14373,12 @@ def test_st_facets00501m11_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m11_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m10_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0b2a, 0x0b2d,
@@ -13643,11 +14399,12 @@ def test_st_facets00501m10_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00501m1_positive(save_xml):
     """
     Enumeration values end with the basic characters 0x0041, 0x004d,
@@ -13668,11 +14425,12 @@ def test_st_facets00501m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00501m/ST_facets00501m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00403m1_positive(save_xml):
     """
     Enumeration value begins with the underscore character 0x005f (valid
@@ -13686,11 +14444,12 @@ def test_st_facets00403m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00403m/ST_facets00403m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00402m1_positive(save_xml):
     """
     Enumeration values begin with the ideographic characters 0x4e00,
@@ -13705,11 +14464,12 @@ def test_st_facets00402m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00402m/ST_facets00402m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m9_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0a8f, 0x0a90,
@@ -13729,11 +14489,12 @@ def test_st_facets00401m9_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m9_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m8_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0a13, 0x0a1d,
@@ -13753,11 +14514,12 @@ def test_st_facets00401m8_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m8_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m7_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x098f, 0x098f,
@@ -13778,11 +14540,12 @@ def test_st_facets00401m7_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m6_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0671, 0x0694,
@@ -13802,11 +14565,12 @@ def test_st_facets00401m6_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m5_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x04d0, 0x04dd,
@@ -13827,11 +14591,12 @@ def test_st_facets00401m5_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m4_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x03d0, 0x03d3,
@@ -13852,11 +14617,12 @@ def test_st_facets00401m4_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m3_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0276, 0x027a,
@@ -13876,11 +14642,12 @@ def test_st_facets00401m3_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m21_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x1fe8, 0x1fea,
@@ -13899,11 +14666,12 @@ def test_st_facets00401m21_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m21_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m20_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x1f5b, 0x1f5d,
@@ -13923,11 +14691,12 @@ def test_st_facets00401m20_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m20_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m2_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x014a, 0x0164,
@@ -13948,11 +14717,12 @@ def test_st_facets00401m2_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m19_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x1ea0, 0x1ecc,
@@ -13971,11 +14741,12 @@ def test_st_facets00401m19_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m19_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m18_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x11ab, 0x11ae,
@@ -13993,11 +14764,12 @@ def test_st_facets00401m18_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m18_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m17_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x115f, 0x1160,
@@ -14015,11 +14787,12 @@ def test_st_facets00401m17_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m17_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m16_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x110b, 0x110b,
@@ -14037,11 +14810,12 @@ def test_st_facets00401m16_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m16_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m15_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0eb0, 0x0eb2,
@@ -14060,11 +14834,12 @@ def test_st_facets00401m15_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m15_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m14_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0e87, 0x0e87,
@@ -14083,11 +14858,12 @@ def test_st_facets00401m14_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m14_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m13_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0d0e, 0x0d0f,
@@ -14107,11 +14883,12 @@ def test_st_facets00401m13_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m13_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m12_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0c35, 0x0c37,
@@ -14132,11 +14909,12 @@ def test_st_facets00401m12_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m12_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m11_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0b9c, 0x0b9e,
@@ -14157,11 +14935,12 @@ def test_st_facets00401m11_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m11_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m10_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0b2a, 0x0b2d,
@@ -14182,11 +14961,12 @@ def test_st_facets00401m10_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m10_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00401m1_positive(save_xml):
     """
     Enumeration values begin with the basic characters 0x0041, 0x004d,
@@ -14207,11 +14987,12 @@ def test_st_facets00401m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00401m/ST_facets00401m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00301m_st_facets00301m1_p(save_xml):
     """
     Enumeration facet restricts string type (valid schema) Base type
@@ -14224,11 +15005,12 @@ def test_st_facets00301m_st_facets00301m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00301m/ST_facets00301m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00301m_st_facets00301m1_n(save_xml):
     """
     Enumeration facet restricts string type (valid schema) Base type
@@ -14241,11 +15023,12 @@ def test_st_facets00301m_st_facets00301m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00301m/ST_facets00301m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m9_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14258,11 +15041,12 @@ def test_st_facets00201m9_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m9_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m9_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14275,11 +15059,12 @@ def test_st_facets00201m9_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m9_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m8_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14292,11 +15077,12 @@ def test_st_facets00201m8_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m8_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m8_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14309,11 +15095,12 @@ def test_st_facets00201m8_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m8_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m7_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14326,11 +15113,12 @@ def test_st_facets00201m7_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m7_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m7_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14343,11 +15131,12 @@ def test_st_facets00201m7_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m7_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m6_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14360,11 +15149,12 @@ def test_st_facets00201m6_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m6_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m6_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14377,11 +15167,12 @@ def test_st_facets00201m6_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m6_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m5_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14394,11 +15185,12 @@ def test_st_facets00201m5_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m5_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m5_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14411,11 +15203,12 @@ def test_st_facets00201m5_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m5_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m4_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14428,11 +15221,12 @@ def test_st_facets00201m4_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m4_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m4_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14445,11 +15239,12 @@ def test_st_facets00201m4_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m4_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m3_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14462,11 +15257,12 @@ def test_st_facets00201m3_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m3_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m3_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14479,11 +15275,12 @@ def test_st_facets00201m3_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m3_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m2_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14496,11 +15293,12 @@ def test_st_facets00201m2_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m2_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14513,11 +15311,12 @@ def test_st_facets00201m2_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m16_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14530,11 +15329,12 @@ def test_st_facets00201m16_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m16_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m16_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14547,11 +15347,12 @@ def test_st_facets00201m16_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m16_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m15_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14564,11 +15365,12 @@ def test_st_facets00201m15_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m15_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m15_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14581,11 +15383,12 @@ def test_st_facets00201m15_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m15_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m14_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14598,11 +15401,12 @@ def test_st_facets00201m14_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m14_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m14_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14615,11 +15419,12 @@ def test_st_facets00201m14_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m14_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m13_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14632,11 +15437,12 @@ def test_st_facets00201m13_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m13_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m13_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14649,11 +15455,12 @@ def test_st_facets00201m13_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m13_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m12_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14666,11 +15473,12 @@ def test_st_facets00201m12_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m12_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m12_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14683,11 +15491,12 @@ def test_st_facets00201m12_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m12_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m11_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14700,11 +15509,12 @@ def test_st_facets00201m11_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m11_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m11_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14717,11 +15527,12 @@ def test_st_facets00201m11_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m11_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m10_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14734,11 +15545,12 @@ def test_st_facets00201m10_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m10_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m10_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14751,11 +15563,12 @@ def test_st_facets00201m10_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m10_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m1_positive(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14768,11 +15581,12 @@ def test_st_facets00201m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00201m1_negative(save_xml):
     """
     maxExclusive facet (valid schema) {facets} for each simple type
@@ -14785,11 +15599,12 @@ def test_st_facets00201m1_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00201m/ST_facets00201m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00124m1_positive(save_xml):
     """
     maxInclusive facet (valid schema) {facets} for each simple type
@@ -14802,11 +15617,12 @@ def test_st_facets00124m1_positive(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00124m/ST_facets00124m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00124m1_negative(save_xml):
     """
     maxInclusive facet (valid schema) {facets} for each simple type
@@ -14819,11 +15635,12 @@ def test_st_facets00124m1_negative(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00124m/ST_facets00124m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00123m_st_facets00123m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14835,11 +15652,12 @@ def test_st_facets00123m_st_facets00123m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00123m/ST_facets00123m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00123m_st_facets00123m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14851,11 +15669,12 @@ def test_st_facets00123m_st_facets00123m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00123m/ST_facets00123m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00122m_st_facets00122m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14867,11 +15686,12 @@ def test_st_facets00122m_st_facets00122m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00122m/ST_facets00122m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00122m_st_facets00122m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14883,11 +15703,12 @@ def test_st_facets00122m_st_facets00122m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00122m/ST_facets00122m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00121m_st_facets00121m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14899,11 +15720,12 @@ def test_st_facets00121m_st_facets00121m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00121m/ST_facets00121m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00121m_st_facets00121m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14915,11 +15737,12 @@ def test_st_facets00121m_st_facets00121m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00121m/ST_facets00121m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00120m_st_facets00120m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14931,11 +15754,12 @@ def test_st_facets00120m_st_facets00120m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00120m/ST_facets00120m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00120m_st_facets00120m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14947,11 +15771,12 @@ def test_st_facets00120m_st_facets00120m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00120m/ST_facets00120m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00119m_st_facets00119m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14963,11 +15788,12 @@ def test_st_facets00119m_st_facets00119m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00119m/ST_facets00119m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00119m_st_facets00119m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14979,11 +15805,12 @@ def test_st_facets00119m_st_facets00119m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00119m/ST_facets00119m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00118m_st_facets00118m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -14995,11 +15822,12 @@ def test_st_facets00118m_st_facets00118m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00118m/ST_facets00118m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00118m_st_facets00118m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15011,11 +15839,12 @@ def test_st_facets00118m_st_facets00118m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00118m/ST_facets00118m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00117m_st_facets00117m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15027,11 +15856,12 @@ def test_st_facets00117m_st_facets00117m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00117m/ST_facets00117m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00117m_st_facets00117m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15043,11 +15873,12 @@ def test_st_facets00117m_st_facets00117m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00117m/ST_facets00117m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00116m_st_facets00116m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15059,11 +15890,12 @@ def test_st_facets00116m_st_facets00116m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00116m/ST_facets00116m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00116m_st_facets00116m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15075,11 +15907,12 @@ def test_st_facets00116m_st_facets00116m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00116m/ST_facets00116m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00115m_st_facets00115m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15091,11 +15924,12 @@ def test_st_facets00115m_st_facets00115m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00115m/ST_facets00115m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00115m_st_facets00115m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15107,11 +15941,12 @@ def test_st_facets00115m_st_facets00115m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00115m/ST_facets00115m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00114m_st_facets00114m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15123,11 +15958,12 @@ def test_st_facets00114m_st_facets00114m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00114m/ST_facets00114m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00114m_st_facets00114m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15139,11 +15975,12 @@ def test_st_facets00114m_st_facets00114m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00114m/ST_facets00114m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00113m_st_facets00113m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15155,11 +15992,12 @@ def test_st_facets00113m_st_facets00113m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00113m/ST_facets00113m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00113m_st_facets00113m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15171,11 +16009,12 @@ def test_st_facets00113m_st_facets00113m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00113m/ST_facets00113m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00112m_st_facets00112m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15187,11 +16026,12 @@ def test_st_facets00112m_st_facets00112m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00112m/ST_facets00112m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00112m_st_facets00112m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15203,11 +16043,12 @@ def test_st_facets00112m_st_facets00112m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00112m/ST_facets00112m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00111m_st_facets00111m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15219,11 +16060,12 @@ def test_st_facets00111m_st_facets00111m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00111m/ST_facets00111m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00111m_st_facets00111m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15235,11 +16077,12 @@ def test_st_facets00111m_st_facets00111m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00111m/ST_facets00111m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00110m_st_facets00110m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15251,11 +16094,12 @@ def test_st_facets00110m_st_facets00110m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00110m/ST_facets00110m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00110m_st_facets00110m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15267,11 +16111,12 @@ def test_st_facets00110m_st_facets00110m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00110m/ST_facets00110m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00109m_st_facets00109m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15283,11 +16128,12 @@ def test_st_facets00109m_st_facets00109m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00109m/ST_facets00109m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00109m_st_facets00109m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15299,11 +16145,12 @@ def test_st_facets00109m_st_facets00109m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00109m/ST_facets00109m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00108m_st_facets00108m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15315,11 +16162,12 @@ def test_st_facets00108m_st_facets00108m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00108m/ST_facets00108m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00108m_st_facets00108m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15331,11 +16179,12 @@ def test_st_facets00108m_st_facets00108m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00108m/ST_facets00108m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00107m_st_facets00107m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15347,11 +16196,12 @@ def test_st_facets00107m_st_facets00107m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00107m/ST_facets00107m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00107m_st_facets00107m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15363,11 +16213,12 @@ def test_st_facets00107m_st_facets00107m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00107m/ST_facets00107m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00106m_st_facets00106m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15379,11 +16230,12 @@ def test_st_facets00106m_st_facets00106m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00106m/ST_facets00106m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00106m_st_facets00106m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15395,11 +16247,12 @@ def test_st_facets00106m_st_facets00106m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00106m/ST_facets00106m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00105m_st_facets00105m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15411,11 +16264,12 @@ def test_st_facets00105m_st_facets00105m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00105m/ST_facets00105m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00105m_st_facets00105m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15427,11 +16281,12 @@ def test_st_facets00105m_st_facets00105m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00105m/ST_facets00105m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00104m_st_facets00104m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15443,11 +16298,12 @@ def test_st_facets00104m_st_facets00104m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00104m/ST_facets00104m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00104m_st_facets00104m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15459,11 +16315,12 @@ def test_st_facets00104m_st_facets00104m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00104m/ST_facets00104m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00103m_st_facets00103m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15475,11 +16332,12 @@ def test_st_facets00103m_st_facets00103m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00103m/ST_facets00103m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00103m_st_facets00103m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15491,11 +16349,12 @@ def test_st_facets00103m_st_facets00103m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00103m/ST_facets00103m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00102m_st_facets00102m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15507,11 +16366,12 @@ def test_st_facets00102m_st_facets00102m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00102m/ST_facets00102m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00102m_st_facets00102m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15523,11 +16383,12 @@ def test_st_facets00102m_st_facets00102m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00102m/ST_facets00102m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00101m_st_facets00101m1_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15539,11 +16400,12 @@ def test_st_facets00101m_st_facets00101m1_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00101m/ST_facets00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00101m_st_facets00101m1_n(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15555,11 +16417,12 @@ def test_st_facets00101m_st_facets00101m1_n(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00101m/ST_facets00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00101m_st_facets00101m2_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15571,11 +16434,12 @@ def test_st_facets00101m_st_facets00101m2_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00101m/ST_facets00101m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_facets00101m_st_facets00101m3_p(save_xml):
     """
     {facets} restriction (valid schema) The {facets} of R constitute a
@@ -15587,11 +16451,12 @@ def test_st_facets00101m_st_facets00101m3_p(save_xml):
         instance="sunData/SType/ST_facets/ST_facets00101m/ST_facets00101m3_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00302m_st_base_td00302m1_p(save_xml):
     """
     the 'union' alternative is chosen (valid schema) If the 'list' or
@@ -15603,11 +16468,12 @@ def test_st_basetd00302m_st_base_td00302m1_p(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00302m/ST_baseTD00302m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00302m_st_base_td00302m1_n(save_xml):
     """
     the 'union' alternative is chosen (valid schema) If the 'list' or
@@ -15619,11 +16485,12 @@ def test_st_basetd00302m_st_base_td00302m1_n(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00302m/ST_baseTD00302m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00302m_st_base_td00302m2_p(save_xml):
     """
     the 'union' alternative is chosen (valid schema) If the 'list' or
@@ -15635,11 +16502,12 @@ def test_st_basetd00302m_st_base_td00302m2_p(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00302m/ST_baseTD00302m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00302m_st_base_td00302m2_n(save_xml):
     """
     the 'union' alternative is chosen (valid schema) If the 'list' or
@@ -15651,11 +16519,12 @@ def test_st_basetd00302m_st_base_td00302m2_n(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00302m/ST_baseTD00302m2_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00302m_st_base_td00302m3_n(save_xml):
     """
     the 'union' alternative is chosen (valid schema) If the 'list' or
@@ -15667,11 +16536,12 @@ def test_st_basetd00302m_st_base_td00302m3_n(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00302m/ST_baseTD00302m3_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00301m_st_base_td00301m1_p(save_xml):
     """
     the 'list' alternative is chosen (valid schema) If the 'list' or
@@ -15683,11 +16553,12 @@ def test_st_basetd00301m_st_base_td00301m1_p(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00301m/ST_baseTD00301m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00301m_st_base_td00301m1_n(save_xml):
     """
     the 'list' alternative is chosen (valid schema) If the 'list' or
@@ -15699,11 +16570,12 @@ def test_st_basetd00301m_st_base_td00301m1_n(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00301m/ST_baseTD00301m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00201m_st_base_td00201m1_p(save_xml):
     """
     The base type is defined by the type of 'simpleType' among the
@@ -15717,11 +16589,12 @@ def test_st_basetd00201m_st_base_td00201m1_p(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00201m/ST_baseTD00201m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00201m_st_base_td00201m1_n(save_xml):
     """
     The base type is defined by the type of 'simpleType' among the
@@ -15735,11 +16608,12 @@ def test_st_basetd00201m_st_base_td00201m1_n(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00201m/ST_baseTD00201m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00101m_st_base_td00101m1_p(save_xml):
     """
     The value of the base [attribute] specifies the base type definition
@@ -15754,11 +16628,12 @@ def test_st_basetd00101m_st_base_td00101m1_p(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00101m/ST_baseTD00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00101m_st_base_td00101m1_n(save_xml):
     """
     The value of the base [attribute] specifies the base type definition
@@ -15773,11 +16648,12 @@ def test_st_basetd00101m_st_base_td00101m1_n(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00101m/ST_baseTD00101m1_n.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_basetd00101m_st_base_td00101m2_p(save_xml):
     """
     The value of the base [attribute] specifies the base type definition
@@ -15792,11 +16668,12 @@ def test_st_basetd00101m_st_base_td00101m2_p(save_xml):
         instance="sunData/SType/ST_baseTD/ST_baseTD00101m/ST_baseTD00101m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_annotation00101m2_positive(save_xml):
     """
     machine-targeted annotation (valid schema) Annotations provide for
@@ -15808,11 +16685,12 @@ def test_st_annotation00101m2_positive(save_xml):
         instance="sunData/SType/ST_annotation/ST_annotation00101m/ST_annotation00101m2_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_st_annotation00101m1_positive(save_xml):
     """
     human-targeted annotation (valid schema) Annotations provide for
@@ -15824,11 +16702,12 @@ def test_st_annotation00101m1_positive(save_xml):
         instance="sunData/SType/ST_annotation/ST_annotation00101m/ST_annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotations00101m6_positive(save_xml):
     """
     machine-targeted placed at the end annotation for the schema itself
@@ -15844,11 +16723,12 @@ def test_annotations00101m6_positive(save_xml):
         instance="sunData/Schema/annotations/annotations00101m/annotations00101m6_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotations00101m5_positive(save_xml):
     """
     machine-targeted double annotation for the schema itself (valid
@@ -15864,11 +16744,12 @@ def test_annotations00101m5_positive(save_xml):
         instance="sunData/Schema/annotations/annotations00101m/annotations00101m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotations00101m4_positive(save_xml):
     """
     machine-targeted  annotation for the schema itself (valid schema)
@@ -15883,11 +16764,12 @@ def test_annotations00101m4_positive(save_xml):
         instance="sunData/Schema/annotations/annotations00101m/annotations00101m4_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotations00101m3_positive(save_xml):
     """
     human-targeted placed at the end annotation for the schema itself
@@ -15903,11 +16785,12 @@ def test_annotations00101m3_positive(save_xml):
         instance="sunData/Schema/annotations/annotations00101m/annotations00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotations00101m2_positive(save_xml):
     """
     human-targeted double annotation for the schema itself (valid schema)
@@ -15923,11 +16806,12 @@ def test_annotations00101m2_positive(save_xml):
         instance="sunData/Schema/annotations/annotations00101m/annotations00101m2_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotations00101m1_positive(save_xml):
     """
     human-targeted  annotation for the schema itself (valid schema)
@@ -15942,11 +16826,12 @@ def test_annotations00101m1_positive(save_xml):
         instance="sunData/Schema/annotations/annotations00101m/annotations00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00302m2_positive(save_xml):
     """
     processContents='lax' and the declaration is not available (valid
@@ -15966,11 +16851,12 @@ def test_pscontents00302m2_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00302m/psContents00302m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00302m2_negative(save_xml):
     """
     processContents='lax' and the declaration is not available (valid
@@ -15990,11 +16876,12 @@ def test_pscontents00302m2_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00302m/psContents00302m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00302m1_positive(save_xml):
     """
     processContents='lax' and the declaration is available (valid schema)
@@ -16014,11 +16901,12 @@ def test_pscontents00302m1_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00302m/psContents00302m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00302m1_negative(save_xml):
     """
     processContents='lax' and the declaration is available (valid schema)
@@ -16038,11 +16926,12 @@ def test_pscontents00302m1_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00302m/psContents00302m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00301m2_positive(save_xml):
     """
     processContents='lax' and the declaration is not available (valid
@@ -16062,11 +16951,12 @@ def test_pscontents00301m2_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00301m/psContents00301m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00301m2_negative(save_xml):
     """
     processContents='lax' and the declaration is not available (valid
@@ -16086,11 +16976,12 @@ def test_pscontents00301m2_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00301m/psContents00301m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00301m1_positive(save_xml):
     """
     processContents='lax' and the declaration is available (valid schema)
@@ -16110,11 +17001,12 @@ def test_pscontents00301m1_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00301m/psContents00301m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00301m1_negative(save_xml):
     """
     processContents='lax' and the declaration is available (valid schema)
@@ -16134,11 +17026,12 @@ def test_pscontents00301m1_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00301m/psContents00301m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00202m1_positive(save_xml):
     """
     processContents='skip' (valid schema) {process contents} controls the
@@ -16153,11 +17046,12 @@ def test_pscontents00202m1_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00202m/psContents00202m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00201m1_positive(save_xml):
     """
     processContents='skip' (valid schema) {process contents} controls the
@@ -16172,11 +17066,12 @@ def test_pscontents00201m1_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00201m/psContents00201m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00201m1_negative(save_xml):
     """
     processContents='skip' (valid schema) {process contents} controls the
@@ -16191,11 +17086,12 @@ def test_pscontents00201m1_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00201m/psContents00201m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00102m2_negative(save_xml):
     """
     processContents='strict' and the declaration is not available (valid
@@ -16212,11 +17108,12 @@ def test_pscontents00102m2_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00102m/psContents00102m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00102m1_positive(save_xml):
     """
     processContents='strict' and the declaration is available (valid
@@ -16233,11 +17130,12 @@ def test_pscontents00102m1_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00102m/psContents00102m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00102m1_negative(save_xml):
     """
     processContents='strict' and the declaration is available (valid
@@ -16254,11 +17152,12 @@ def test_pscontents00102m1_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00102m/psContents00102m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00101m2_negative(save_xml):
     """
     processContents='strict' and the declaration is not available (valid
@@ -16275,11 +17174,12 @@ def test_pscontents00101m2_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00101m/psContents00101m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00101m1_positive(save_xml):
     """
     processContents='strict' and the declaration is available (valid
@@ -16296,11 +17196,12 @@ def test_pscontents00101m1_positive(save_xml):
         instance="sunData/Wildcard/psContents/psContents00101m/psContents00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_pscontents00101m1_negative(save_xml):
     """
     processContents='strict' and the declaration is available (valid
@@ -16317,11 +17218,12 @@ def test_pscontents00101m1_negative(save_xml):
         instance="sunData/Wildcard/psContents/psContents00101m/psContents00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00302m1_positive(save_xml):
     """
     namespace='ns_test1 ns_test2' (valid schema) {namespace constraint}
@@ -16336,11 +17238,12 @@ def test_nsconstraint00302m1_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00302m/nsConstraint00302m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00302m1_negative(save_xml):
     """
     namespace='ns_test1 ns_test2' (valid schema) {namespace constraint}
@@ -16355,11 +17258,12 @@ def test_nsconstraint00302m1_negative(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00302m/nsConstraint00302m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00301m1_positive(save_xml):
     """
     namespace='ns_test1 ns_test2' (valid schema) {namespace constraint}
@@ -16374,11 +17278,12 @@ def test_nsconstraint00301m1_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00301m/nsConstraint00301m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00301m1_negative(save_xml):
     """
     namespace='ns_test1 ns_test2' (valid schema) {namespace constraint}
@@ -16393,11 +17298,12 @@ def test_nsconstraint00301m1_negative(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00301m/nsConstraint00301m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00202m1_positive(save_xml):
     """
     namespace='##other' (valid schema) {namespace constraint} provides for
@@ -16411,11 +17317,12 @@ def test_nsconstraint00202m1_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00202m/nsConstraint00202m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00202m1_negative(save_xml):
     """
     namespace='##other' (valid schema) {namespace constraint} provides for
@@ -16429,11 +17336,12 @@ def test_nsconstraint00202m1_negative(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00202m/nsConstraint00202m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00201m1_positive(save_xml):
     """
     namespace='##other' (valid schema) {namespace constraint} provides for
@@ -16447,11 +17355,12 @@ def test_nsconstraint00201m1_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00201m/nsConstraint00201m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00201m1_negative(save_xml):
     """
     namespace='##other' (valid schema) {namespace constraint} provides for
@@ -16465,11 +17374,12 @@ def test_nsconstraint00201m1_negative(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00201m/nsConstraint00201m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00102m2_positive(save_xml):
     """
     default value of 'namespace' is '##any' (valid schema) {namespace
@@ -16483,11 +17393,12 @@ def test_nsconstraint00102m2_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00102m/nsConstraint00102m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00102m1_positive(save_xml):
     """
     namespace='##any' (valid schema) {namespace constraint} provides for
@@ -16500,11 +17411,12 @@ def test_nsconstraint00102m1_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00102m/nsConstraint00102m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00101m2_positive(save_xml):
     """
     default value of 'namespace' is '##any' (valid schema) {namespace
@@ -16518,11 +17430,12 @@ def test_nsconstraint00101m2_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00101m/nsConstraint00101m2_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00101m2_negative(save_xml):
     """
     default value of 'namespace' is '##any' (valid schema) {namespace
@@ -16536,11 +17449,12 @@ def test_nsconstraint00101m2_negative(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00101m/nsConstraint00101m2_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00101m1_positive(save_xml):
     """
     namespace='##any' (valid schema) {namespace constraint} provides for
@@ -16553,11 +17467,12 @@ def test_nsconstraint00101m1_positive(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00101m/nsConstraint00101m1_p.xml",
         instance_is_valid=True,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_nsconstraint00101m1_negative(save_xml):
     """
     namespace='##any' (valid schema) {namespace constraint} provides for
@@ -16570,11 +17485,12 @@ def test_nsconstraint00101m1_negative(save_xml):
         instance="sunData/Wildcard/nsConstraint/nsConstraint00101m/nsConstraint00101m1_n.xml",
         instance_is_valid=False,
         class_name="A",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m7_positive_915(save_xml):
     """
     machine-targeted  annotation for a wildcard schema component (any)
@@ -16589,11 +17505,12 @@ def test_annotation00101m7_positive_915(save_xml):
         instance="sunData/Wildcard/annotation/annotation00101m/annotation00101m7_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m5_positive(save_xml):
     """
     human-targeted  annotation for a wildcard schema component (any)
@@ -16608,11 +17525,12 @@ def test_annotation00101m5_positive(save_xml):
         instance="sunData/Wildcard/annotation/annotation00101m/annotation00101m5_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m3_positive_917(save_xml):
     """
     machine-targeted  annotation for a wildcard schema component
@@ -16628,11 +17546,12 @@ def test_annotation00101m3_positive_917(save_xml):
         instance="sunData/Wildcard/annotation/annotation00101m/annotation00101m3_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_annotation00101m1_positive_918(save_xml):
     """
     human-targeted  annotation for a wildcard schema component
@@ -16648,6 +17567,6 @@ def test_annotation00101m1_positive_918(save_xml):
         instance="sunData/Wildcard/annotation/annotation00101m/annotation00101m1_p.xml",
         instance_is_valid=True,
         class_name="Root",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_sun_meta_919.py
+++ b/tests/test_sun_meta_919.py
@@ -5286,6 +5286,7 @@ def test_au_attrdecl00101m1_p_positive(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_targetns00101m_target_ns00101m1_p(save_xml):
     """
     Simple types are identified by their {name} and {target namespace}.
@@ -6269,7 +6270,6 @@ def test_valueconstraint01101m2_negative(save_xml):
     )
 
 
-@pytest.mark.xfail
 def test_valueconstraint01101m1_positive(save_xml):
     """
     fixed value is valid (valid schema) For a string to be a valid default
@@ -12164,6 +12164,7 @@ def test_st_variety00101m1_negative(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_st_targetns00201m_st_target_ns00201m1_p(save_xml):
     """
     reference to type (valid schema) Simple type {name}s and {target
@@ -12180,6 +12181,7 @@ def test_st_targetns00201m_st_target_ns00201m1_p(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_st_targetns00101m_st_target_ns00101m1_p(save_xml):
     """
     Identify the type by their {name} and {target namespace} (valid
@@ -12248,6 +12250,7 @@ def test_st_targetns00101m_st_target_ns00101m2_n(save_xml):
     )
 
 
+@pytest.mark.xfail
 def test_st_name00401m_st_name00401m1_p(save_xml):
     """
     Simple type {name}s is provided for reference (valid schema) Simple

--- a/tests/test_wg_meta_53.py
+++ b/tests/test_wg_meta_53.py
@@ -32,7 +32,6 @@ def test_sg_abstract_edc_ee1t_xml(save_xml):
 
 
 @pytest.mark.schema11
-@pytest.mark.xfail
 def test_sg_abstract_edc_ee1i_xml(save_xml):
 
     assert_bindings(

--- a/tests/test_wg_meta_53.py
+++ b/tests/test_wg_meta_53.py
@@ -172,6 +172,7 @@ def test_sg_abstract_edc_e1ie1i_xml(save_xml):
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa2_e1_xml(save_xml):
 
     assert_bindings(
@@ -180,11 +181,12 @@ def test_sg_abstract_upa2_e1_xml(save_xml):
         instance="wgData/sg/e1.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa2_e1bis_xml(save_xml):
 
     assert_bindings(
@@ -193,11 +195,12 @@ def test_sg_abstract_upa2_e1bis_xml(save_xml):
         instance="wgData/sg/e1.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa2_e1token_xml(save_xml):
 
     assert_bindings(
@@ -206,11 +209,12 @@ def test_sg_abstract_upa2_e1token_xml(save_xml):
         instance="wgData/sg/e1token.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa2_e1short_xml(save_xml):
 
     assert_bindings(
@@ -219,11 +223,12 @@ def test_sg_abstract_upa2_e1short_xml(save_xml):
         instance="wgData/sg/e1short.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa_e1_xml(save_xml):
 
     assert_bindings(
@@ -232,11 +237,12 @@ def test_sg_abstract_upa_e1_xml(save_xml):
         instance="wgData/sg/e1.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa_e1token_xml(save_xml):
 
     assert_bindings(
@@ -245,11 +251,12 @@ def test_sg_abstract_upa_e1token_xml(save_xml):
         instance="wgData/sg/e1token.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_abstract_upa_e1short_xml(save_xml):
 
     assert_bindings(
@@ -258,11 +265,12 @@ def test_sg_abstract_upa_e1short_xml(save_xml):
         instance="wgData/sg/e1short.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_sns1a(save_xml):
 
     assert_bindings(
@@ -271,11 +279,12 @@ def test_sg_and_defined_sibling_3_sns1a(save_xml):
         instance="wgData/sg/sns1a.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 @pytest.mark.xfail
 def test_sg_and_defined_sibling_3_sns1b(save_xml):
 
@@ -285,11 +294,12 @@ def test_sg_and_defined_sibling_3_sns1b(save_xml):
         instance="wgData/sg/sns1b.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_sns1c(save_xml):
 
     assert_bindings(
@@ -298,11 +308,12 @@ def test_sg_and_defined_sibling_3_sns1c(save_xml):
         instance="wgData/sg/sns1c.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_snn1a(save_xml):
 
     assert_bindings(
@@ -311,11 +322,12 @@ def test_sg_and_defined_sibling_3_snn1a(save_xml):
         instance="wgData/sg/snn1a.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_snn1b(save_xml):
 
     assert_bindings(
@@ -324,11 +336,12 @@ def test_sg_and_defined_sibling_3_snn1b(save_xml):
         instance="wgData/sg/snn1b.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_snn1c(save_xml):
 
     assert_bindings(
@@ -337,11 +350,12 @@ def test_sg_and_defined_sibling_3_snn1c(save_xml):
         instance="wgData/sg/snn1c.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_snea(save_xml):
 
     assert_bindings(
@@ -350,11 +364,12 @@ def test_sg_and_defined_sibling_3_snea(save_xml):
         instance="wgData/sg/snea.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_sneb(save_xml):
 
     assert_bindings(
@@ -363,11 +378,12 @@ def test_sg_and_defined_sibling_3_sneb(save_xml):
         instance="wgData/sg/sneb.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_3_snec(save_xml):
 
     assert_bindings(
@@ -376,11 +392,12 @@ def test_sg_and_defined_sibling_3_snec(save_xml):
         instance="wgData/sg/snec.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_2_esn(save_xml):
 
     assert_bindings(
@@ -389,11 +406,12 @@ def test_sg_and_defined_sibling_2_esn(save_xml):
         instance="wgData/sg/esn.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_2_nsn(save_xml):
 
     assert_bindings(
@@ -402,11 +420,12 @@ def test_sg_and_defined_sibling_2_nsn(save_xml):
         instance="wgData/sg/nsn.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_2_ssn(save_xml):
 
     assert_bindings(
@@ -415,11 +434,12 @@ def test_sg_and_defined_sibling_2_ssn(save_xml):
         instance="wgData/sg/ssn.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_2_n1sn(save_xml):
 
     assert_bindings(
@@ -428,11 +448,12 @@ def test_sg_and_defined_sibling_2_n1sn(save_xml):
         instance="wgData/sg/n1sn.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_2_s1sn(save_xml):
 
     assert_bindings(
@@ -441,11 +462,12 @@ def test_sg_and_defined_sibling_2_s1sn(save_xml):
         instance="wgData/sg/s1sn.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_sn(save_xml):
 
     assert_bindings(
@@ -454,11 +476,12 @@ def test_sg_and_defined_sibling_1_sn(save_xml):
         instance="wgData/sg/sn.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_s1n(save_xml):
 
     assert_bindings(
@@ -467,11 +490,12 @@ def test_sg_and_defined_sibling_1_s1n(save_xml):
         instance="wgData/sg/s1n.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_sn1(save_xml):
 
     assert_bindings(
@@ -480,11 +504,12 @@ def test_sg_and_defined_sibling_1_sn1(save_xml):
         instance="wgData/sg/sn1.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_sne(save_xml):
 
     assert_bindings(
@@ -493,11 +518,12 @@ def test_sg_and_defined_sibling_1_sne(save_xml):
         instance="wgData/sg/sne.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_snn(save_xml):
 
     assert_bindings(
@@ -506,11 +532,12 @@ def test_sg_and_defined_sibling_1_snn(save_xml):
         instance="wgData/sg/snn.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_sns(save_xml):
 
     assert_bindings(
@@ -519,11 +546,12 @@ def test_sg_and_defined_sibling_1_sns(save_xml):
         instance="wgData/sg/sns.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_snn1(save_xml):
 
     assert_bindings(
@@ -532,11 +560,12 @@ def test_sg_and_defined_sibling_1_snn1(save_xml):
         instance="wgData/sg/snn1.xml",
         instance_is_valid=True,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_sg_and_defined_sibling_1_sns1(save_xml):
 
     assert_bindings(
@@ -545,11 +574,12 @@ def test_sg_and_defined_sibling_1_sns1(save_xml):
         instance="wgData/sg/sns1.xml",
         instance_is_valid=False,
         class_name="Test",
-        version="1.0 1.1",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_uri_3986_valid_001(save_xml):
 
     assert_bindings(
@@ -558,11 +588,12 @@ def test_iri_001_uri_3986_valid_001(save_xml):
         instance="wgData/iri/URI-3986-valid-001.xml",
         instance_is_valid=True,
         class_name="Uri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_uri_3986_valid_002(save_xml):
 
     assert_bindings(
@@ -571,11 +602,12 @@ def test_iri_001_uri_3986_valid_002(save_xml):
         instance="wgData/iri/URI-3986-valid-002.xml",
         instance_is_valid=True,
         class_name="Uri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_uri_3986_valid_003(save_xml):
 
     assert_bindings(
@@ -584,11 +616,12 @@ def test_iri_001_uri_3986_valid_003(save_xml):
         instance="wgData/iri/URI-3986-valid-003.xml",
         instance_is_valid=True,
         class_name="Uri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_uri_3986_invalid_001(save_xml):
 
     assert_bindings(
@@ -597,11 +630,12 @@ def test_iri_001_uri_3986_invalid_001(save_xml):
         instance="wgData/iri/URI-3986-invalid-001.xml",
         instance_is_valid=False,
         class_name="Uri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_uri_3986_invalid_002(save_xml):
 
     assert_bindings(
@@ -610,11 +644,12 @@ def test_iri_001_uri_3986_invalid_002(save_xml):
         instance="wgData/iri/URI-3986-invalid-002.xml",
         instance_is_valid=False,
         class_name="Uri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_uri_3986_invalid_003(save_xml):
 
     assert_bindings(
@@ -623,11 +658,12 @@ def test_iri_001_uri_3986_invalid_003(save_xml):
         instance="wgData/iri/URI-3986-invalid-003.xml",
         instance_is_valid=False,
         class_name="Uri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_absolute_uri_3986_valid_001(save_xml):
 
     assert_bindings(
@@ -636,11 +672,12 @@ def test_iri_001_absolute_uri_3986_valid_001(save_xml):
         instance="wgData/iri/absolute-URI-3986-valid-001.xml",
         instance_is_valid=True,
         class_name="AbsoluteUri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_absolute_uri_3986_valid_002(save_xml):
 
     assert_bindings(
@@ -649,11 +686,12 @@ def test_iri_001_absolute_uri_3986_valid_002(save_xml):
         instance="wgData/iri/absolute-URI-3986-valid-002.xml",
         instance_is_valid=True,
         class_name="AbsoluteUri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_absolute_uri_3986_valid_003(save_xml):
 
     assert_bindings(
@@ -662,11 +700,12 @@ def test_iri_001_absolute_uri_3986_valid_003(save_xml):
         instance="wgData/iri/absolute-URI-3986-valid-003.xml",
         instance_is_valid=True,
         class_name="AbsoluteUri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_absolute_uri_3986_invalid_001(save_xml):
 
     assert_bindings(
@@ -675,11 +714,12 @@ def test_iri_001_absolute_uri_3986_invalid_001(save_xml):
         instance="wgData/iri/absolute-URI-3986-invalid-001.xml",
         instance_is_valid=False,
         class_name="AbsoluteUri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_absolute_uri_3986_invalid_002(save_xml):
 
     assert_bindings(
@@ -688,11 +728,12 @@ def test_iri_001_absolute_uri_3986_invalid_002(save_xml):
         instance="wgData/iri/absolute-URI-3986-invalid-002.xml",
         instance_is_valid=False,
         class_name="AbsoluteUri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )
 
 
+@pytest.mark.schema11
 def test_iri_001_absolute_uri_3986_invalid_003(save_xml):
 
     assert_bindings(
@@ -701,6 +742,6 @@ def test_iri_001_absolute_uri_3986_invalid_003(save_xml):
         instance="wgData/iri/absolute-URI-3986-invalid-003.xml",
         instance_is_valid=False,
         class_name="AbsoluteUri3986",
-        version="1.0",
+        version="1.1",
         save_xml=save_xml,
     )

--- a/tests/test_wg_meta_53.py
+++ b/tests/test_wg_meta_53.py
@@ -32,6 +32,7 @@ def test_sg_abstract_edc_ee1t_xml(save_xml):
 
 
 @pytest.mark.schema11
+@pytest.mark.xfail
 def test_sg_abstract_edc_ee1i_xml(save_xml):
 
     assert_bindings(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ import pytest
 import xmlschema
 from click.testing import CliRunner
 from lxml import etree
+
 from xsdata import cli
 from xsdata.formats.dataclass.parsers import XmlParser
 from xsdata.formats.dataclass.serializers import XmlSerializer
@@ -81,10 +82,7 @@ def assert_bindings(
 
 def assert_valid(validator, tree):
     __tracebackhide__ = True
-    if isinstance(validator, xmlschema.XMLSchema11):
-        validator.validate(tree)
-    else:
-        validator.assertValid(tree)
+    validator.validate(tree)
 
 
 @functools.lru_cache(maxsize=5)
@@ -104,12 +102,12 @@ def initialize_validator(path: Path, version: str):
         if version == "1.1":
             return xmlschema.XMLSchema11(str(path))
         else:
-            xmlschema_doc = etree.parse(str(path))
-            return etree.XMLSchema(xmlschema_doc)
+            return xmlschema.XMLSchema10(str(path))
     except Exception:
         if version == "1.1":
-            return None
-        return initialize_validator(path, "1.1")
+            return xmlschema.XMLSchema10(str(path))
+        else:
+            return xmlschema.XMLSchema11(str(path))
 
 
 def load_class(output, clazz_name):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,10 +104,7 @@ def initialize_validator(path: Path, version: str):
         else:
             return xmlschema.XMLSchema10(str(path))
     except Exception:
-        if version == "1.1":
-            return xmlschema.XMLSchema10(str(path))
-        else:
-            return xmlschema.XMLSchema11(str(path))
+        return None
 
 
 def load_class(output, clazz_name):

--- a/xsdata/msData/attribute/attP029.xml
+++ b/xsdata/msData/attribute/attP029.xml
@@ -1,4 +1,0 @@
-<!-- xsdata instance -->
-<x:doc xmlns:x="http://xsdtesting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <x:elem/>
-</x:doc>

--- a/xsdata/msData/attribute/attP031.xml
+++ b/xsdata/msData/attribute/attP031.xml
@@ -1,4 +1,0 @@
-<!-- xsdata instance -->
-<x:doc xmlns:x="http://xsdtesting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <x:elem/>
-</x:doc>

--- a/xsdata/msData/simpleType/stZ007.xml
+++ b/xsdata/msData/simpleType/stZ007.xml
@@ -1,5 +1,0 @@
-<!-- xsdata instance -->
-<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <e1>123</e1>
-  <e2/>
-</root>

--- a/xsdata/msData/simpleType/stZ007.xml
+++ b/xsdata/msData/simpleType/stZ007.xml
@@ -1,0 +1,5 @@
+<!-- xsdata instance -->
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <e1>123</e1>
+  <e2/>
+</root>

--- a/xsdata/msData/simpleType/test107331_4.xml
+++ b/xsdata/msData/simpleType/test107331_4.xml
@@ -1,0 +1,7 @@
+<!-- xsdata instance -->
+<root>
+  <c name="name" type="1" state="1">this is a string</c>
+  <b>1.2 3.4 0.9</b>
+  <a>123456</a>
+  <a>abcdefgh</a>
+</root>

--- a/xsdata/msData/simpleType/test107331_4.xml
+++ b/xsdata/msData/simpleType/test107331_4.xml
@@ -1,7 +1,0 @@
-<!-- xsdata instance -->
-<root>
-  <c name="name" type="1" state="1">this is a string</c>
-  <b>1.2 3.4 0.9</b>
-  <a>123456</a>
-  <a>abcdefgh</a>
-</root>

--- a/xsdata/msData/simpleType/test107331_9.xml
+++ b/xsdata/msData/simpleType/test107331_9.xml
@@ -1,7 +1,0 @@
-<!-- xsdata instance -->
-<root xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <item>1234567</item>
-  <item>abcdefgh</item>
-  <item>1.2 3.4 0.9</item>
-  <item>this is a string</item>
-</root>

--- a/xsdata/msData/simpleType/test107331_9.xml
+++ b/xsdata/msData/simpleType/test107331_9.xml
@@ -1,0 +1,7 @@
+<!-- xsdata instance -->
+<root xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <item>1234567</item>
+  <item>abcdefgh</item>
+  <item>1.2 3.4 0.9</item>
+  <item>this is a string</item>
+</root>

--- a/xsdata/wgData/sg/e1.xml
+++ b/xsdata/wgData/sg/e1.xml
@@ -1,4 +1,0 @@
-<!-- xsdata instance -->
-<sg:test xmlns:sg="http://www.w3.org/XML/2008/xsdl-exx/ns1">
-  <sg:e1>Test case for substitution groups.</sg:e1>
-</sg:test>

--- a/xsdata/wgData/sg/e1short.xml
+++ b/xsdata/wgData/sg/e1short.xml
@@ -1,4 +1,0 @@
-<!-- xsdata instance -->
-<sg:test xmlns:sg="http://www.w3.org/XML/2008/xsdl-exx/ns1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <sg:e1 xsi:type="xs:short">41</sg:e1>
-</sg:test>

--- a/xsdata/wgData/sg/e1token.xml
+++ b/xsdata/wgData/sg/e1token.xml
@@ -1,4 +1,0 @@
-<!-- xsdata instance -->
-<sg:test xmlns:sg="http://www.w3.org/XML/2008/xsdl-exx/ns1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <sg:e1 xsi:type="xs:token">Test</sg:e1>
-</sg:test>

--- a/xsdata/wgData/sg/ee1i.xml
+++ b/xsdata/wgData/sg/ee1i.xml
@@ -1,5 +1,0 @@
-<!-- xsdata instance -->
-<sg:test xmlns:sg="http://www.w3.org/XML/2008/xsdl-exx/ns1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <sg:e1 xsi:type="xs:short">41</sg:e1>
-  <sg:e>Test of substitution groups.</sg:e>
-</sg:test>

--- a/xsdata/wgData/sg/ee1i.xml
+++ b/xsdata/wgData/sg/ee1i.xml
@@ -1,0 +1,5 @@
+<!-- xsdata instance -->
+<sg:test xmlns:sg="http://www.w3.org/XML/2008/xsdl-exx/ns1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <sg:e1 xsi:type="xs:short">41</sg:e1>
+  <sg:e>Test of substitution groups.</sg:e>
+</sg:test>


### PR DESCRIPTION
Early on I opted to use a combination of xmlschema and lxml validation because of speed and errors that didn't make sense at the time.

This is a new attempt to see how things have progressed with xmlschema. The tests runner is dummy it will attempt with both versions `XMLSchema11` and `XMLSchema10` until it gets back a validator instance, most likely the culprit for most of the ~30% speed diff.


First Results
combo: 96 failed, 26036 passed, 192 skipped
xmlschema only: 90 failed, 26078 passed, 156 skipped

- More passing tests, less skipped ones
- The overall speed seems a lot slower but not that terrible
- The new failed/success tests need to be examined
- The schema version needs to be re-examined there some tricky cases where I need to do some more checks to successful determine the correct version.

